### PR TITLE
Add schema definitions and export script for artifacts

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,6 +4,12 @@ set -eu
 
 repo_root="$(git rev-parse --show-toplevel)"
 
+echo "Running prettier on JSON files"
+cd "$repo_root"
+bunx prettier --write fedramp-consolidated-rules.json schemas/fedramp-consolidated-rules.schema.json
+git add fedramp-consolidated-rules.json schemas/fedramp-consolidated-rules.schema.json
+
+echo "Running bun test from $repo_root/tools"
 echo "Running bun check from $repo_root/tools"
 cd "$repo_root/tools"
 bun run check

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Claude Code
+CLAUDE.md

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -1225,15 +1225,36 @@
               "varies_by_class": {
                 "a": {
                   "statement": "Providers of Class A offerings MAY supply per-service FedRAMP Certification materials.",
-                  "primary_key_word": "MAY"
+                  "primary_key_word": "MAY",
+                  "artifacts": {
+                    "both": {
+                      "all_classes": [
+                        "Explanation of the supplied materials, including how to access and use them."
+                      ]
+                    }
+                  }
                 },
                 "b": {
                   "statement": "Providers of Class B offerings MAY supply per-service FedRAMP Certification materials.",
-                  "primary_key_word": "MAY"
+                  "primary_key_word": "MAY",
+                  "artifacts": {
+                    "both": {
+                      "all_classes": [
+                        "Explanation of the supplied materials, including how to access and use them."
+                      ]
+                    }
+                  }
                 },
                 "c": {
                   "statement": "Providers of Class C offerings MAY supply per-service FedRAMP Certification materials.",
-                  "primary_key_word": "MAY"
+                  "primary_key_word": "MAY",
+                  "artifacts": {
+                    "both": {
+                      "all_classes": [
+                        "Explanation of the supplied materials, including how to access and use them."
+                      ]
+                    }
+                  }
                 },
                 "d": {
                   "statement": "Providers of Class D offerings MUST supply per-service FedRAMP Certification materials.",
@@ -1242,6 +1263,13 @@
                     "obtain": "2027-05-04",
                     "maintain": "2027-05-04",
                     "grace_by_assessment_months": 2
+                  },
+                  "artifacts": {
+                    "both": {
+                      "all_classes": [
+                        "Explanation of the supplied materials, including how to access and use them."
+                      ]
+                    }
                   }
                 }
               },
@@ -1250,13 +1278,6 @@
                 "Providers are encouraged to provide a single comprehensive set of materials for all shared aspects of the service offering and only provide separate materials for unique aspects of each service to minimize the burden on providers and agencies."
               ],
               "affects": ["Providers"],
-              "artifacts": {
-                "both": {
-                  "all_classes": [
-                    "Explanation of the supplied materials, including how to access and use them."
-                  ]
-                }
-              },
               "terms": ["Agency", "Provider"],
               "updated": [
                 {

--- a/schemas/fedramp-consolidated-rules.schema.json
+++ b/schemas/fedramp-consolidated-rules.schema.json
@@ -322,6 +322,10 @@
               {
                 "properties": { "primary_key_word": {} },
                 "required": ["primary_key_word"]
+              },
+              {
+                "properties": { "artifacts": {} },
+                "required": ["artifacts"]
               }
             ]
           }
@@ -415,7 +419,8 @@
         "effective_date": { "$ref": "#/$defs/effective_dates" },
         "timeframe_type": { "type": "string" },
         "timeframe_num": { "type": "number" },
-        "pain_timeframes": { "$ref": "#/$defs/pain_timeframes" }
+        "pain_timeframes": { "$ref": "#/$defs/pain_timeframes" },
+        "artifacts": { "$ref": "#/$defs/artifacts" }
       },
       "additionalProperties": false
     },
@@ -462,8 +467,16 @@
           "properties": { "varies_by_class": {} },
           "required": ["varies_by_class"],
           "not": {
-            "properties": { "statement": {} },
-            "required": ["statement"]
+            "anyOf": [
+              {
+                "properties": { "statement": {} },
+                "required": ["statement"]
+              },
+              {
+                "properties": { "artifacts": {} },
+                "required": ["artifacts"]
+              }
+            ]
           }
         }
       ],
@@ -494,56 +507,10 @@
       "type": "object",
       "required": ["statement"],
       "properties": {
-        "statement": { "type": "string" }
+        "statement": { "type": "string" },
+        "artifacts": { "$ref": "#/$defs/artifacts" }
       },
       "additionalProperties": false
-    },
-    "default_artifacts": {
-      "type": "object",
-      "required": ["FRR", "KSI"],
-      "properties": {
-        "FRR": { "$ref": "#/$defs/artifact_list" },
-        "KSI": { "$ref": "#/$defs/artifact_list" }
-      },
-      "additionalProperties": false
-    },
-    "artifacts": {
-      "type": "object",
-      "properties": {
-        "both": { "$ref": "#/$defs/artifacts_by_class" },
-        "20x": { "$ref": "#/$defs/artifacts_by_class" },
-        "rev5": { "$ref": "#/$defs/artifacts_by_class" }
-      },
-      "oneOf": [
-        {
-          "properties": {
-            "both": { "$ref": "#/$defs/artifacts_by_class" }
-          },
-          "required": ["both"],
-          "maxProperties": 1
-        },
-        {
-          "properties": {
-            "20x": { "$ref": "#/$defs/artifacts_by_class" },
-            "rev5": { "$ref": "#/$defs/artifacts_by_class" }
-          },
-          "required": ["20x", "rev5"],
-          "maxProperties": 2
-        }
-      ],
-      "additionalProperties": false
-    },
-    "artifacts_by_class": {
-      "type": "object",
-      "properties": {
-        "all_classes": { "$ref": "#/$defs/artifact_list" }
-      },
-      "required": ["all_classes"],
-      "additionalProperties": false
-    },
-    "artifact_list": {
-      "type": "array",
-      "items": { "type": "string" }
     },
     "default_artifacts": {
       "type": "object",

--- a/schemas/fedramp-consolidated-rules.schema.json
+++ b/schemas/fedramp-consolidated-rules.schema.json
@@ -545,6 +545,57 @@
       "type": "array",
       "items": { "type": "string" }
     },
+    "default_artifacts": {
+      "type": "object",
+      "required": ["FRR", "KSI"],
+      "properties": {
+        "FRR": { "$ref": "#/$defs/artifact_list" },
+        "KSI": { "$ref": "#/$defs/artifact_list" }
+      },
+      "additionalProperties": false
+    },
+    "artifacts": {
+      "type": "object",
+      "properties": {
+        "both": { "$ref": "#/$defs/artifacts_by_class" },
+        "20x": { "$ref": "#/$defs/artifacts_by_class" },
+        "rev5": { "$ref": "#/$defs/artifacts_by_class" }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "both": { "$ref": "#/$defs/artifacts_by_class" }
+          },
+          "required": ["both"],
+          "maxProperties": 1
+        },
+        {
+          "properties": {
+            "20x": { "$ref": "#/$defs/artifacts_by_class" },
+            "rev5": { "$ref": "#/$defs/artifacts_by_class" }
+          },
+          "required": ["20x", "rev5"],
+          "maxProperties": 2
+        }
+      ],
+      "additionalProperties": false
+    },
+    "artifacts_by_class": {
+      "type": "object",
+      "properties": {
+        "all_classes": { "$ref": "#/$defs/artifact_list" },
+        "a": { "$ref": "#/$defs/artifact_list" },
+        "b": { "$ref": "#/$defs/artifact_list" },
+        "c": { "$ref": "#/$defs/artifact_list" },
+        "d": { "$ref": "#/$defs/artifact_list" }
+      },
+      "required": ["all_classes"],
+      "additionalProperties": false
+    },
+    "artifact_list": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
     "primary_key_word_enum": {
       "type": "string",
       "description": "Defines the primary keyword for a requirement or indicator, indicating its strength.",

--- a/tools/bun.lock
+++ b/tools/bun.lock
@@ -1,12 +1,12 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "tools",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
+        "xlsx": "^0.18.5",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -22,15 +22,25 @@
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "adler-32": ["adler-32@1.3.1", "", {}, "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="],
+
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
+    "cfb": ["cfb@1.2.2", "", { "dependencies": { "adler-32": "~1.3.0", "crc-32": "~1.2.0" } }, "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA=="],
+
+    "codepage": ["codepage@1.15.0", "", {}, "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA=="],
+
+    "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "frac": ["frac@1.1.2", "", {}, "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -38,8 +48,16 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "ssf": ["ssf@0.11.2", "", { "dependencies": { "frac": "~1.1.2" } }, "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "wmf": ["wmf@1.0.2", "", {}, "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw=="],
+
+    "word": ["word@0.3.0", "", {}, "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA=="],
+
+    "xlsx": ["xlsx@0.18.5", "", { "dependencies": { "adler-32": "~1.3.0", "cfb": "~1.2.1", "codepage": "~1.15.0", "crc-32": "~1.2.1", "ssf": "~0.11.2", "wmf": "~1.0.1", "word": "~0.3.0" }, "bin": { "xlsx": "bin/xlsx.njs" } }, "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ=="],
   }
 }

--- a/tools/export-spreadsheet.ts
+++ b/tools/export-spreadsheet.ts
@@ -1,0 +1,196 @@
+import * as XLSX from "xlsx";
+import { getOptionValue } from "./src/cli";
+import { loadRulesDocument } from "./src/rules";
+import type { KsiIndicator, Requirement, RulesDocument } from "./src/types";
+
+const CLASS_KEYS = ["a", "b", "c", "d"] as const;
+
+function joinList(values: unknown): string {
+  if (!Array.isArray(values)) return "";
+  return values.filter((v): v is string => typeof v === "string").join("; ");
+}
+
+// artifacts: { "both"|"20x"|"rev5": { "all_classes"?: string[], "a"?: string[], ... } }
+type ArtifactsByClass = Partial<Record<"all_classes" | "a" | "b" | "c" | "d", string[]>>;
+type ArtifactsField = Record<string, ArtifactsByClass>;
+
+function flattenArtifacts(artifacts: unknown): Record<string, string> {
+  const merged: Record<"all_classes" | "a" | "b" | "c" | "d", string[]> = {
+    all_classes: [], a: [], b: [], c: [], d: [],
+  };
+
+  if (!artifacts || typeof artifacts !== "object" || Array.isArray(artifacts)) {
+    return {
+      "Artifacts (All Classes)": "",
+      "Artifacts (Class A)": "",
+      "Artifacts (Class B)": "",
+      "Artifacts (Class C)": "",
+      "Artifacts (Class D)": "",
+    };
+  }
+
+  for (const appVal of Object.values(artifacts as ArtifactsField)) {
+    for (const key of Object.keys(merged) as (keyof typeof merged)[]) {
+      if (Array.isArray(appVal[key])) {
+        merged[key].push(...appVal[key]!.filter(Boolean));
+      }
+    }
+  }
+
+  return {
+    "Artifacts (All Classes)": merged.all_classes.join("; "),
+    "Artifacts (Class A)": merged.a.join("; "),
+    "Artifacts (Class B)": merged.b.join("; "),
+    "Artifacts (Class C)": merged.c.join("; "),
+    "Artifacts (Class D)": merged.d.join("; "),
+  };
+}
+
+function lastUpdatedDate(updated: Requirement["updated"]): string {
+  return updated?.[0]?.date ?? "";
+}
+
+function lastUpdatedComment(updated: Requirement["updated"]): string {
+  return updated?.[0]?.comment ?? "";
+}
+
+// ── FRD ──────────────────────────────────────────────────────────────────────
+
+function buildFrdRows(document: RulesDocument) {
+  const rows: Record<string, string>[] = [];
+
+  for (const [scopeKey, definitions] of Object.entries(document.FRD.data ?? {})) {
+    for (const [id, def] of Object.entries(definitions)) {
+      rows.push({
+        ID: id,
+        Applicability: scopeKey,
+        Term: def.term,
+        Tag: def.tag ?? "",
+        Alts: joinList(def.alts),
+        Definition: def.definition,
+        Note: def.note ?? joinList(def.notes),
+        Reference: def.reference ?? "",
+        "Reference URL": def.reference_url ?? def.referenceurl ?? "",
+        "Last Updated": lastUpdatedDate(def.updated),
+        "Update Comment": lastUpdatedComment(def.updated),
+      });
+    }
+  }
+
+  return rows;
+}
+
+// ── FRR ──────────────────────────────────────────────────────────────────────
+
+function statementForClass(req: Requirement, classKey: (typeof CLASS_KEYS)[number]): string {
+  return req.varies_by_class?.[classKey]?.statement ?? "";
+}
+
+function pkwForClass(req: Requirement, classKey: (typeof CLASS_KEYS)[number]): string {
+  return req.varies_by_class?.[classKey]?.primary_key_word ?? "";
+}
+
+function buildFrrRows(document: RulesDocument) {
+  const rows: Record<string, string>[] = [];
+
+  for (const [sectionKey, section] of Object.entries(document.FRR ?? {})) {
+    for (const [applicability, scope] of Object.entries(section.data ?? {})) {
+      for (const [labelKey, requirements] of Object.entries(scope ?? {})) {
+        for (const [id, req] of Object.entries(requirements)) {
+          const hasVariants = Boolean(req.varies_by_class);
+
+          rows.push({
+            ID: id,
+            Process: sectionKey,
+            Applicability: applicability,
+            Label: labelKey,
+            Name: req.name,
+            Statement: req.statement ?? "",
+            "Primary Keyword": req.primary_key_word ?? "",
+            "Statement (Class A)": hasVariants ? statementForClass(req, "a") : "",
+            "Keyword (Class A)": hasVariants ? pkwForClass(req, "a") : "",
+            "Statement (Class B)": hasVariants ? statementForClass(req, "b") : "",
+            "Keyword (Class B)": hasVariants ? pkwForClass(req, "b") : "",
+            "Statement (Class C)": hasVariants ? statementForClass(req, "c") : "",
+            "Keyword (Class C)": hasVariants ? pkwForClass(req, "c") : "",
+            "Statement (Class D)": hasVariants ? statementForClass(req, "d") : "",
+            "Keyword (Class D)": hasVariants ? pkwForClass(req, "d") : "",
+            "Following Information": joinList(req.following_information),
+            Note: req.note ?? joinList(req.notes),
+            Affects: joinList(req.affects),
+            Controls: joinList((req as unknown as Record<string, unknown>).controls),
+            Terms: joinList(req.terms),
+            "Timeframe Type": String((req as unknown as Record<string, unknown>).timeframe_type ?? ""),
+            "Timeframe Num": String((req as unknown as Record<string, unknown>).timeframe_num ?? ""),
+            ...flattenArtifacts((req as unknown as Record<string, unknown>).artifacts),
+            "Last Updated": lastUpdatedDate(req.updated),
+            "Update Comment": lastUpdatedComment(req.updated),
+          });
+        }
+      }
+    }
+  }
+
+  return rows;
+}
+
+// ── KSI ──────────────────────────────────────────────────────────────────────
+
+function ksiStatementForClass(ind: KsiIndicator, classKey: (typeof CLASS_KEYS)[number]): string {
+  return ind.varies_by_class?.[classKey]?.statement ?? "";
+}
+
+function buildKsiRows(document: RulesDocument) {
+  const rows: Record<string, string>[] = [];
+
+  for (const [themeKey, theme] of Object.entries(document.KSI ?? {})) {
+    const indicators = Array.isArray(theme.indicators)
+      ? Object.fromEntries(theme.indicators.map((ind, i) => [`KSI-${themeKey}-${String(i + 1).padStart(3, "0")}`, ind]))
+      : theme.indicators;
+
+    for (const [id, ind] of Object.entries(indicators ?? {})) {
+      const hasVariants = Boolean(ind.varies_by_class);
+
+      rows.push({
+        ID: id,
+        Theme: themeKey,
+        "Theme Name": theme.name,
+        Name: ind.name,
+        Statement: ind.statement ?? "",
+        "Statement (Class A)": hasVariants ? ksiStatementForClass(ind, "a") : "",
+        "Statement (Class B)": hasVariants ? ksiStatementForClass(ind, "b") : "",
+        "Statement (Class C)": hasVariants ? ksiStatementForClass(ind, "c") : "",
+        "Statement (Class D)": hasVariants ? ksiStatementForClass(ind, "d") : "",
+        Controls: joinList((ind as unknown as Record<string, unknown>).controls),
+        Terms: joinList(ind.terms),
+        Note: ind.note ?? joinList(ind.notes),
+        "Last Updated": lastUpdatedDate(ind.updated),
+        "Update Comment": lastUpdatedComment(ind.updated),
+      });
+    }
+  }
+
+  return rows;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+const outputPath = getOptionValue("--output") ?? "../fedramp-consolidated-rules.xlsx";
+
+const document = loadRulesDocument();
+
+const wb = XLSX.utils.book_new();
+
+const frdRows = buildFrdRows(document);
+XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(frdRows), "FRD Definitions");
+
+const frrRows = buildFrrRows(document);
+XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(frrRows), "FRR Requirements");
+
+const ksiRows = buildKsiRows(document);
+XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(ksiRows), "KSI Indicators");
+
+XLSX.writeFile(wb, outputPath);
+
+console.log(`Wrote ${frdRows.length} FRD definitions, ${frrRows.length} FRR requirements, ${ksiRows.length} KSI indicators.`);
+console.log(`Spreadsheet saved to: ${outputPath}`);

--- a/tools/package.json
+++ b/tools/package.json
@@ -22,11 +22,13 @@
     "fix:ids": "bun run fix -- --scope ids",
     "fix:order": "bun run fix -- --scope order",
     "summary:rules": "bun run summary -- --scope rules",
-    "hooks:install": "sh ./install-git-hooks.sh"
+    "hooks:install": "sh ./install-git-hooks.sh",
+    "export": "bun run export-spreadsheet.ts"
   },
   "dependencies": {
     "ajv": "^8.17.1",
-    "ajv-formats": "^3.0.1"
+    "ajv-formats": "^3.0.1",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@types/bun": "latest",


### PR DESCRIPTION
## Summary

- Extends the schema so that `artifacts` on `frr_requirement` and `ksi_indicator` is only valid at the root level when there is **no** `varies_by_class`; when `varies_by_class` is present, `artifacts` must live inside each class entry (`a`/`b`/`c`/`d`) instead
- Adds `artifacts` as an allowed property on `frr_requirement_level` and `ksi_indicator_level` (the per-class entry types)
- Removes a duplicate `$defs` block in the schema (`default_artifacts`, `artifacts`, `artifacts_by_class`, and `artifact_list` each appeared twice)
- Migrates `CDS-CSO-PSM` — the one existing requirement with both `varies_by_class` and `artifacts` — to place the artifact inside each class entry

## Test plan

- [ ] `bun run test` passes from `tools/`
- [ ] `CDS-CSO-PSM` in the data has `artifacts` inside each of `a`, `b`, `c`, `d` and no root-level `artifacts`
- [ ] A requirement with `varies_by_class` and root-level `artifacts` fails schema validation
- [ ] A requirement without `varies_by_class` and root-level `artifacts` still passes