### PR TITLE
Updating ICP and 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,14 @@ The JSON file has four top-level sections:
 Important fields include `term`, `definition`, `alts`, references, notes, and
 `updated` history.
 
+The FRD data container uses applicability buckets. Shared definitions live under
+`FRD.data.all`; framework-specific definitions, if present, live under
+`FRD.data.20x` or `FRD.data.rev5`.
+
+FRD effective metadata may be common (`FRD.info.effective`) or split into
+paired framework-specific blocks (`FRD.info.20x.effective` and
+`FRD.info.rev5.effective`).
+
 When a defined term appears in an FRR rule or KSI indicator, use the FRD
 definition instead of assuming the plain-language meaning.
 
@@ -55,7 +63,11 @@ definition instead of assuming the plain-language meaning.
 Each process contains:
 
 - `info`
-  Rule metadata, purpose, status, effective metadata, and label definitions.
+  Rule metadata, purpose, status, effective metadata, label definitions, and
+  optional flow descriptions. Effective metadata may be common
+  (`info.effective`) or split into paired framework-specific blocks
+  (`info.20x.effective` and `info.rev5.effective`). Labels and flows may also
+  be common or framework-specific.
 - `data`
   The rule tree.
 
@@ -65,7 +77,7 @@ The rule tree is organized as:
 FRR -> process -> data -> applicability -> label -> requirement ID
 ```
 
-Applicability keys are `both`, `20x`, and `rev5`. Labels identify actors,
+Applicability keys are `all`, `20x`, and `rev5`. Labels identify actors,
 scopes, or process buckets. Requirement IDs follow the
 `PROCESS-LABEL-KEY` pattern, such as `VDR-CSO-123`.
 
@@ -74,9 +86,13 @@ Each requirement contains either:
 - a single `statement` and `primary_key_word`, or
 - a `varies_by_class` object with class-specific statements and keywords.
 
-Other useful fields include `affects`, `controls`, `artifacts`,
-`following_information`, `examples`, `notification`, timeframes, terms,
-references, and `updated` history.
+Class-specific variants may also include `following_information`, `artifacts`,
+notes, effective dates, simple timeframes, and `pain_timeframes`.
+
+Other useful top-level fields include `affects`, `controls`, `artifacts`,
+`following_information`, `following_information_bullets`, `examples`,
+`notification`, simple timeframes, terms, references, corrective actions,
+effective dates, and `updated` history.
 
 ### KSI
 
@@ -93,19 +109,26 @@ terms, references, and update history.
   matching when structured access is practical.
 - Validate the rules file against the schema before relying on automated
   analysis.
-- Select the correct applicability path: `both`, `20x`, or `rev5`.
-- Check `info.effective` before deciding whether a rule applies to a framework
-  or timeline.
+- Select the correct applicability path: `all`, `20x`, or `rev5`; `all`
+  means shared across frameworks.
+- Check common `info.effective` or the framework-specific
+  `info.20x.effective` / `info.rev5.effective` before deciding whether a rule
+  applies to a framework or timeline.
 - Check each document `status`; `placeholder` and `empty` content should be
   treated differently from `stable` content.
 - Resolve relevant terms through `FRD`.
-- Respect `varies_by_class` before applying a rule to a specific service class.
+- Resolve FRR label definitions from common `info.labels` plus any matching
+  framework-specific `info.20x.labels` or `info.rev5.labels`.
+- Respect `varies_by_class` before applying a rule to a specific service class,
+  including class-specific following information, artifacts, notes, and
+  timeframes.
 - Treat `MUST` and `MUST NOT` as hard requirements, `SHOULD` and `SHOULD NOT`
   as expected practices with possible justified exceptions, and `MAY` as
   optional or permitted behavior.
 - Cite stable IDs for every finding, mapping, or recommendation.
-- Use `affects`, `controls`, `artifacts`, and `default_artifacts` as mapping
-  signals. They are aids for analysis, not replacements for the rule statement.
+- Use `affects`, `controls`, `artifacts`, `default_artifacts`, notifications,
+  and timeframes as mapping signals. They are aids for analysis, not
+  replacements for the rule statement.
 - Distinguish evidence found, evidence missing, and conclusions inferred from
   evidence. Do not claim compliance from silence.
 
@@ -135,6 +158,66 @@ the rules as a structured mapping source:
 - Prefer narrowly scoped findings with exact citations over broad claims about
   FedRAMP readiness.
 
+## Changelog Generation
+
+When asked to generate a changelog for the active branch, produce a screen-only
+summary of the branch delta against `main`; do not create a changelog file
+unless the user explicitly asks for one.
+
+- Output the changelog as copy/pasteable Markdown. When responding in chat,
+  place the changelog itself inside a fenced `markdown` code block; keep any
+  explanatory notes outside the block.
+- Use plain repository paths inside the changelog instead of clickable Markdown
+  file links so the copied text remains portable.
+- Use the branch merge base with `main` as the starting point and the current
+  branch tip as the ending point. Prefer `git diff main...HEAD`,
+  `git diff --name-status main...HEAD`, and
+  `git log --reverse --format='%h %s' main..HEAD`.
+- If `main` is missing or stale and network access is available, fetch it first;
+  otherwise state which local ref was used.
+- Treat committed branch changes as the changelog scope by default. Mention
+  uncommitted workspace changes separately only when they affect the requested
+  analysis or the user asks to include them.
+- Validate the rules file against the schema before relying on automated JSON
+  analysis. If validation cannot be run, say so and continue carefully.
+- Parse JSON with a real JSON parser when comparing
+  [fedramp-consolidated-rules.json](fedramp-consolidated-rules.json) and
+  [schemas/fedramp-consolidated-rules.schema.json](schemas/fedramp-consolidated-rules.schema.json);
+  avoid text-only diff analysis for rule content whenever structured access is
+  practical.
+- Compare the initial branch state to the final branch state, not commit by
+  commit, unless a commit-level explanation is specifically requested.
+- Use stable IDs in every rule-content bullet: `FRD-XXX`, `FRR` requirement IDs
+  such as `VDR-CSO-123`, and `KSI-THEME-KEY`.
+- For each substantively changed rule, definition, or indicator, write one
+  sentence describing the user-visible change. Include additions, removals,
+  renamed terms, wording changes, actor/scope changes, applicability moves,
+  artifact changes, control mappings, examples, notifications, references,
+  timeframes, and class-specific variants.
+- Group purely mechanical metadata churn, such as mass `updated` date resets or
+  property ordering changes, instead of listing every affected rule separately.
+- Separate evidence from inference. When a conclusion comes from schema shape,
+  property names, or structural movement rather than explicit wording, label it
+  as structural.
+- Use exactly these changelog sections, in this order:
+  1. `Rules Content Changes`
+     Summarize changes inside `fedramp-consolidated-rules.json` itself. Focus
+     on rule, definition, indicator, FRR document, and metadata meaning changes.
+  2. `Schema And Structure Changes`
+     Summarize changes to
+     `schemas/fedramp-consolidated-rules.schema.json` and corresponding
+     structural changes in the rules JSON, such as top-level `info` changes,
+     property additions, renamed applicability buckets, required fields,
+     controlled vocabularies, and object shapes.
+  3. `Tooling And Test Changes`
+     Summarize support-code changes, CLI behavior, validators, fixers,
+     generated-summary behavior, package scripts, test harnesses, and test
+     coverage.
+- Keep bullets simple and high signal. Prefer a single line per bullet unless
+  the change is complex enough that a short second sentence prevents ambiguity.
+- End with a brief validation note naming the commands run, such as
+  `bun run check`, or explain why validation was not run.
+
 ## Editing Guidance
 
 If asked to edit the rules:
@@ -143,7 +226,8 @@ If asked to edit the rules:
   only when necessary, the schema.
 - Keep IDs stable unless the requested change requires a new or corrected ID.
 - Preserve schema-driven property order.
-- Update `updated` history when changing rule or definition meaning.
+- Update `updated` history when changing rule, definition, or indicator
+  meaning.
 - Regenerate [RULES.md](RULES.md) through the tooling rather than editing it by
   hand.
 - Run the tooling checks when available.

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -2429,7 +2429,7 @@
         "name": "Incident Communications Procedures",
         "short_name": "ICP",
         "web_name": "incident-communications-procedures",
-        "purpose": "The Incident Communications Procedures rules explain how providers must communicate incident information to FedRAMP, CISA, and government customers.",
+        "purpose": "The Incident Communications Procedures rules explain how providers must communicate incident information to FedRAMP and government customers.",
         "status": "placeholder",
         "labels": {
           "FRP": {
@@ -2584,48 +2584,18 @@
                 }
               ]
             },
-            "ICP-CSO-EFI": {
-              "name": "Estimate Federal Impact",
-              "statement": "Providers SHOULD promptly estimate the likely adverse impact of an incident on agency customers to assign a Potential Agency Impact N-rating; this step is called Incident Rating.",
-              "following_information": [
-                "N1 means minimal customer effect on 1 or more agencies.",
-                "N2 means narrow customer effect on 1 or more agencies.",
-                "N3 means disruptive customer effect on 1 agency.",
-                "N4 means debilitating customer effect on 1 agency or disruptive customer effect on more than 1 agency.",
-                "N5 means debilitating customer effect on more than 1 agency."
-              ],
-              "primary_key_word": "SHOULD",
-              "affects": ["Providers"],
-              "terms": [
-                "Agency",
-                "Debilitating Customer Effect",
-                "Disruptive Customer Effect",
-                "Incident",
-                "Likely",
-                "Minimal Customer Effect",
-                "Narrow Customer Effect",
-                "Potential Agency Impact",
-                "Promptly",
-                "Provider"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
             "ICP-CSO-IIR": {
               "name": "Initial Incident Report",
-              "statement": "Providers MUST responsibly notify all affected parties after identifying FedRAMP Reportable Incidents by providing an Initial Incident Report with all available required information.",
+              "statement": "Providers MUST responsibly notify all affected parties after identifying FedRAMP Reportable Incidents by providing an Initial Incident Report with as much of the following information that is available at the time of reporting:",
               "following_information": [
                 "Contact information for the federal incident response coordinator.",
-                "Provider tracking identifier.",
-                "Description of the incident.",
-                "Incident timeline.",
-                "Historical and current Potential Adverse Impact estimates.",
-                "Functional impact to federal agency customers.",
-                "Estimated recovery plan, milestones, and timelines."
+                "Provider's internally assigned tracking identifier",
+                "Description of the incident",
+                "Timeline of the incident, including start time, time and source of detection, time of completed FedRAMP Reportable Incident evaluation, and other major incident milestones determined by the provider",
+                "Historically and currently estimated Potential Adverse Impact N-rating (PAIN) of the incident, including an explanation of the evaluation following the requirements in ICP-CSO-EFI Estimate Federal Impact (if applicable)",
+                "Functional impact to federal agency customers (include impact to confidentiality and/or integrity and the impacted federal customer data types)",
+                "Estimated recovery plan, milestones, and timelines",
+                "List of likely affected customer agencies"
               ],
               "primary_key_word": "MUST",
               "affects": ["Providers"],
@@ -2665,16 +2635,13 @@
             },
             "ICP-CSO-OIR": {
               "name": "Ongoing Incident Reports",
-              "statement": "Providers MUST responsibly notify all affected parties of ongoing activity by providing Ongoing Incident Reports as new information becomes available during incident response for FedRAMP Reportable Incidents.",
+              "statement": "Providers MUST responsibly notify all affected parties of ongoing activity as new information becomes available during incident response for FedRAMP Reportable Incidents, including updates (or lack of updates) to all previously reported information and as much of the the following additional information that is available:",
               "following_information": [
-                "Updates or lack of updates to previously reported information.",
-                "Attack vector, if identified.",
-                "Observed incident activity.",
-                "Indicators of compromise.",
-                "Relevant Cybersecurity and Infrastructure Security Agency identifier, if available.",
-                "Related Common Vulnerabilities and Exposures identifier, if applicable.",
-                "Root cause.",
-                "Response and recovery activities."
+                "Observed incident activity",
+                "Indicators of compromise",
+                "Related Common Vulnerabilities and Exposures (CVE) identifier, if applicable",
+                "Root cause",
+                "Response and recovery activities"
               ],
               "primary_key_word": "MUST",
               "affects": ["Providers"],
@@ -3130,6 +3097,56 @@
                 {
                   "date": "2026-04-25",
                   "comment": "Drafted for human review from PROPOSED-RULES.md."
+                }
+              ]
+            },
+            "ICP-CSO-EFI": {
+              "name": "Estimate Federal Impact",
+              "statement": "Providers SHOULD promptly estimate the likely adverse impact of an incident on agency customers to assign a Potential Agency Impact N-rating; this step is called Incident Rating.",
+              "following_information": [
+                "N1 means minimal customer effect on 1 or more agencies.",
+                "N2 means narrow customer effect on 1 or more agencies.",
+                "N3 means disruptive customer effect on 1 agency.",
+                "N4 means debilitating customer effect on 1 agency or disruptive customer effect on more than 1 agency.",
+                "N5 means debilitating customer effect on more than 1 agency."
+              ],
+              "primary_key_word": "SHOULD",
+              "affects": ["Providers"],
+              "terms": [
+                "Agency",
+                "Debilitating Customer Effect",
+                "Disruptive Customer Effect",
+                "Incident",
+                "Likely",
+                "Minimal Customer Effect",
+                "Narrow Customer Effect",
+                "Potential Agency Impact",
+                "Promptly",
+                "Provider"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "ICP-CSO-AIR": {
+              "name": "Automated Incident Reporting",
+              "statement": "Providers SHOULD use automation to minimize human intervention in the process of reporting FedRAMP Reportable Incidents to all affected parties.",
+              "danger": "Modern cloud services should not be reporting incidents by hand-crafting emails!",
+              "primary_key_word": "SHOULD",
+              "affects": ["Providers"],
+              "terms": [
+                "All Affected Parties",
+                "FedRAMP Reportable Incident",
+                "Incident",
+                "Provider"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
                 }
               ]
             }

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -155,21 +155,6 @@
             }
           ]
         },
-        "FRD-CAE": {
-          "term": "Catastrophic Adverse Effect",
-          "definition": "A severe negative impact on an organization caused by the loss of confidentiality, integrity, or availability of its information. At a minimum, this includes effects that would likely: (i) result in a severe degradation in the availability or performance of services within the cloud service offering for 24+ hours; OR (ii) directly or indirectly result in unauthorized access, disclosure, or modification of a majority of the federal customer data stored within the cloud service offering.",
-          "tag": "Adverse Effect",
-          "alts": [
-            "catastrophic adverse effect",
-            "catastrophic adverse effects"
-          ],
-          "updated": [
-            {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-            }
-          ]
-        },
         "FRD-CCC": {
           "term": "Certification Class Change",
           "definition": "A type of significant change that is likely to change the FedRAMP Certification class for the entire cloud service offering (e.g. from Class B to Class C or from Class D to Class C).",
@@ -222,11 +207,38 @@
             }
           ]
         },
+        "FRD-DCE": {
+          "term": "Debilitating Customer Effect",
+          "definition": "An unwanted customer effect that interrupts use of the cloud service for most users or compromises the integrity or confidentiality of most federal customer data. If the adverse customer effect is unknown then it should be treated as if it is debilitating until proven otherwise.",
+          "tag": "Customer Effect",
+          "alts": [
+            "debilitating customer effect",
+            "debilitating customer effects"
+          ],
+          "updated": [
+            {
+              "date": "2026-07-04",
+              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+            }
+          ]
+        },
         "FRD-DTM": {
           "term": "Deterministic Telemetry",
           "definition": "Verifiable data collected directly from an authoritative source that represents a factual and reproducible observation of the attributes of a system such as the system's state, configuration, or behavior.",
           "note": "Probabilistic inferences, generative outputs, or predictive assessments such as those produced using generative transformer models (commonly referred to as “Generative AI”) do not constitute a factual record of the system state and must not be used to generate deterministic telemetry.",
           "alts": ["deterministic telemetry"],
+          "updated": [
+            {
+              "date": "2026-07-04",
+              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+            }
+          ]
+        },
+        "FRD-DCF": {
+          "term": "Disruptive Customer Effect",
+          "definition": "A significant negative impact on an organization caused by the loss of confidentiality, integrity, or availability of its information. At a minimum, this includes effects that would likely: (i) result in intermittent or ongoing degradation in the availability or performance of services within the cloud service offering, causing unpredictable interruptions to operations for 12+ hours; OR (ii) directly or indirectly result in unauthorized access, disclosure, or modification of a minority of the federal customer data stored within the cloud service offering.",
+          "tag": "Customer Effect",
+          "alts": ["disruptive customer effect", "disruptive customer effects"],
           "updated": [
             {
               "date": "2026-07-04",
@@ -276,21 +288,6 @@
             }
           ]
         },
-        "FRD-FRI": {
-          "term": "Federal Reportable Incident",
-          "definition": "An incident that affects the confidentiality or integrity of federal customer data or is likely to affect the confidentiality or integrity of federal customer data.",
-          "tag": "Incident",
-          "alts": [
-            "federal reportable incident",
-            "federal reportable incidents"
-          ],
-          "updated": [
-            {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-            }
-          ]
-        },
         "FRD-FCT": {
           "term": "FedRAMP Certified",
           "definition": "The status of a cloud service offering that has received FedRAMP Certification and meets the legal requirement to be FedRAMP authorized.",
@@ -317,6 +314,21 @@
           "term": "FedRAMP Recognized",
           "definition": "The status of independent assessment services that are recognized by FedRAMP to perform assessment activities on behalf of FedRAMP for cloud service offerings seeking to obtain or maintain FedRAMP Certification.",
           "alts": ["FedRAMP Recognized", "FedRAMP Recognition"],
+          "updated": [
+            {
+              "date": "2026-07-04",
+              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+            }
+          ]
+        },
+        "FRD-FRI": {
+          "term": "FedRAMP Reportable Incident",
+          "definition": "An incident that affects the confidentiality or integrity of federal customer data or is likely to affect the confidentiality or integrity of federal customer data.",
+          "tag": "Incident",
+          "alts": [
+            "FedRAMP Reportable Incident",
+            "FedRAMP Reportable Incidents"
+          ],
           "updated": [
             {
               "date": "2026-07-04",
@@ -354,7 +366,7 @@
         },
         "FRD-FMV": {
           "term": "Fully Mitigated Vulnerability",
-          "definition": "A vulnerability where the likelihood of exploitation or Potential Adverse Impact N-rating has been reduced from the original evaluation until either are negligible, but the vulnerability is still detected.",
+          "definition": "A vulnerability where the likelihood of exploitation or Potential Agency Impact N-rating has been reduced from the original evaluation until either are negligible, but the vulnerability is still detected.",
           "tag": "Vulnerability",
           "alts": [
             "fully mitigated vulnerability",
@@ -525,18 +537,6 @@
             }
           ]
         },
-        "FRD-LAE": {
-          "term": "Limited Adverse Effect",
-          "definition": "A minor negative impact on an organization caused by the loss of confidentiality, integrity, or availability of its information. At a minimum, this includes effects that would likely: (i) result in degradation of the availability or performance of services within the cloud service offering for a minority of relevant users; OR (ii) directly or indirectly result in unauthorized access, disclosure, or modification of a small amount of the federal customer data stored within the cloud service offering by only a few relevant users.",
-          "tag": "Adverse Effect",
-          "alts": ["limited adverse effect", "limited adverse effects"],
-          "updated": [
-            {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-            }
-          ]
-        },
         "FRD-MBI": {
           "term": "Machine-Based (Information Resources)",
           "definition": "Any information technology information resource—including systems, processes, software, hardware, services, cloud-native capabilities, and any other such capability, component, or resource—that relies primarily on mechanical or electronic devices (i.e. computers) for operation.",
@@ -574,11 +574,23 @@
             }
           ]
         },
-        "FRD-NAE": {
-          "term": "Negligible Adverse Effect",
-          "definition": "A small negative impact on an organization caused by the loss of confidentiality, integrity, or availability of its information. At a minimum, this includes effects that would likely: (i) result in minor inconvenience when accessing or using services within the cloud service offering; OR (ii) result in degradation of the availability or performance of services within the cloud service offering for only a few relevant users.",
-          "tag": "Adverse Effect",
-          "alts": ["negligible adverse effect", "negligible adverse effects"],
+        "FRD-MCE": {
+          "term": "Minimal Customer Effect",
+          "definition": "An unwanted customer effect that is only noticeable by some users. This includes minor inconveniences such as reduced performance.",
+          "tag": "Customer Effect",
+          "alts": ["minimal customer effect", "minimal customer effects"],
+          "updated": [
+            {
+              "date": "2026-07-04",
+              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+            }
+          ]
+        },
+        "FRD-NCE": {
+          "term": "Narrow Customer Effect",
+          "definition": "An unwanted customer effect that interrupts use of the cloud service for some users for less than 12 hours, or that compromises the integrity or confidentiality of an extremely limited amount and type of federal customer data.",
+          "tag": "Customer Effect",
+          "alts": ["narrow customer effect", "narrow customer effects"],
           "updated": [
             {
               "date": "2026-07-04",
@@ -639,7 +651,7 @@
         },
         "FRD-PMV": {
           "term": "Partially Mitigated Vulnerability",
-          "definition": "A vulnerability where the likelihood or Potential Adverse Impact N-rating has been reduced from the original evaluation but the risk of exploitation still exists and the vulnerability is still detected.",
+          "definition": "A vulnerability where the likelihood or Potential Agency Impact N-rating has been reduced from the original evaluation but the risk of exploitation still exists and the vulnerability is still detected.",
           "tag": "Vulnerability",
           "alts": [
             "partially mitigated vulnerability",
@@ -677,13 +689,13 @@
           ]
         },
         "FRD-PAI": {
-          "term": "Potential Adverse Impact",
-          "definition": "The estimated cumulative effect of unauthorized access, disruption, harm, or other adverse impact to the United States federal government that is likely to result from either a security incident or the exploitation of a vulnerability in the cloud service offering; as estimated following appropriate FedRAMP rules to calculate the Potential Adverse Impact N-rating (PAIN).",
+          "term": "Potential Agency Impact",
+          "definition": "The estimated cumulative effect of unauthorized access, disruption, harm, or other adverse impacts to all agencies using the cloud service that are likely to result from security incidents or the exploitation of vulnerabilities in the cloud service offering; as estimated following appropriate FedRAMP rules to calculate the Potential Agency Impact N-rating (PAIN).",
           "alts": [
-            "potential adverse impact",
-            "potential adverse impacts",
+            "potential agency impact",
+            "potential agency impacts",
             "PAIN",
-            "Potential Adverse Impact N-rating"
+            "Potential Agency Impact N-rating"
           ],
           "updated": [
             {
@@ -810,18 +822,6 @@
           ],
           "reference": "NIST FIPS 199 Standards for Security Categorization of Federal Information and Information Systems",
           "reference_url": "https://csrc.nist.gov/pubs/fips/199/final",
-          "updated": [
-            {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-            }
-          ]
-        },
-        "FRD-SAE": {
-          "term": "Serious Adverse Effect",
-          "definition": "A significant negative impact on an organization caused by the loss of confidentiality, integrity, or availability of its information. At a minimum, this includes effects that would likely: (i) result in intermittent or ongoing degradation in the availability or performance of services within the cloud service offering, causing unpredictable interruptions to operations for 12+ hours; OR (ii) directly or indirectly result in unauthorized access, disclosure, or modification of a minority of the federal customer data stored within the cloud service offering.",
-          "tag": "Adverse Effect",
-          "alts": ["serious adverse effect", "serious adverse effects"],
           "updated": [
             {
               "date": "2026-07-04",
@@ -1741,7 +1741,9 @@
                 "Accepted vulnerabilities",
                 "Transformative changes",
                 "Updated recommendations or best practices for security, configuration, usage, or similar aspects of the cloud service offering",
-                "A list of all agencies that are directly using the product"
+                "A list of all agencies that are directly using the product",
+                "FedRAMP Reportable Incidents or an attestation that no such incidents occurred",
+                "Lessons learned and changes planned or made as a result of FedRAMP Reportable Incidents (if such occurred)"
               ],
               "primary_key_word": "MUST",
               "affects": ["Providers"],
@@ -1751,6 +1753,8 @@
                 "All Necessary Parties",
                 "Certification Data",
                 "Cloud Service Offering",
+                "FedRAMP Reportable Incident",
+                "Incident",
                 "Ongoing Certification",
                 "Ongoing Certification Report (OCR)",
                 "Provider",
@@ -2207,11 +2211,11 @@
                 "**Class B:** by 3:00 p.m. Eastern Time on the 3rd business day",
                 "**Class A:** by 3:00 p.m. Eastern Time on the 5th business day"
               ],
-              "note": "FedRAMP Class D Certified cloud service providers are expected to address Emergency messages (including tests) from FedRAMP with a reaction time appropriate to operating a service where failure to react rapidly might have a severe or catastrophic adverse effect on the U.S. Government; some Emergency messages may require faster reaction and all such messages should be addressed as quickly as possible.",
+              "note": "FedRAMP Class D Certified cloud service providers are expected to address Emergency messages (including tests) from FedRAMP with a reaction time appropriate to operating a service where failure to react rapidly might have a severe or debilitating customer effect on the U.S. Government; some Emergency messages may require faster reaction and all such messages should be addressed as quickly as possible.",
               "primary_key_word": "MUST",
               "affects": ["FedRAMP"],
               "terms": [
-                "Catastrophic Adverse Effect",
+                "Debilitating Customer Effect",
                 "FedRAMP Certified",
                 "Provider"
               ],
@@ -2442,24 +2446,25 @@
               "name": "Public Availability Reporting",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers of Class A offerings SHOULD maintain a publicly accessible status service that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats.",
+                  "statement": "Providers of Class A offerings SHOULD maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats.",
                   "primary_key_word": "SHOULD"
                 },
                 "b": {
-                  "statement": "Providers of Class B offerings SHOULD maintain a publicly accessible status service that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats.",
+                  "statement": "Providers of Class B offerings SHOULD maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats.",
                   "primary_key_word": "SHOULD"
                 },
                 "c": {
-                  "statement": "Providers of Class C offerings MUST maintain a publicly accessible status service that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats.",
+                  "statement": "Providers of Class C offerings MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats.",
                   "primary_key_word": "MUST"
                 },
                 "d": {
-                  "statement": "Providers of Class D offerings MUST maintain a publicly accessible status service that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats.",
+                  "statement": "Providers of Class D offerings MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats.",
                   "primary_key_word": "MUST"
                 }
               },
               "affects": ["Providers"],
               "terms": [
+                "All Necessary Parties",
                 "Cloud Service Offering",
                 "Incident",
                 "Machine-Readable",
@@ -2474,13 +2479,12 @@
             },
             "ICP-CSO-EFR": {
               "name": "Evaluate Federal Reportability",
-              "statement": "Providers MUST promptly evaluate incidents to determine if they affect confidentiality or integrity of federal customer data or are likely to affect confidentiality or integrity of federal customer data.",
-              "note": "An incident that meets this test is a federal reportable incident.",
+              "statement": "Providers MUST promptly evaluate incidents to determine if they affect confidentiality or integrity of federal customer data or are likely to affect confidentiality or integrity of federal customer data; such incidents are FedRAMP Reportable Incidents and must be reported following the FedRAMP Incident Communications Procedures.",
               "primary_key_word": "MUST",
               "affects": ["Providers"],
               "terms": [
+                "FedRAMP Reportable Incident",
                 "Federal Customer Data",
-                "Federal Reportable Incident",
                 "Incident",
                 "Likely",
                 "Promptly",
@@ -2493,28 +2497,49 @@
                 }
               ]
             },
-            "ICP-CSO-EFI": {
-              "name": "Estimate Federal Impact",
-              "statement": "Providers MUST evaluate federal reportable incidents to estimate adverse impact on government customers and assign a Potential Adverse Impact N-rating.",
-              "following_information": [
-                "N1 means negligible adverse effect on 1 or more agencies.",
-                "N2 means limited adverse effect on 1 or more agencies.",
-                "N3 means serious adverse effect on 1 agency.",
-                "N4 means catastrophic adverse effect on 1 agency or serious adverse effect on more than 1 agency.",
-                "N5 means catastrophic adverse effect on more than 1 agency."
-              ],
+            "ICP-CSO-DPR": {
+              "name": "Default PAIN Rating",
+              "statement": "Providers MUST treat FedRAMP Reportable Incidents as if they have a Potential Agency Impact N-rating (PAIN) of 5 UNLESS they promptly estimate the PAIN rating following the rule in ICP-CSO-EFI Estimate Federal Impact.",
               "primary_key_word": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Agency",
-                "Catastrophic Adverse Effect",
-                "Federal Reportable Incident",
+                "FedRAMP Reportable Incident",
                 "Incident",
-                "Limited Adverse Effect",
-                "Negligible Adverse Effect",
-                "Potential Adverse Impact",
-                "Provider",
-                "Serious Adverse Effect"
+                "Potential Agency Impact",
+                "Promptly",
+                "Provider"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "ICP-CSO-EFI": {
+              "name": "Estimate Federal Impact",
+              "statement": "Providers SHOULD promptly estimate the likely adverse impact of an incident on agency customers to assign a Potential Agency Impact N-rating; this step is called Incident Rating.",
+              "following_information": [
+                "N1 means minimal customer effect on 1 or more agencies.",
+                "N2 means narrow customer effect on 1 or more agencies.",
+                "N3 means disruptive customer effect on 1 agency.",
+                "N4 means debilitating customer effect on 1 agency or disruptive customer effect on more than 1 agency.",
+                "N5 means debilitating customer effect on more than 1 agency."
+              ],
+              "primary_key_word": "SHOULD",
+              "affects": ["Providers"],
+              "terms": [
+                "Agency",
+                "Debilitating Customer Effect",
+                "Disruptive Customer Effect",
+                "Incident",
+                "Likely",
+                "Minimal Customer Effect",
+                "Narrow Customer Effect",
+                "Potential Agency Impact",
+                "Promptly",
+                "Provider"
               ],
               "updated": [
                 {
@@ -2525,7 +2550,7 @@
             },
             "ICP-CSO-AAP": {
               "name": "Notify All Affected Parties",
-              "statement": "Providers MUST responsibly notify all affected parties after identifying federal reportable incidents using email, push notification, form submission, secure portal upload, or another method specified by FedRAMP rules or written agency agreement.",
+              "statement": "Providers MUST responsibly notify all affected parties after identifying FedRAMP Reportable Incidents using email, push notification, form submission, secure portal upload, or another method specified by FedRAMP rules or written agency agreement.",
               "following_information": [
                 "Notify FedRAMP via fedramp_security@gsa.gov or fedramp_security@fedramp.gov.",
                 "Follow contact arrangements provided by each agency customer's security contact.",
@@ -2537,7 +2562,7 @@
                 "Agency",
                 "All Affected Parties",
                 "Cloud Service Offering",
-                "Federal Reportable Incident",
+                "FedRAMP Reportable Incident",
                 "Incident",
                 "Provider",
                 "Responsibly",
@@ -2574,7 +2599,7 @@
             },
             "ICP-CSO-IIR": {
               "name": "Initial Incident Report",
-              "statement": "Providers MUST responsibly notify all affected parties after identifying federal reportable incidents by providing an Initial Incident Report with all available required information.",
+              "statement": "Providers MUST responsibly notify all affected parties after identifying FedRAMP Reportable Incidents by providing an Initial Incident Report with all available required information.",
               "following_information": [
                 "Contact information for the federal incident response coordinator.",
                 "Provider tracking identifier.",
@@ -2589,10 +2614,9 @@
               "terms": [
                 "Agency",
                 "All Affected Parties",
-                "Federal Reportable Incident",
+                "FedRAMP Reportable Incident",
                 "Incident",
                 "Initial Incident Report (IIR)",
-                "Potential Adverse Impact",
                 "Provider",
                 "Responsibly",
                 "Vulnerability Response"
@@ -2606,7 +2630,7 @@
             },
             "ICP-CSO-OIR": {
               "name": "Ongoing Incident Reports",
-              "statement": "Providers MUST responsibly notify all affected parties of ongoing activity by providing Ongoing Incident Reports as new information becomes available during incident response for federal reportable incidents.",
+              "statement": "Providers MUST responsibly notify all affected parties of ongoing activity by providing Ongoing Incident Reports as new information becomes available during incident response for FedRAMP Reportable Incidents.",
               "following_information": [
                 "Updates or lack of updates to previously reported information.",
                 "Attack vector, if identified.",
@@ -2622,7 +2646,7 @@
               "terms": [
                 "Agency",
                 "All Affected Parties",
-                "Federal Reportable Incident",
+                "FedRAMP Reportable Incident",
                 "Incident",
                 "Ongoing Incident Report (OIR)",
                 "Provider",
@@ -2660,7 +2684,7 @@
               "name": "Incident Report Timeframes",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers of Class A offerings MUST notify all affected parties of federal reportable incidents within the maximum timeframes from evaluation or recovery shown below, based on the Potential Adverse Impact N-rating.",
+                  "statement": "Providers of Class A offerings MUST notify all affected parties of FedRAMP Reportable Incidents within the maximum timeframes from evaluation or recovery shown below, based on the Potential Agency Impact N-rating.",
                   "primary_key_word": "MUST",
                   "pain_timeframes": {
                     "1": {
@@ -2751,7 +2775,7 @@
                   }
                 },
                 "b": {
-                  "statement": "Providers of Class B offerings MUST notify all affected parties of federal reportable incidents within the maximum timeframes from evaluation or recovery shown below, based on the Potential Adverse Impact N-rating.",
+                  "statement": "Providers of Class B offerings MUST notify all affected parties of FedRAMP Reportable Incidents within the maximum timeframes from evaluation or recovery shown below, based on the Potential Agency Impact N-rating.",
                   "primary_key_word": "MUST",
                   "pain_timeframes": {
                     "1": {
@@ -2842,7 +2866,7 @@
                   }
                 },
                 "c": {
-                  "statement": "Providers of Class C offerings MUST notify all affected parties of federal reportable incidents within the maximum timeframes from evaluation or recovery shown below, based on the Potential Adverse Impact N-rating.",
+                  "statement": "Providers of Class C offerings MUST notify all affected parties of FedRAMP Reportable Incidents within the maximum timeframes from evaluation or recovery shown below, based on the Potential Agency Impact N-rating.",
                   "primary_key_word": "MUST",
                   "pain_timeframes": {
                     "1": {
@@ -2933,7 +2957,7 @@
                   }
                 },
                 "d": {
-                  "statement": "Providers of Class D offerings MUST notify all affected parties of federal reportable incidents within the maximum timeframes from evaluation or recovery shown below, based on the Potential Adverse Impact N-rating.",
+                  "statement": "Providers of Class D offerings MUST notify all affected parties of FedRAMP Reportable Incidents within the maximum timeframes from evaluation or recovery shown below, based on the Potential Agency Impact N-rating.",
                   "primary_key_word": "MUST",
                   "pain_timeframes": {
                     "1": {
@@ -3026,10 +3050,11 @@
               },
               "affects": ["Providers"],
               "terms": [
+                "Agency",
                 "All Affected Parties",
-                "Federal Reportable Incident",
+                "FedRAMP Reportable Incident",
                 "Incident",
-                "Potential Adverse Impact",
+                "Potential Agency Impact",
                 "Provider"
               ],
               "updated": [
@@ -4421,13 +4446,13 @@
             "VDR-AGM-RVR": {
               "name": "Review Vulnerability Reports",
               "statement": "Agencies SHOULD review the information provided in vulnerability reports at appropriate and reasonable intervals commensurate with the expectations and risk posture indicated by their Authorization to Operate, and SHOULD use automated processing and filtering of machine readable information from cloud service providers.",
-              "note": "FedRAMP recommends that agencies only review overdue and accepted vulnerabilities Potential Adverse Impact N-rating > 2 unless the cloud service provider recommends mitigations or the service is included in a higher risk federal information system. Furthermore, accepted vulnerabilities generally only need to be reviewed when they are added or during an updated risk assessment due to changes in the agency's use or authorization.",
+              "note": "FedRAMP recommends that agencies only review overdue and accepted vulnerabilities Potential Agency Impact N-rating > 2 unless the cloud service provider recommends mitigations or the service is included in a higher risk federal information system. Furthermore, accepted vulnerabilities generally only need to be reviewed when they are added or during an updated risk assessment due to changes in the agency's use or authorization.",
               "primary_key_word": "SHOULD",
               "affects": ["Agencies"],
               "terms": [
                 "Accepted Vulnerability",
                 "Agency",
-                "Potential Adverse Impact",
+                "Potential Agency Impact",
                 "Provider",
                 "Vulnerability"
               ],
@@ -4667,25 +4692,25 @@
             },
             "VDR-EVA-EPA": {
               "name": "Estimate Potential Adverse Impact",
-              "statement": "Providers MUST evaluate detected vulnerabilities, considering the context of the cloud service offering, to estimate the potential adverse impact of exploitation on government customers AND assign one of the following Potential Adverse Impact N-ratings (PAIN):",
+              "statement": "Providers MUST evaluate detected vulnerabilities, considering the context of the cloud service offering, to estimate the potential adverse impact of exploitation on government customers AND assign one of the following Potential Agency Impact N-ratings (PAIN):",
               "following_information_bullets": [
-                "**N1**: Exploitation could be expected to have negligible adverse effects on one or more agencies that use the cloud service offering.",
-                "**N2**: Exploitation could be expected to have limited adverse effects on one or more agencies that use the cloud service offering.",
-                "**N3**: Exploitation could be expected to have a serious adverse effect on one agency that uses the cloud service offering.",
-                "**N4**: Exploitation could be expected to have a catastrophic adverse effect on one agency that uses the cloud service offering OR a serious adverse effect on more than one federal agency that uses the cloud service offering.",
-                "**N5**: Exploitation could be expected to have a catastrophic adverse effect on more than one agency that uses the cloud service offering."
+                "**N1**: Exploitation could be expected to have minimal customer effects on one or more agencies that use the cloud service offering.",
+                "**N2**: Exploitation could be expected to have narrow customer effects on one or more agencies that use the cloud service offering.",
+                "**N3**: Exploitation could be expected to have a disruptive customer effect on one agency that uses the cloud service offering.",
+                "**N4**: Exploitation could be expected to have a debilitating customer effect on one agency that uses the cloud service offering OR a disruptive customer effect on more than one federal agency that uses the cloud service offering.",
+                "**N5**: Exploitation could be expected to have a debilitating customer effect on more than one agency that uses the cloud service offering."
               ],
               "primary_key_word": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Agency",
-                "Catastrophic Adverse Effect",
                 "Cloud Service Offering",
-                "Limited Adverse Effect",
-                "Negligible Adverse Effect",
-                "Potential Adverse Impact",
+                "Debilitating Customer Effect",
+                "Disruptive Customer Effect",
+                "Minimal Customer Effect",
+                "Narrow Customer Effect",
+                "Potential Agency Impact",
                 "Provider",
-                "Serious Adverse Effect",
                 "Vulnerability",
                 "Vulnerability Detection"
               ],
@@ -4818,9 +4843,9 @@
                 "Time of completed evaluation",
                 "Is it an internet-reachable vulnerability or not?",
                 "Is it a likely exploitable vulnerability or not?",
-                "Historically and currently estimated Potential Adverse Impact N-rating of exploitation",
-                "Time and Potential Adverse Impact N-rating of each completed and evaluated reduction in Potential Adverse Impact N-rating",
-                "Estimated time and target Potential Adverse Impact N-rating of next reduction in Potential Adverse Impact N-rating",
+                "Historically and currently estimated Potential Agency Impact N-rating of exploitation",
+                "Time and Potential Agency Impact N-rating of each completed and evaluated reduction in Potential Agency Impact N-rating",
+                "Estimated time and target Potential Agency Impact N-rating of next reduction in Potential Agency Impact N-rating",
                 "Is it currently or is it likely to become an overdue vulnerability or not? If so, explain.",
                 "Any supplementary information the provider responsibly determines will help federal agencies assess or mitigate the risk to their federal customer data within the cloud service offering resulting from the vulnerability",
                 "Final disposition of the vulnerability"
@@ -4836,7 +4861,7 @@
                 "Likely",
                 "Likely Exploitable Vulnerability (LEV)",
                 "Overdue Vulnerability",
-                "Potential Adverse Impact",
+                "Potential Agency Impact",
                 "Provider",
                 "Responsibly",
                 "Vulnerability",
@@ -4859,7 +4884,7 @@
                 "Time of completed evaluation",
                 "Is it an internet-reachable vulnerability or not?",
                 "Is it a likely exploitable vulnerability or not?",
-                "Currently estimated Potential Adverse Impact N-rating",
+                "Currently estimated Potential Agency Impact N-rating",
                 "Explanation of why this is an accepted vulnerability",
                 "Any supplementary information the provider determines will responsibly help federal agencies assess or mitigate the risk to their federal customer data within the cloud service offering resulting from the accepted vulnerability"
               ],
@@ -4873,7 +4898,7 @@
                 "Internet-Reachable Vulnerability (IRV)",
                 "Likely",
                 "Likely Exploitable Vulnerability (LEV)",
-                "Potential Adverse Impact",
+                "Potential Agency Impact",
                 "Provider",
                 "Responsibly",
                 "Vulnerability",
@@ -5196,7 +5221,7 @@
               "name": "Mitigation and Remediation Expectations",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers of Class A offerings SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower potential adverse impact within the timeframes from evaluation shown below, factoring for the current Potential Adverse Impact N-rating, internet reachability, and likely exploitability:",
+                  "statement": "Providers of Class A offerings SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower potential adverse impact within the timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
                   "primary_key_word": "SHOULD",
                   "pain_timeframes": {
                     "1": {},
@@ -5271,7 +5296,7 @@
                   }
                 },
                 "b": {
-                  "statement": "Providers of Class B offerings SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower potential adverse impact within the timeframes from evaluation shown below, factoring for the current Potential Adverse Impact N-rating, internet reachability, and likely exploitability:",
+                  "statement": "Providers of Class B offerings SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower potential adverse impact within the timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
                   "primary_key_word": "SHOULD",
                   "pain_timeframes": {
                     "1": {},
@@ -5346,7 +5371,7 @@
                   }
                 },
                 "c": {
-                  "statement": "Providers of Class C offerings SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower potential adverse impact N-rating within the timeframes from evaluation shown below, factoring for the current Potential Adverse Impact N-rating, internet reachability, and likely exploitability:",
+                  "statement": "Providers of Class C offerings SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower Potential Agency Impact N-rating within the timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
                   "primary_key_word": "SHOULD",
                   "pain_timeframes": {
                     "1": {},
@@ -5421,7 +5446,7 @@
                   }
                 },
                 "d": {
-                  "statement": "Providers of Class D offerings SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower Potential Adverse Impact N-rating within the maximum timeframes from evaluation shown below, factoring for the current Potential Adverse Impact N-rating, internet reachability, and likely exploitability:",
+                  "statement": "Providers of Class D offerings SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower Potential Agency Impact N-rating within the maximum timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
                   "primary_key_word": "SHOULD",
                   "pain_timeframes": {
                     "1": {},
@@ -5498,8 +5523,9 @@
               },
               "affects": ["Providers"],
               "terms": [
+                "Agency",
                 "Likely",
-                "Potential Adverse Impact",
+                "Potential Agency Impact",
                 "Provider",
                 "Vulnerability"
               ],
@@ -5527,28 +5553,30 @@
               "name": "Internet-Reachable Incidents",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers of Class A offerings MAY treat internet-reachable likely exploitable vulnerabilities where Potential Adverse Impact N-rating > 3 as a security incident until they are partially mitigated to N3 or below.",
+                  "statement": "Providers of Class A offerings MAY treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated to N3 or below.",
                   "primary_key_word": "MAY"
                 },
                 "b": {
-                  "statement": "Providers of Class B offerings MAY treat internet-reachable likely exploitable vulnerabilities where Potential Adverse Impact N-rating > 3 as a security incident until they are partially mitigated to N3 or below.",
+                  "statement": "Providers of Class B offerings MAY treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated to N3 or below.",
                   "primary_key_word": "MAY"
                 },
                 "c": {
-                  "statement": "Providers of Class C offerings SHOULD treat internet-reachable likely exploitable vulnerabilities where Potential Adverse Impact N-rating > 3 as a security incident until they are partially mitigated to N3 or below.",
+                  "statement": "Providers of Class C offerings SHOULD treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated to N3 or below.",
                   "primary_key_word": "SHOULD"
                 },
                 "d": {
-                  "statement": "Providers of Class D offerings SHOULD treat internet-reachable likely exploitable vulnerabilities where Potential Adverse Impact N-rating > 3 as a security incident until they are partially mitigated to N3 or below.",
+                  "statement": "Providers of Class D offerings SHOULD treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated to N3 or below.",
                   "primary_key_word": "SHOULD"
                 }
               },
               "affects": ["Providers"],
               "terms": [
+                "Agency",
+                "FedRAMP Reportable Incident",
                 "Incident",
                 "Likely",
                 "Likely Exploitable Vulnerability (LEV)",
-                "Potential Adverse Impact",
+                "Potential Agency Impact",
                 "Provider",
                 "Vulnerability"
               ],
@@ -5563,28 +5591,30 @@
               "name": "Non-Internet-Reachable Incidents",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers of Class A offerings MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Adverse Impact N-rating = 5 as a security incident until they are partially mitigated to N4 or below.",
+                  "statement": "Providers of Class A offerings MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated to N4 or below.",
                   "primary_key_word": "MAY"
                 },
                 "b": {
-                  "statement": "Providers of Class B offerings MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Adverse Impact N-rating = 5 as a security incident until they are partially mitigated to N4 or below.",
+                  "statement": "Providers of Class B offerings MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated to N4 or below.",
                   "primary_key_word": "MAY"
                 },
                 "c": {
-                  "statement": "Providers of Class C offerings MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Adverse Impact N-rating = 5 as a security incident until they are partially mitigated to N4 or below.",
+                  "statement": "Providers of Class C offerings MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated to N4 or below.",
                   "primary_key_word": "MAY"
                 },
                 "d": {
-                  "statement": "Providers of Class D offerings SHOULD treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Adverse Impact N-rating = 5 as a security incident until they are partially mitigated to N4 or below.",
+                  "statement": "Providers of Class D offerings SHOULD treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated to N4 or below.",
                   "primary_key_word": "SHOULD"
                 }
               },
               "affects": ["Providers"],
               "terms": [
+                "Agency",
+                "FedRAMP Reportable Incident",
                 "Incident",
                 "Likely",
                 "Likely Exploitable Vulnerability (LEV)",
-                "Potential Adverse Impact",
+                "Potential Agency Impact",
                 "Provider",
                 "Vulnerability"
               ],

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -2,8 +2,8 @@
   "info": {
     "title": "FedRAMP Consolidated Rules for 2026 Public Preview",
     "description": "This datafile contains the Consolidated Rules for FedRAMP in structured machine-readable text. It includes definitions, requirements, recommendations, and key security indicators.",
-    "version": "2026.05.17.01-preview",
-    "last_updated": "2026-05-17",
+    "version": "2026.05.22.01-preview",
+    "last_updated": "2026-05-22",
     "default_artifacts": {
       "FRR": [
         "Explanation of how the rule is followed, or an explanation of the reason and resulting risk to customers for not following the rule.",
@@ -47,7 +47,7 @@
           "alts": ["accepted vulnerability", "accepted vulnerabilities"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -60,7 +60,7 @@
           "alts": ["adaptive", "adaptive change", "adaptive changes"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -73,7 +73,7 @@
           "do_not_link": true,
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -88,7 +88,7 @@
           "reference_url": "https://www.govinfo.gov/app/details/USCODE-2023-title44/USCODE-2023-title44-chap35-subchapI-sec3502",
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -100,7 +100,7 @@
           "alts": ["all affected parties"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -112,7 +112,7 @@
           "alts": ["all necessary assessors"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -124,7 +124,7 @@
           "alts": ["all necessary parties"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -136,7 +136,7 @@
           "alts": ["artifact", "artifacts"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -150,7 +150,7 @@
           "do_not_link": true,
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -165,7 +165,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -177,7 +177,7 @@
           "alts": ["certification class change", "certification class changes"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -190,7 +190,7 @@
           "alts": ["certification data"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -205,7 +205,7 @@
           "reference_url": "https://fedramp.gov/docs/authority/law/#b-additional-definitions",
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -217,7 +217,7 @@
           "alts": ["cloud service offering", "cloud service offerings"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -229,7 +229,7 @@
           "alts": ["deterministic telemetry"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -240,7 +240,7 @@
           "alts": ["drift", "drifts", "drifting"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -259,7 +259,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -271,7 +271,7 @@
           "alts": ["federal customer data"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -286,7 +286,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -308,7 +308,7 @@
           "reference_url": "https://www.fedramp.gov/docs/authority/law/#sec-3608-federal-risk-and-authorization-management-program",
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -319,7 +319,7 @@
           "alts": ["FedRAMP Recognized", "FedRAMP Recognition"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -330,7 +330,7 @@
           "alts": ["security inbox", "security inboxes", "FSI"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -347,7 +347,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -362,7 +362,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -373,7 +373,7 @@
           "alts": ["handle", "handles", "handled", "handling"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -387,7 +387,7 @@
           "reference_url": "https://www.govinfo.gov/app/details/USCODE-2023-title44/USCODE-2023-title44-chap35-subchapII-sec3552",
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -402,7 +402,7 @@
           "reference_url": "https://www.govinfo.gov/app/details/USCODE-2023-title44/USCODE-2023-title44-chap35-subchapI-sec3502",
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -414,7 +414,7 @@
           "alts": ["initial certification", "initial certifications"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -426,7 +426,7 @@
           "alts": ["initial FedRAMP assessment", "IFRA"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -443,7 +443,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -467,7 +467,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -486,7 +486,7 @@
           "reference_url": "https://www.cisa.gov/news-events/directives/bod-22-01-reducing-significant-risk-known-exploited-vulnerabilities",
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -497,7 +497,7 @@
           "alts": ["likely", "likelihood"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -520,7 +520,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -532,7 +532,7 @@
           "alts": ["limited adverse effect", "limited adverse effects"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -545,7 +545,7 @@
           "alts": ["machine-based", "machine based"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -556,7 +556,7 @@
           "alts": ["machine-generated"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -569,7 +569,7 @@
           "reference_url": "https://www.govinfo.gov/app/details/USCODE-2023-title44/USCODE-2023-title44-chap35-subchapI-sec3502",
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -581,7 +581,7 @@
           "alts": ["negligible adverse effect", "negligible adverse effects"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -592,7 +592,7 @@
           "alts": ["ongoing certification", "ongoing certifications"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -603,7 +603,7 @@
           "alts": ["ongoing certification report", "OCR", "OCRs"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -620,7 +620,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -632,7 +632,7 @@
           "alts": ["overdue vulnerability", "overdue vulnerabilities"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -647,7 +647,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -659,7 +659,7 @@
           "alts": ["persistent FedRAMP assessment", "PFRA"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -671,7 +671,7 @@
           "alts": ["persistently", "persistent"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -687,7 +687,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -700,7 +700,7 @@
           "alts": ["privileged account", "privileged accounts"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -712,7 +712,7 @@
           "alts": ["promptly", "prompt"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -731,7 +731,7 @@
           "do_not_link": true,
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -743,7 +743,7 @@
           "alts": ["quarterly review", "quarterly reviews"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -754,7 +754,7 @@
           "alts": ["regularly", "regular"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -766,7 +766,7 @@
           "alts": ["remediated vulnerability", "remediated vulnerabilities"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -778,7 +778,7 @@
           "alts": ["responsibly"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -794,7 +794,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -812,7 +812,7 @@
           "reference_url": "https://csrc.nist.gov/pubs/fips/199/final",
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -824,7 +824,7 @@
           "alts": ["serious adverse effect", "serious adverse effects"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -838,7 +838,7 @@
           "reference_url": "https://csrc.nist.gov/pubs/sp/800/37/r2/final",
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -853,7 +853,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -869,7 +869,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -886,7 +886,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -898,7 +898,7 @@
           "alts": ["trust center", "trust centers"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -912,7 +912,7 @@
           "reference_url": "https://www.iso.org/standard/27001",
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -926,7 +926,7 @@
           "reference_url": "https://www.iso.org/standard/27001",
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -940,7 +940,7 @@
           "reference_url": "https://www.govinfo.gov/app/details/USCODE-2024-title6/USCODE-2024-title6-chap1-subchapXVIII-sec650",
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -959,7 +959,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -978,7 +978,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -7541,7 +7541,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -7561,7 +7561,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -7576,7 +7576,7 @@
           "controls": ["cm-3", "cm-3.2", "cm-3.4", "cm-5", "cm-7.1", "cm-9"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -7588,7 +7588,7 @@
           "controls": ["cm-3", "cm-3.2", "cm-4.2", "si-2"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -7609,7 +7609,7 @@
           "controls": ["cm-2", "si-3"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -7619,7 +7619,7 @@
           "controls": ["ca-2.1", "ca-7.1"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -7643,7 +7643,7 @@
           "controls": ["ac-17.3", "cm-2", "pl-10"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -7675,7 +7675,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -7691,7 +7691,7 @@
           "controls": [],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -7707,7 +7707,7 @@
           "controls": ["ac-17.3", "ca-9", "cm-7.1", "sc-7.5", "si-8"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -7723,7 +7723,7 @@
           "controls": ["sc-5", "si-8", "si-8.2"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -7748,7 +7748,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -7781,7 +7781,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -7812,7 +7812,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -7837,7 +7837,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -7883,7 +7883,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -7934,7 +7934,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -7954,7 +7954,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -7974,7 +7974,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -7995,7 +7995,7 @@
           "controls": ["ir-3", "ir-4", "ir-4.1", "ir-8"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8018,7 +8018,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8030,7 +8030,7 @@
           "controls": ["ir-3", "ir-4", "ir-4.1", "ir-5", "ir-8"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8050,7 +8050,7 @@
           "controls": ["si-11"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8070,7 +8070,7 @@
           "controls": ["ca-7", "cm-2", "cm-6", "si-7.7"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8097,7 +8097,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8128,7 +8128,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8148,7 +8148,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8177,7 +8177,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8189,7 +8189,7 @@
           "controls": [],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8211,7 +8211,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8236,7 +8236,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8248,7 +8248,7 @@
           "controls": ["ra-5.11"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8269,7 +8269,7 @@
           "controls": ["cm-2.3", "cp-6", "cp-9", "cp-10", "cp-10.2", "si-12"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8302,7 +8302,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8314,7 +8314,7 @@
           "controls": ["cp-2.3", "cp-10"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8337,7 +8337,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8370,7 +8370,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8387,7 +8387,7 @@
           "controls": ["ac-17.2", "ia-5.2", "ia-5.6", "sc-12", "sc-17"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8409,7 +8409,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8420,7 +8420,7 @@
           "controls": ["sc-4"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8444,7 +8444,7 @@
           "controls": ["si-12.3", "si-18.4"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8475,7 +8475,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ]
@@ -8485,7 +8485,7 @@
           "controls": ["sc-23", "si-7.1"],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8518,7 +8518,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8556,7 +8556,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],
@@ -8579,7 +8579,7 @@
           ],
           "updated": [
             {
-              "date": "2026-05-04",
+              "date": "2026-07-04",
               "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
             }
           ],

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -1112,6 +1112,45 @@
                 }
               ]
             },
+            "CDS-CSO-PAR": {
+              "name": "Public Availability Reporting",
+              "varies_by_class": {
+                "a": {
+                  "statement": "Providers of Class A offerings SHOULD maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service SHOULD be available even if the primary cloud service offering is unavailable.",
+                  "primary_key_word": "SHOULD",
+                  "note": "This service may be separate from the trust center."
+                },
+                "b": {
+                  "statement": "Providers of Class B offerings MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service MUST be available even if the primary cloud service offering is unavailable.",
+                  "primary_key_word": "MUST",
+                  "note": "This service may be separate from the trust center."
+                },
+                "c": {
+                  "statement": "Providers of Class C offerings MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service MUST be available even if the primary cloud service offering is unavailable.",
+                  "primary_key_word": "MUST",
+                  "note": "This service may be separate from the trust center."
+                },
+                "d": {
+                  "statement": "Providers of Class D offerings MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service MUST be available even if the primary cloud service offering is unavailable.",
+                  "primary_key_word": "MUST",
+                  "note": "This service may be separate from the trust center."
+                }
+              },
+              "affects": ["Providers"],
+              "terms": [
+                "All Necessary Parties",
+                "Cloud Service Offering",
+                "Incident",
+                "Machine-Readable",
+                "Provider"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
             "CDS-CSO-UTC": {
               "name": "Use Trust Centers",
               "statement": "Providers MUST use a FedRAMP-compatible trust center to store and share FedRAMP Certification Data with all necessary parties.",
@@ -2505,41 +2544,6 @@
             }
           },
           "CSO": {
-            "ICP-CSO-PAR": {
-              "name": "Public Availability Reporting",
-              "varies_by_class": {
-                "a": {
-                  "statement": "Providers of Class A offerings SHOULD maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats.",
-                  "primary_key_word": "SHOULD"
-                },
-                "b": {
-                  "statement": "Providers of Class B offerings SHOULD maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats.",
-                  "primary_key_word": "SHOULD"
-                },
-                "c": {
-                  "statement": "Providers of Class C offerings MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats.",
-                  "primary_key_word": "MUST"
-                },
-                "d": {
-                  "statement": "Providers of Class D offerings MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats.",
-                  "primary_key_word": "MUST"
-                }
-              },
-              "affects": ["Providers"],
-              "terms": [
-                "All Necessary Parties",
-                "Cloud Service Offering",
-                "Incident",
-                "Machine-Readable",
-                "Provider"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
             "ICP-CSO-EFR": {
               "name": "Evaluate Federal Reportability",
               "statement": "Providers MUST promptly evaluate incidents to determine if they affect confidentiality or integrity of federal customer data or are likely to affect confidentiality or integrity of federal customer data; such incidents are FedRAMP Reportable Incidents and must be reported following the FedRAMP Incident Communications Procedures.",
@@ -6398,7 +6402,6 @@
                 "FSI-CSO-INB",
                 "FSI-CSO-RCV",
                 "FSI-CSO-CRA",
-                "ICP-CSO-PAR",
                 "ICP-CSO-EFR",
                 "VDR-CSO-DET",
                 "CCM-OCR-AVL",

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -2548,55 +2548,6 @@
                 }
               ]
             },
-            "ICP-CSO-AAP": {
-              "name": "Notify All Affected Parties",
-              "statement": "Providers MUST responsibly notify all affected parties after identifying FedRAMP Reportable Incidents using email, push notification, form submission, secure portal upload, or another method specified by FedRAMP rules or written agency agreement.",
-              "following_information": [
-                "Notify FedRAMP via fedramp_security@gsa.gov or fedramp_security@fedramp.gov.",
-                "Follow contact arrangements provided by each agency customer's security contact.",
-                "Upload notification information to the cloud service offering's secure portal or FedRAMP-compatible trust center."
-              ],
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "Agency",
-                "All Affected Parties",
-                "Cloud Service Offering",
-                "FedRAMP Reportable Incident",
-                "Incident",
-                "Provider",
-                "Responsibly",
-                "Trust Center"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "ICP-CSO-CSA": {
-              "name": "Notify Cybersecurity and Infrastructure Security Agency",
-              "statement": "Providers MUST responsibly notify the Cybersecurity and Infrastructure Security Agency if an incident affects or is likely to affect the confidentiality or integrity of federal customer data, following the Cybersecurity and Infrastructure Security Agency Federal Incident Notification Guidelines.",
-              "reference": "Cybersecurity and Infrastructure Security Agency Federal Incident Notification Guidelines",
-              "reference_url": "https://www.cisa.gov/federal-incident-notification-guidelines",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "Agency",
-                "Federal Customer Data",
-                "Incident",
-                "Likely",
-                "Provider",
-                "Responsibly"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
             "ICP-CSO-IIR": {
               "name": "Initial Incident Report",
               "statement": "Providers MUST responsibly notify all affected parties after identifying FedRAMP Reportable Incidents by providing an Initial Incident Report with all available required information.",
@@ -2611,6 +2562,22 @@
               ],
               "primary_key_word": "MUST",
               "affects": ["Providers"],
+              "notification": [
+                {
+                  "party": "FedRAMP",
+                  "method": "email",
+                  "target": "fedramp_security@fedramp.gov"
+                },
+                {
+                  "party": "Agency Customers",
+                  "method": "following agreement"
+                },
+                {
+                  "party": "all necessary parties",
+                  "method": "whatever",
+                  "target": "trust center"
+                }
+              ],
               "terms": [
                 "Agency",
                 "All Affected Parties",
@@ -2643,6 +2610,22 @@
               ],
               "primary_key_word": "MUST",
               "affects": ["Providers"],
+              "notification": [
+                {
+                  "party": "FedRAMP",
+                  "method": "email",
+                  "target": "fedramp_security@fedramp.gov"
+                },
+                {
+                  "party": "Agency Customers",
+                  "method": "following agreement"
+                },
+                {
+                  "party": "all necessary parties",
+                  "method": "whatever",
+                  "target": "trust center"
+                }
+              ],
               "terms": [
                 "Agency",
                 "All Affected Parties",
@@ -2666,6 +2649,22 @@
               "statement": "Providers MUST responsibly notify all affected parties by providing a Final Incident Report once the incident has been resolved and recovery is complete, including final updates to all previously reported information.",
               "primary_key_word": "MUST",
               "affects": ["Providers"],
+              "notification": [
+                {
+                  "party": "FedRAMP",
+                  "method": "email",
+                  "target": "fedramp_security@fedramp.gov"
+                },
+                {
+                  "party": "Agency Customers",
+                  "method": "following agreement"
+                },
+                {
+                  "party": "all necessary parties",
+                  "method": "whatever",
+                  "target": "trust center"
+                }
+              ],
               "terms": [
                 "All Affected Parties",
                 "Final Incident Report (FIR)",

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -1116,22 +1116,22 @@
               "name": "Public Availability Reporting",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers of Class A offerings SHOULD maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service SHOULD be available even if the primary cloud service offering is unavailable.",
+                  "statement": "Providers with Class A Certifications SHOULD maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service SHOULD be available even if the primary cloud service offering is unavailable.",
                   "primary_key_word": "SHOULD",
                   "note": "This service may be separate from the trust center."
                 },
                 "b": {
-                  "statement": "Providers of Class B offerings MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service MUST be available even if the primary cloud service offering is unavailable.",
+                  "statement": "Providers with Class B Certifications MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service MUST be available even if the primary cloud service offering is unavailable.",
                   "primary_key_word": "MUST",
                   "note": "This service may be separate from the trust center."
                 },
                 "c": {
-                  "statement": "Providers of Class C offerings MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service MUST be available even if the primary cloud service offering is unavailable.",
+                  "statement": "Providers with Class C Certifications MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service MUST be available even if the primary cloud service offering is unavailable.",
                   "primary_key_word": "MUST",
                   "note": "This service may be separate from the trust center."
                 },
                 "d": {
-                  "statement": "Providers of Class D offerings MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service MUST be available even if the primary cloud service offering is unavailable.",
+                  "statement": "Providers with Class D Certifications MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service MUST be available even if the primary cloud service offering is unavailable.",
                   "primary_key_word": "MUST",
                   "note": "This service may be separate from the trust center."
                 }
@@ -1252,7 +1252,7 @@
               "name": "Per-Service Certification Materials",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers of Class A offerings MAY supply per-service FedRAMP Certification materials.",
+                  "statement": "Providers with Class A Certifications MAY supply per-service FedRAMP Certification materials.",
                   "primary_key_word": "MAY",
                   "artifacts": {
                     "all": [
@@ -1261,7 +1261,7 @@
                   }
                 },
                 "b": {
-                  "statement": "Providers of Class B offerings MAY supply per-service FedRAMP Certification materials.",
+                  "statement": "Providers with Class B Certifications MAY supply per-service FedRAMP Certification materials.",
                   "primary_key_word": "MAY",
                   "artifacts": {
                     "all": [
@@ -1270,7 +1270,7 @@
                   }
                 },
                 "c": {
-                  "statement": "Providers of Class C offerings MAY supply per-service FedRAMP Certification materials.",
+                  "statement": "Providers with Class C Certifications MAY supply per-service FedRAMP Certification materials.",
                   "primary_key_word": "MAY",
                   "artifacts": {
                     "all": [
@@ -1279,7 +1279,7 @@
                   }
                 },
                 "d": {
-                  "statement": "Providers of Class D offerings MUST supply per-service FedRAMP Certification materials.",
+                  "statement": "Providers with Class D Certifications MUST supply per-service FedRAMP Certification materials.",
                   "primary_key_word": "MUST",
                   "effective_date": {
                     "obtain": "2027-05-04",
@@ -1543,7 +1543,7 @@
               "name": "Structured Certification Data",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers of Class A offerings MUST supply semi-structured text-based FedRAMP Certification Data.",
+                  "statement": "Providers with Class A Certifications MUST supply semi-structured text-based FedRAMP Certification Data.",
                   "primary_key_word": "MUST",
                   "effective_date": {
                     "obtain": "2027-01-01",
@@ -1552,7 +1552,7 @@
                   }
                 },
                 "b": {
-                  "statement": "Providers of Class B offerings MUST supply semi-structured text-based FedRAMP Certification Data.",
+                  "statement": "Providers with Class B Certifications MUST supply semi-structured text-based FedRAMP Certification Data.",
                   "primary_key_word": "MUST",
                   "effective_date": {
                     "obtain": "2027-01-01",
@@ -1561,7 +1561,7 @@
                   }
                 },
                 "c": {
-                  "statement": "Providers of Class C offerings MUST supply semi-structured text-based FedRAMP Certification Data.",
+                  "statement": "Providers with Class C Certifications MUST supply semi-structured text-based FedRAMP Certification Data.",
                   "primary_key_word": "MUST",
                   "effective_date": {
                     "obtain": "2027-01-01",
@@ -1570,7 +1570,7 @@
                   }
                 },
                 "d": {
-                  "statement": "Providers of Class D offerings MUST supply comprehensive machine-readable FedRAMP Certification Data.",
+                  "statement": "Providers with Class D Certifications MUST supply comprehensive machine-readable FedRAMP Certification Data.",
                   "primary_key_word": "MUST",
                   "effective_date": {
                     "obtain": "2027-05-04",
@@ -1933,25 +1933,25 @@
               "name": "Quarterly Review Meeting",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers of Class A offerings MAY host a synchronous Quarterly Review every 3 months, open to all necessary parties, to review aspects of the most recent Ongoing Certification Reports that the provider determines are of the most relevance to agencies.",
+                  "statement": "Providers with Class A Certifications MAY host a synchronous Quarterly Review every 3 months, open to all necessary parties, to review aspects of the most recent Ongoing Certification Reports that the provider determines are of the most relevance to agencies.",
                   "primary_key_word": "MAY",
                   "timeframe_type": "months",
                   "timeframe_num": 3
                 },
                 "b": {
-                  "statement": "Providers of Class B offerings SHOULD host a synchronous Quarterly Review every 3 months, open to all necessary parties, to review aspects of the most recent Ongoing Certification Reports that the provider determines are of the most relevance to agencies.",
+                  "statement": "Providers with Class B Certifications SHOULD host a synchronous Quarterly Review every 3 months, open to all necessary parties, to review aspects of the most recent Ongoing Certification Reports that the provider determines are of the most relevance to agencies.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "months",
                   "timeframe_num": 3
                 },
                 "c": {
-                  "statement": "Providers of Class C offerings MUST host a synchronous Quarterly Review every 3 months, open to all necessary parties, to review aspects of the most recent Ongoing Certification Reports that the provider determines are of the most relevance to agencies.",
+                  "statement": "Providers with Class C Certifications MUST host a synchronous Quarterly Review every 3 months, open to all necessary parties, to review aspects of the most recent Ongoing Certification Reports that the provider determines are of the most relevance to agencies.",
                   "primary_key_word": "MUST",
                   "timeframe_type": "months",
                   "timeframe_num": 3
                 },
                 "d": {
-                  "statement": "Providers of Class D offerings MUST host a synchronous Quarterly Review every 3 months, open to all necessary parties, to review aspects of the most recent Ongoing Certification Reports that the provider determines are of the most relevance to agencies.",
+                  "statement": "Providers with Class D Certifications MUST host a synchronous Quarterly Review every 3 months, open to all necessary parties, to review aspects of the most recent Ongoing Certification Reports that the provider determines are of the most relevance to agencies.",
                   "primary_key_word": "MUST",
                   "timeframe_type": "months",
                   "timeframe_num": 3
@@ -2586,18 +2586,212 @@
             },
             "ICP-CSO-IIR": {
               "name": "Initial Incident Report",
-              "statement": "Providers MUST responsibly notify all affected parties after identifying FedRAMP Reportable Incidents by providing an Initial Incident Report with as much of the following information that is available at the time of reporting:",
-              "following_information": [
-                "Contact information for the federal incident response coordinator.",
-                "Provider's internally assigned tracking identifier",
-                "Description of the incident",
-                "Timeline of the incident, including start time, time and source of detection, time of completed FedRAMP Reportable Incident evaluation, and other major incident milestones determined by the provider",
-                "Historically and currently estimated Potential Adverse Impact N-rating (PAIN) of the incident, including an explanation of the evaluation following the requirements in ICP-CSO-EFI Estimate Federal Impact (if applicable)",
-                "Functional impact to federal agency customers (include impact to confidentiality and/or integrity and the impacted federal customer data types)",
-                "Estimated recovery plan, milestones, and timelines",
-                "List of likely affected customer agencies"
-              ],
-              "primary_key_word": "MUST",
+              "varies_by_class": {
+                "a": {
+                  "statement": "Providers with Class A Certifications SHOULD responsibly notify all affected parties after identifying FedRAMP Reportable Incidents by providing an Initial Incident Report with as much of the following information that is available at the time of reporting:",
+                  "following_information": [
+                    "Contact information for the federal incident response coordinator.",
+                    "Provider's internally assigned tracking identifier",
+                    "Description of the incident",
+                    "Timeline of the incident, including start time, time and source of detection, time of completed FedRAMP Reportable Incident evaluation, and other major incident milestones determined by the provider",
+                    "Historically and currently estimated Potential Adverse Impact N-rating (PAIN) of the incident, including an explanation of the evaluation following the requirements in ICP-CSO-EFI Estimate Federal Impact (if applicable)",
+                    "Functional impact to federal agency customers (include impact to confidentiality and/or integrity and the impacted federal customer data types)",
+                    "Estimated recovery plan, milestones, and timelines",
+                    "List of likely affected customer agencies"
+                  ],
+                  "primary_key_word": "SHOULD",
+                  "pain_timeframes": {
+                    "1": {
+                      "iir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 1,
+                        "description": "Initial Incident Report"
+                      }
+                    },
+                    "2": {
+                      "iir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 1,
+                        "description": "Initial Incident Report"
+                      }
+                    },
+                    "3": {
+                      "iir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 6,
+                        "description": "Initial Incident Report"
+                      }
+                    },
+                    "4": {
+                      "iir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 6,
+                        "description": "Initial Incident Report"
+                      }
+                    },
+                    "5": {
+                      "iir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 6,
+                        "description": "Initial Incident Report"
+                      }
+                    }
+                  }
+                },
+                "b": {
+                  "statement": "Providers with Class B Certifications MUST responsibly notify all affected parties after identifying FedRAMP Reportable Incidents by providing an Initial Incident Report with as much of the following information that is available at the time of reporting:",
+                  "following_information": [
+                    "Contact information for the federal incident response coordinator.",
+                    "Provider's internally assigned tracking identifier",
+                    "Description of the incident",
+                    "Timeline of the incident, including start time, time and source of detection, time of completed FedRAMP Reportable Incident evaluation, and other major incident milestones determined by the provider",
+                    "Historically and currently estimated Potential Adverse Impact N-rating (PAIN) of the incident, including an explanation of the evaluation following the requirements in ICP-CSO-EFI Estimate Federal Impact (if applicable)",
+                    "Functional impact to federal agency customers (include impact to confidentiality and/or integrity and the impacted federal customer data types)",
+                    "Estimated recovery plan, milestones, and timelines",
+                    "List of likely affected customer agencies"
+                  ],
+                  "primary_key_word": "MUST",
+                  "pain_timeframes": {
+                    "1": {
+                      "iir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 1,
+                        "description": "Initial Incident Report"
+                      }
+                    },
+                    "2": {
+                      "iir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 1,
+                        "description": "Initial Incident Report"
+                      }
+                    },
+                    "3": {
+                      "iir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 6,
+                        "description": "Initial Incident Report"
+                      }
+                    },
+                    "4": {
+                      "iir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 6,
+                        "description": "Initial Incident Report"
+                      }
+                    },
+                    "5": {
+                      "iir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 6,
+                        "description": "Initial Incident Report"
+                      }
+                    }
+                  }
+                },
+                "c": {
+                  "statement": "Providers with Class C Certifications MUST responsibly notify all affected parties after identifying FedRAMP Reportable Incidents by providing an Initial Incident Report with as much of the following information that is available at the time of reporting:",
+                  "following_information": [
+                    "Contact information for the federal incident response coordinator.",
+                    "Provider's internally assigned tracking identifier",
+                    "Description of the incident",
+                    "Timeline of the incident, including start time, time and source of detection, time of completed FedRAMP Reportable Incident evaluation, and other major incident milestones determined by the provider",
+                    "Historically and currently estimated Potential Adverse Impact N-rating (PAIN) of the incident, including an explanation of the evaluation following the requirements in ICP-CSO-EFI Estimate Federal Impact (if applicable)",
+                    "Functional impact to federal agency customers (include impact to confidentiality and/or integrity and the impacted federal customer data types)",
+                    "Estimated recovery plan, milestones, and timelines",
+                    "List of likely affected customer agencies"
+                  ],
+                  "primary_key_word": "MUST",
+                  "pain_timeframes": {
+                    "1": {
+                      "iir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 1,
+                        "description": "Initial Incident Report"
+                      }
+                    },
+                    "2": {
+                      "iir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 24,
+                        "description": "Initial Incident Report"
+                      }
+                    },
+                    "3": {
+                      "iir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 1,
+                        "description": "Initial Incident Report"
+                      }
+                    },
+                    "4": {
+                      "iir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 1,
+                        "description": "Initial Incident Report"
+                      }
+                    },
+                    "5": {
+                      "iir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 1,
+                        "description": "Initial Incident Report"
+                      }
+                    }
+                  }
+                },
+                "d": {
+                  "statement": "Providers with Class D Certifications MUST responsibly notify all affected parties after identifying FedRAMP Reportable Incidents by providing an Initial Incident Report with as much of the following information that is available at the time of reporting:",
+                  "following_information": [
+                    "Contact information for the federal incident response coordinator.",
+                    "Provider's internally assigned tracking identifier",
+                    "Description of the incident",
+                    "Timeline of the incident, including start time, time and source of detection, time of completed FedRAMP Reportable Incident evaluation, and other major incident milestones determined by the provider",
+                    "Historically and currently estimated Potential Adverse Impact N-rating (PAIN) of the incident, including an explanation of the evaluation following the requirements in ICP-CSO-EFI Estimate Federal Impact (if applicable)",
+                    "Functional impact to federal agency customers (include impact to confidentiality and/or integrity and the impacted federal customer data types)",
+                    "Estimated recovery plan, milestones, and timelines",
+                    "List of likely affected customer agencies"
+                  ],
+                  "primary_key_word": "MUST",
+                  "pain_timeframes": {
+                    "1": {
+                      "iir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 1,
+                        "description": "Initial Incident Report"
+                      }
+                    },
+                    "2": {
+                      "iir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 1,
+                        "description": "Initial Incident Report"
+                      }
+                    },
+                    "3": {
+                      "iir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 0.25,
+                        "description": "Initial Incident Report"
+                      }
+                    },
+                    "4": {
+                      "iir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 0.25,
+                        "description": "Initial Incident Report"
+                      }
+                    },
+                    "5": {
+                      "iir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 0.25,
+                        "description": "Initial Incident Report"
+                      }
+                    }
+                  }
+                }
+              },
               "affects": ["Providers"],
               "notification": [
                 {
@@ -2617,14 +2811,12 @@
                 }
               ],
               "terms": [
-                "Agency",
                 "All Affected Parties",
                 "FedRAMP Reportable Incident",
                 "Incident",
                 "Initial Incident Report (IIR)",
                 "Provider",
-                "Responsibly",
-                "Vulnerability Response"
+                "Responsibly"
               ],
               "updated": [
                 {
@@ -2635,15 +2827,200 @@
             },
             "ICP-CSO-OIR": {
               "name": "Ongoing Incident Reports",
-              "statement": "Providers MUST responsibly notify all affected parties of ongoing activity as new information becomes available during incident response for FedRAMP Reportable Incidents, including updates (or lack of updates) to all previously reported information and as much of the the following additional information that is available:",
-              "following_information": [
-                "Observed incident activity",
-                "Indicators of compromise",
-                "Related Common Vulnerabilities and Exposures (CVE) identifier, if applicable",
-                "Root cause",
-                "Response and recovery activities"
-              ],
-              "primary_key_word": "MUST",
+              "varies_by_class": {
+                "a": {
+                  "statement": "Providers with Class A Certifications SHOULD responsibly notify all affected parties of ongoing activity as new information becomes available during incident response for FedRAMP Reportable Incidents, including updates (or lack of updates) to all previously reported information and as much of the the following additional information that is available:",
+                  "following_information": [
+                    "Observed incident activity",
+                    "Indicators of compromise",
+                    "Related Common Vulnerabilities and Exposures (CVE) identifier (if applicable)",
+                    "Root cause",
+                    "Response and recovery activities"
+                  ],
+                  "primary_key_word": "SHOULD",
+                  "pain_timeframes": {
+                    "1": {
+                      "oir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 1,
+                        "description": "Ongoing Incident Report"
+                      }
+                    },
+                    "2": {
+                      "oir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 1,
+                        "description": "Ongoing Incident Report"
+                      }
+                    },
+                    "3": {
+                      "oir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 1,
+                        "description": "Ongoing Incident Report"
+                      }
+                    },
+                    "4": {
+                      "oir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 1,
+                        "description": "Ongoing Incident Report"
+                      }
+                    },
+                    "5": {
+                      "oir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 1,
+                        "description": "Ongoing Incident Report"
+                      }
+                    }
+                  }
+                },
+                "b": {
+                  "statement": "Providers with Class B Certifications MUST responsibly notify all affected parties of ongoing activity as new information becomes available during incident response for FedRAMP Reportable Incidents, including updates (or lack of updates) to all previously reported information and as much of the the following additional information that is available:",
+                  "following_information": [
+                    "Observed incident activity",
+                    "Indicators of compromise",
+                    "Related Common Vulnerabilities and Exposures (CVE) identifier, if applicable",
+                    "Root cause",
+                    "Response and recovery activities"
+                  ],
+                  "primary_key_word": "MUST",
+                  "pain_timeframes": {
+                    "1": {
+                      "oir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 1,
+                        "description": "Ongoing Incident Report"
+                      }
+                    },
+                    "2": {
+                      "oir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 1,
+                        "description": "Ongoing Incident Report"
+                      }
+                    },
+                    "3": {
+                      "oir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 1,
+                        "description": "Ongoing Incident Report"
+                      }
+                    },
+                    "4": {
+                      "oir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 1,
+                        "description": "Ongoing Incident Report"
+                      }
+                    },
+                    "5": {
+                      "oir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 1,
+                        "description": "Ongoing Incident Report"
+                      }
+                    }
+                  }
+                },
+                "c": {
+                  "statement": "Providers with Class C Certifications MUST responsibly notify all affected parties of ongoing activity as new information becomes available during incident response for FedRAMP Reportable Incidents, including updates (or lack of updates) to all previously reported information and as much of the the following additional information that is available:",
+                  "following_information": [
+                    "Observed incident activity",
+                    "Indicators of compromise",
+                    "Related Common Vulnerabilities and Exposures (CVE) identifier, if applicable",
+                    "Root cause",
+                    "Response and recovery activities"
+                  ],
+                  "primary_key_word": "MUST",
+                  "pain_timeframes": {
+                    "1": {
+                      "oir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 1,
+                        "description": "Ongoing Incident Report"
+                      }
+                    },
+                    "2": {
+                      "oir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 24,
+                        "description": "Ongoing Incident Report"
+                      }
+                    },
+                    "3": {
+                      "oir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 6,
+                        "description": "Ongoing Incident Report"
+                      }
+                    },
+                    "4": {
+                      "oir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 6,
+                        "description": "Ongoing Incident Report"
+                      }
+                    },
+                    "5": {
+                      "oir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 6,
+                        "description": "Ongoing Incident Report"
+                      }
+                    }
+                  }
+                },
+                "d": {
+                  "statement": "Providers with Class D Certifications MUST responsibly notify all affected parties of ongoing activity as new information becomes available during incident response for FedRAMP Reportable Incidents, including updates (or lack of updates) to all previously reported information and as much of the the following additional information that is available:",
+                  "following_information": [
+                    "Observed incident activity",
+                    "Indicators of compromise",
+                    "Related Common Vulnerabilities and Exposures (CVE) identifier, if applicable",
+                    "Root cause",
+                    "Response and recovery activities"
+                  ],
+                  "primary_key_word": "MUST",
+                  "pain_timeframes": {
+                    "1": {
+                      "oir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 24,
+                        "description": "Ongoing Incident Report"
+                      }
+                    },
+                    "2": {
+                      "oir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 6,
+                        "description": "Ongoing Incident Report"
+                      }
+                    },
+                    "3": {
+                      "oir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 3,
+                        "description": "Ongoing Incident Report"
+                      }
+                    },
+                    "4": {
+                      "oir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 3,
+                        "description": "Ongoing Incident Report"
+                      }
+                    },
+                    "5": {
+                      "oir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 3,
+                        "description": "Ongoing Incident Report"
+                      }
+                    }
+                  }
+                }
+              },
               "affects": ["Providers"],
               "notification": [
                 {
@@ -2663,14 +3040,11 @@
                 }
               ],
               "terms": [
-                "Agency",
                 "All Affected Parties",
                 "FedRAMP Reportable Incident",
                 "Incident",
-                "Ongoing Incident Report (OIR)",
                 "Provider",
                 "Responsibly",
-                "Vulnerability",
                 "Vulnerability Response"
               ],
               "updated": [
@@ -2682,8 +3056,172 @@
             },
             "ICP-CSO-FIR": {
               "name": "Final Incident Report",
-              "statement": "Providers MUST responsibly notify all affected parties by providing a Final Incident Report once the incident has been resolved and recovery is complete, including final updates to all previously reported information.",
-              "primary_key_word": "MUST",
+              "varies_by_class": {
+                "a": {
+                  "statement": "Providers with Class A Certifications MUST responsibly notify all affected parties by providing a Final Incident Report once the incident has been resolved and recovery is complete, including final updates to all previously reported information.",
+                  "primary_key_word": "MUST",
+                  "pain_timeframes": {
+                    "1": {
+                      "fir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 3,
+                        "description": "Final Incident Report"
+                      }
+                    },
+                    "2": {
+                      "fir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 3,
+                        "description": "Final Incident Report"
+                      }
+                    },
+                    "3": {
+                      "fir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 3,
+                        "description": "Final Incident Report"
+                      }
+                    },
+                    "4": {
+                      "fir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 3,
+                        "description": "Final Incident Report"
+                      }
+                    },
+                    "5": {
+                      "fir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 3,
+                        "description": "Final Incident Report"
+                      }
+                    }
+                  }
+                },
+                "b": {
+                  "statement": "Providers with Class B Certifications MUST responsibly notify all affected parties by providing a Final Incident Report once the incident has been resolved and recovery is complete, including final updates to all previously reported information.",
+                  "primary_key_word": "MUST",
+                  "pain_timeframes": {
+                    "1": {
+                      "fir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 3,
+                        "description": "Final Incident Report"
+                      }
+                    },
+                    "2": {
+                      "fir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 3,
+                        "description": "Final Incident Report"
+                      }
+                    },
+                    "3": {
+                      "fir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 3,
+                        "description": "Final Incident Report"
+                      }
+                    },
+                    "4": {
+                      "fir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 3,
+                        "description": "Final Incident Report"
+                      }
+                    },
+                    "5": {
+                      "fir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 3,
+                        "description": "Final Incident Report"
+                      }
+                    }
+                  }
+                },
+                "c": {
+                  "statement": "Providers with Class C Certifications MUST responsibly notify all affected parties by providing a Final Incident Report once the incident has been resolved and recovery is complete, including final updates to all previously reported information.",
+                  "primary_key_word": "MUST",
+                  "pain_timeframes": {
+                    "1": {
+                      "fir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 1,
+                        "description": "Final Incident Report"
+                      }
+                    },
+                    "2": {
+                      "fir": {
+                        "timeframe_type": "bizdays",
+                        "timeframe_num": 1,
+                        "description": "Final Incident Report"
+                      }
+                    },
+                    "3": {
+                      "fir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 6,
+                        "description": "Final Incident Report"
+                      }
+                    },
+                    "4": {
+                      "fir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 6,
+                        "description": "Final Incident Report"
+                      }
+                    },
+                    "5": {
+                      "fir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 6,
+                        "description": "Final Incident Report"
+                      }
+                    }
+                  }
+                },
+                "d": {
+                  "statement": "Providers with Class D Certifications MUST responsibly notify all affected parties by providing a Final Incident Report once the incident has been resolved and recovery is complete, including final updates to all previously reported information.",
+                  "primary_key_word": "MUST",
+                  "pain_timeframes": {
+                    "1": {
+                      "fir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 24,
+                        "description": "Final Incident Report"
+                      }
+                    },
+                    "2": {
+                      "fir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 6,
+                        "description": "Final Incident Report"
+                      }
+                    },
+                    "3": {
+                      "fir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 3,
+                        "description": "Final Incident Report"
+                      }
+                    },
+                    "4": {
+                      "fir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 3,
+                        "description": "Final Incident Report"
+                      }
+                    },
+                    "5": {
+                      "fir": {
+                        "timeframe_type": "hours",
+                        "timeframe_num": 3,
+                        "description": "Final Incident Report"
+                      }
+                    }
+                  }
+                }
+              },
               "affects": ["Providers"],
               "notification": [
                 {
@@ -2713,390 +3251,6 @@
                 {
                   "date": "2026-05-04",
                   "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "ICP-CSO-IRT": {
-              "name": "Incident Report Timeframes",
-              "varies_by_class": {
-                "a": {
-                  "statement": "Providers of Class A offerings MUST notify all affected parties of FedRAMP Reportable Incidents within the maximum timeframes from evaluation or recovery shown below, based on the Potential Agency Impact N-rating.",
-                  "primary_key_word": "MUST",
-                  "pain_timeframes": {
-                    "1": {
-                      "iir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 1,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 1,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 3,
-                        "description": "Final Incident Report"
-                      }
-                    },
-                    "2": {
-                      "iir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 1,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 1,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 3,
-                        "description": "Final Incident Report"
-                      }
-                    },
-                    "3": {
-                      "iir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 12,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 1,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 3,
-                        "description": "Final Incident Report"
-                      }
-                    },
-                    "4": {
-                      "iir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 6,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 1,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 3,
-                        "description": "Final Incident Report"
-                      }
-                    },
-                    "5": {
-                      "iir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 6,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 1,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 3,
-                        "description": "Final Incident Report"
-                      }
-                    }
-                  }
-                },
-                "b": {
-                  "statement": "Providers of Class B offerings MUST notify all affected parties of FedRAMP Reportable Incidents within the maximum timeframes from evaluation or recovery shown below, based on the Potential Agency Impact N-rating.",
-                  "primary_key_word": "MUST",
-                  "pain_timeframes": {
-                    "1": {
-                      "iir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 1,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 1,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 3,
-                        "description": "Final Incident Report"
-                      }
-                    },
-                    "2": {
-                      "iir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 1,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 1,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 3,
-                        "description": "Final Incident Report"
-                      }
-                    },
-                    "3": {
-                      "iir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 12,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 1,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 3,
-                        "description": "Final Incident Report"
-                      }
-                    },
-                    "4": {
-                      "iir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 6,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 1,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 3,
-                        "description": "Final Incident Report"
-                      }
-                    },
-                    "5": {
-                      "iir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 6,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 1,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 3,
-                        "description": "Final Incident Report"
-                      }
-                    }
-                  }
-                },
-                "c": {
-                  "statement": "Providers of Class C offerings MUST notify all affected parties of FedRAMP Reportable Incidents within the maximum timeframes from evaluation or recovery shown below, based on the Potential Agency Impact N-rating.",
-                  "primary_key_word": "MUST",
-                  "pain_timeframes": {
-                    "1": {
-                      "iir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 1,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 1,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 1,
-                        "description": "Final Incident Report"
-                      }
-                    },
-                    "2": {
-                      "iir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 24,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 24,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 1,
-                        "description": "Final Incident Report"
-                      }
-                    },
-                    "3": {
-                      "iir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 6,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 24,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "bizdays",
-                        "timeframe_num": 1,
-                        "description": "Final Incident Report"
-                      }
-                    },
-                    "4": {
-                      "iir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 1,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 6,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 6,
-                        "description": "Final Incident Report"
-                      }
-                    },
-                    "5": {
-                      "iir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 1,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 6,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 6,
-                        "description": "Final Incident Report"
-                      }
-                    }
-                  }
-                },
-                "d": {
-                  "statement": "Providers of Class D offerings MUST notify all affected parties of FedRAMP Reportable Incidents within the maximum timeframes from evaluation or recovery shown below, based on the Potential Agency Impact N-rating.",
-                  "primary_key_word": "MUST",
-                  "pain_timeframes": {
-                    "1": {
-                      "iir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 1,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 24,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 24,
-                        "description": "Final Incident Report"
-                      }
-                    },
-                    "2": {
-                      "iir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 1,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 6,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 6,
-                        "description": "Final Incident Report"
-                      }
-                    },
-                    "3": {
-                      "iir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 1,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 6,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 6,
-                        "description": "Final Incident Report"
-                      }
-                    },
-                    "4": {
-                      "iir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 0.5,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 6,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 6,
-                        "description": "Final Incident Report"
-                      }
-                    },
-                    "5": {
-                      "iir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 0.25,
-                        "description": "Initial Incident Report"
-                      },
-                      "oir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 3,
-                        "description": "Ongoing Incident Report"
-                      },
-                      "fir": {
-                        "timeframe_type": "hours",
-                        "timeframe_num": 3,
-                        "description": "Final Incident Report"
-                      }
-                    }
-                  }
-                }
-              },
-              "affects": ["Providers"],
-              "terms": [
-                "Agency",
-                "All Affected Parties",
-                "FedRAMP Reportable Incident",
-                "Incident",
-                "Potential Agency Impact",
-                "Provider"
-              ],
-              "updated": [
-                {
-                  "date": "2026-04-25",
-                  "comment": "Drafted for human review from PROPOSED-RULES.md."
                 }
               ]
             },
@@ -4354,19 +4508,19 @@
               "name": "Using Validated Cryptographic Modules",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers of Class A offerings MAY use cryptographic modules or update streams of cryptographic modules with active validations under the NIST Cryptographic Module Validation Program when using cryptographic services to protect federal customer data.",
+                  "statement": "Providers with Class A Certifications MAY use cryptographic modules or update streams of cryptographic modules with active validations under the NIST Cryptographic Module Validation Program when using cryptographic services to protect federal customer data.",
                   "primary_key_word": "MAY"
                 },
                 "b": {
-                  "statement": "Providers of Class B offerings MAY use cryptographic modules or update streams of cryptographic modules with active validations under the NIST Cryptographic Module Validation Program when using cryptographic services to protect federal customer data.",
+                  "statement": "Providers with Class B Certifications MAY use cryptographic modules or update streams of cryptographic modules with active validations under the NIST Cryptographic Module Validation Program when using cryptographic services to protect federal customer data.",
                   "primary_key_word": "MAY"
                 },
                 "c": {
-                  "statement": "Providers of Class C offerings SHOULD use cryptographic modules or update streams of cryptographic modules with active validations under the NIST Cryptographic Module Validation Program when using cryptographic services to protect federal customer data.",
+                  "statement": "Providers with Class C Certifications SHOULD use cryptographic modules or update streams of cryptographic modules with active validations under the NIST Cryptographic Module Validation Program when using cryptographic services to protect federal customer data.",
                   "primary_key_word": "SHOULD"
                 },
                 "d": {
-                  "statement": "Providers of Class D offerings MUST use cryptographic modules or update streams of cryptographic modules with active validations under the NIST Cryptographic Module Validation Program when using cryptographic services to protect federal customer data.",
+                  "statement": "Providers with Class D Certifications MUST use cryptographic modules or update streams of cryptographic modules with active validations under the NIST Cryptographic Module Validation Program when using cryptographic services to protect federal customer data.",
                   "primary_key_word": "MUST"
                 }
               },
@@ -5099,25 +5253,25 @@
               "name": "Historical Activity",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers of Class A offerings MAY make all recent historical vulnerability detection and response activity available in a machine-readable format for automated retrieval by all necessary parties (e.g. using an API service or similar); this information MAY be updated persistently, at least once every month.",
+                  "statement": "Providers with Class A Certifications MAY make all recent historical vulnerability detection and response activity available in a machine-readable format for automated retrieval by all necessary parties (e.g. using an API service or similar); this information MAY be updated persistently, at least once every month.",
                   "primary_key_word": "MAY",
                   "timeframe_type": "month",
                   "timeframe_num": 1
                 },
                 "b": {
-                  "statement": "Providers of Class B offerings SHOULD make all recent historical vulnerability detection and response activity available in a machine-readable format for automated retrieval by all necessary parties (e.g. using an API service or similar); this information SHOULD be updated persistently, at least once every month.",
+                  "statement": "Providers with Class B Certifications SHOULD make all recent historical vulnerability detection and response activity available in a machine-readable format for automated retrieval by all necessary parties (e.g. using an API service or similar); this information SHOULD be updated persistently, at least once every month.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "month",
                   "timeframe_num": 1
                 },
                 "c": {
-                  "statement": "Providers of Class C offerings SHOULD make all recent historical vulnerability detection and response activity available in a machine-readable format for automated retrieval by all necessary parties (e.g. using an API service or similar); this information SHOULD be updated persistently, at least once every 14 days.",
+                  "statement": "Providers with Class C Certifications SHOULD make all recent historical vulnerability detection and response activity available in a machine-readable format for automated retrieval by all necessary parties (e.g. using an API service or similar); this information SHOULD be updated persistently, at least once every 14 days.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 14
                 },
                 "d": {
-                  "statement": "Providers of Class D offerings SHOULD make all recent historical vulnerability detection and response activity available in a machine-readable format for automated retrieval by all necessary parties (e.g. using an API service or similar); this information SHOULD be updated persistently, at least once every 7 days.",
+                  "statement": "Providers with Class D Certifications SHOULD make all recent historical vulnerability detection and response activity available in a machine-readable format for automated retrieval by all necessary parties (e.g. using an API service or similar); this information SHOULD be updated persistently, at least once every 7 days.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 7
@@ -5144,25 +5298,25 @@
               "name": "Persistent Sample Detection",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers of Class A offerings SHOULD persistently perform vulnerability detection on representative samples of similar machine-based information resources, at least once every 14 days.",
+                  "statement": "Providers with Class A Certifications SHOULD persistently perform vulnerability detection on representative samples of similar machine-based information resources, at least once every 14 days.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 14
                 },
                 "b": {
-                  "statement": "Providers of Class B offerings SHOULD persistently perform vulnerability detection on representative samples of similar machine-based information resources, at least once every 7 days.",
+                  "statement": "Providers with Class B Certifications SHOULD persistently perform vulnerability detection on representative samples of similar machine-based information resources, at least once every 7 days.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 7
                 },
                 "c": {
-                  "statement": "Providers of Class C offerings SHOULD persistently perform vulnerability detection on representative samples of similar machine-based information resources, at least once every 3 days.",
+                  "statement": "Providers with Class C Certifications SHOULD persistently perform vulnerability detection on representative samples of similar machine-based information resources, at least once every 3 days.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 3
                 },
                 "d": {
-                  "statement": "Providers of Class D offerings SHOULD persistently perform vulnerability detection on representative samples of similar machine-based information resources, at least once per day.",
+                  "statement": "Providers with Class D Certifications SHOULD persistently perform vulnerability detection on representative samples of similar machine-based information resources, at least once per day.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 1
@@ -5188,25 +5342,25 @@
               "name": "Persistent Drift Detection",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers of Class A offerings SHOULD persistently perform vulnerability detection on all information resources that are likely to drift, at least once every 3 months.",
+                  "statement": "Providers with Class A Certifications SHOULD persistently perform vulnerability detection on all information resources that are likely to drift, at least once every 3 months.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "month",
                   "timeframe_num": 3
                 },
                 "b": {
-                  "statement": "Providers of Class B offerings SHOULD persistently perform vulnerability detection on all information resources that are likely to drift, at least once every month.",
+                  "statement": "Providers with Class B Certifications SHOULD persistently perform vulnerability detection on all information resources that are likely to drift, at least once every month.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "month",
                   "timeframe_num": 1
                 },
                 "c": {
-                  "statement": "Providers of Class C offerings SHOULD persistently perform vulnerability detection on all information resources that are likely to drift, at least once every 14 days.",
+                  "statement": "Providers with Class C Certifications SHOULD persistently perform vulnerability detection on all information resources that are likely to drift, at least once every 14 days.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 14
                 },
                 "d": {
-                  "statement": "Providers of Class D offerings SHOULD persistently perform vulnerability detection on all information resources that are likely to drift, at least once every 7 days.",
+                  "statement": "Providers with Class D Certifications SHOULD persistently perform vulnerability detection on all information resources that are likely to drift, at least once every 7 days.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 7
@@ -5233,25 +5387,25 @@
               "name": "Persistently Complete Detection",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers of Class A offerings SHOULD persistently perform vulnerability detection on all information resources that are NOT likely to drift, at least once every 6 months.",
+                  "statement": "Providers with Class A Certifications SHOULD persistently perform vulnerability detection on all information resources that are NOT likely to drift, at least once every 6 months.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "month",
                   "timeframe_num": 6
                 },
                 "b": {
-                  "statement": "Providers of Class B offerings SHOULD persistently perform vulnerability detection on all information resources that are NOT likely to drift, at least once every 6 months.",
+                  "statement": "Providers with Class B Certifications SHOULD persistently perform vulnerability detection on all information resources that are NOT likely to drift, at least once every 6 months.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "month",
                   "timeframe_num": 6
                 },
                 "c": {
-                  "statement": "Providers of Class C offerings SHOULD persistently perform vulnerability detection on all information resources that are NOT likely to drift, at least once every month.",
+                  "statement": "Providers with Class C Certifications SHOULD persistently perform vulnerability detection on all information resources that are NOT likely to drift, at least once every month.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "month",
                   "timeframe_num": 1
                 },
                 "d": {
-                  "statement": "Providers of Class D offerings SHOULD persistently perform vulnerability detection on all information resources that are NOT likely to drift, at least once every month.",
+                  "statement": "Providers with Class D Certifications SHOULD persistently perform vulnerability detection on all information resources that are NOT likely to drift, at least once every month.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "month",
                   "timeframe_num": 1
@@ -5278,25 +5432,25 @@
               "name": "Evaluate Vulnerabilities Quickly",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers of Class A offerings SHOULD evaluate ALL vulnerabilities as required by VDR-EVA (Evaluation) within 14 days of detection.",
+                  "statement": "Providers with Class A Certifications SHOULD evaluate ALL vulnerabilities as required by VDR-EVA (Evaluation) within 14 days of detection.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 14
                 },
                 "b": {
-                  "statement": "Providers of Class B offerings SHOULD evaluate ALL vulnerabilities as required by VDR-EVA (Evaluation) within 7 days of detection.",
+                  "statement": "Providers with Class B Certifications SHOULD evaluate ALL vulnerabilities as required by VDR-EVA (Evaluation) within 7 days of detection.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 7
                 },
                 "c": {
-                  "statement": "Providers of Class C offerings SHOULD evaluate ALL vulnerabilities as required by VDR-EVA (Evaluation) within 5 days of detection.",
+                  "statement": "Providers with Class C Certifications SHOULD evaluate ALL vulnerabilities as required by VDR-EVA (Evaluation) within 5 days of detection.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 5
                 },
                 "d": {
-                  "statement": "Providers of Class D offerings SHOULD evaluate ALL vulnerabilities as required by VDR-EVA (Evaluation) within 2 days of detection.",
+                  "statement": "Providers with Class D Certifications SHOULD evaluate ALL vulnerabilities as required by VDR-EVA (Evaluation) within 2 days of detection.",
                   "primary_key_word": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 2
@@ -5315,7 +5469,7 @@
               "name": "Mitigation and Remediation Expectations",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers of Class A offerings SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower potential adverse impact within the timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
+                  "statement": "Providers with Class A Certifications SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower potential adverse impact within the timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
                   "primary_key_word": "SHOULD",
                   "pain_timeframes": {
                     "1": {},
@@ -5390,7 +5544,7 @@
                   }
                 },
                 "b": {
-                  "statement": "Providers of Class B offerings SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower potential adverse impact within the timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
+                  "statement": "Providers with Class B Certifications SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower potential adverse impact within the timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
                   "primary_key_word": "SHOULD",
                   "pain_timeframes": {
                     "1": {},
@@ -5465,7 +5619,7 @@
                   }
                 },
                 "c": {
-                  "statement": "Providers of Class C offerings SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower Potential Agency Impact N-rating within the timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
+                  "statement": "Providers with Class C Certifications SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower Potential Agency Impact N-rating within the timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
                   "primary_key_word": "SHOULD",
                   "pain_timeframes": {
                     "1": {},
@@ -5540,7 +5694,7 @@
                   }
                 },
                 "d": {
-                  "statement": "Providers of Class D offerings SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower Potential Agency Impact N-rating within the maximum timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
+                  "statement": "Providers with Class D Certifications SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower Potential Agency Impact N-rating within the maximum timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
                   "primary_key_word": "SHOULD",
                   "pain_timeframes": {
                     "1": {},
@@ -5647,19 +5801,19 @@
               "name": "Internet-Reachable Incidents",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers of Class A offerings MAY treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated to N3 or below.",
+                  "statement": "Providers with Class A Certifications MAY treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated to N3 or below.",
                   "primary_key_word": "MAY"
                 },
                 "b": {
-                  "statement": "Providers of Class B offerings MAY treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated to N3 or below.",
+                  "statement": "Providers with Class B Certifications MAY treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated to N3 or below.",
                   "primary_key_word": "MAY"
                 },
                 "c": {
-                  "statement": "Providers of Class C offerings SHOULD treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated to N3 or below.",
+                  "statement": "Providers with Class C Certifications SHOULD treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated to N3 or below.",
                   "primary_key_word": "SHOULD"
                 },
                 "d": {
-                  "statement": "Providers of Class D offerings SHOULD treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated to N3 or below.",
+                  "statement": "Providers with Class D Certifications SHOULD treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated to N3 or below.",
                   "primary_key_word": "SHOULD"
                 }
               },
@@ -5685,19 +5839,19 @@
               "name": "Non-Internet-Reachable Incidents",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers of Class A offerings MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated to N4 or below.",
+                  "statement": "Providers with Class A Certifications MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated to N4 or below.",
                   "primary_key_word": "MAY"
                 },
                 "b": {
-                  "statement": "Providers of Class B offerings MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated to N4 or below.",
+                  "statement": "Providers with Class B Certifications MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated to N4 or below.",
                   "primary_key_word": "MAY"
                 },
                 "c": {
-                  "statement": "Providers of Class C offerings MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated to N4 or below.",
+                  "statement": "Providers with Class C Certifications MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated to N4 or below.",
                   "primary_key_word": "MAY"
                 },
                 "d": {
-                  "statement": "Providers of Class D offerings SHOULD treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated to N4 or below.",
+                  "statement": "Providers with Class D Certifications SHOULD treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated to N4 or below.",
                   "primary_key_word": "SHOULD"
                 }
               },
@@ -6160,25 +6314,25 @@
               "name": "Independent Verification and Validation",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers of Class A offerings MAY persistently complete an independent verification and validation assessment at least once per year; these assessments MAY be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MAY be included in their FedRAMP Certification Data without inappropriate modification.",
+                  "statement": "Providers with Class A Certifications MAY persistently complete an independent verification and validation assessment at least once per year; these assessments MAY be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MAY be included in their FedRAMP Certification Data without inappropriate modification.",
                   "primary_key_word": "MAY",
                   "timeframe_type": "years",
                   "timeframe_num": 1
                 },
                 "b": {
-                  "statement": "Providers of Class B offerings MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
+                  "statement": "Providers with Class B Certifications MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
                   "primary_key_word": "MUST",
                   "timeframe_type": "years",
                   "timeframe_num": 1
                 },
                 "c": {
-                  "statement": "Providers of Class C offerings MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
+                  "statement": "Providers with Class C Certifications MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
                   "primary_key_word": "MUST",
                   "timeframe_type": "years",
                   "timeframe_num": 1
                 },
                 "d": {
-                  "statement": "Providers of Class D offerings MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
+                  "statement": "Providers with Class D Certifications MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
                   "primary_key_word": "MUST",
                   "timeframe_type": "years",
                   "timeframe_num": 1

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -27,14 +27,12 @@
       "purpose": "FedRAMP Definitions establish a shared understanding for terms when the plain-language meaning is not precise enough to support consistent use across the rules. When a defined term appears in a rule, the definition is a critical part of that rule and must be followed precisely, even if the term is commonly used differently elsewhere; when no definition exists, the plain-language meaning is expected.",
       "status": "stable",
       "effective": {
-        "all": {
-          "is": "required",
-          "current_status": "Consolidated Rules for 2026",
-          "date": {
-            "obtain": "2026-07-04",
-            "maintain": "2026-07-04",
-            "grace_ends": "2026-05-04"
-          }
+        "is": "required",
+        "current_status": "Consolidated Rules for 2026",
+        "date": {
+          "obtain": "2026-07-04",
+          "maintain": "2026-07-04",
+          "grace_ends": "2026-05-04"
         }
       }
     },
@@ -994,39 +992,10 @@
         "web_name": "certification-data-sharing",
         "purpose": "The Certification Data Sharing rules allow providers to store and share FedRAMP certification information through the platform they choose as long as it follows FedRAMP rules for access, accuracy, and transparency. This helps customers and the public review consistent, current security and compliance information while recognizing that the information usually remains the provider's intellectual property and is not federal information.",
         "status": "stable",
-        "effective": {
-          "20x": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-07-04",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-05-04"
-            }
-          },
-          "rev5": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2027-01-01",
-              "maintain": "2027-08-01",
-              "grace_ends": "2028-02-01"
-            },
-            "signup_url": "ADDME"
-          }
-        },
         "labels": {
           "CSO": {
             "name": "General Provider Responsibilities",
             "description": "These rules apply to providers for FedRAMP Certifications of any type."
-          },
-          "CSX": {
-            "name": "20x-Specific Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP 20x Certifications."
-          },
-          "CSL": {
-            "name": "Rev5-Specific Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Rev5 Certifications."
           },
           "TRC": {
             "name": "FedRAMP-Compatible Trust Centers",
@@ -1035,6 +1004,41 @@
           "UTC": {
             "name": "Using a Trust Center",
             "description": "These rules apply to providers that are using a FedRAMP-compatible trust center instead of USDA Connect; they DO NOT apply to providers using USDA Connect."
+          }
+        },
+        "20x": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2026-07-04",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-05-04"
+            }
+          },
+          "labels": {
+            "CSX": {
+              "name": "20x-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP 20x Certifications."
+            }
+          }
+        },
+        "rev5": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2027-01-01",
+              "maintain": "2027-08-01",
+              "grace_ends": "2028-02-01"
+            },
+            "signup_url": "ADDME"
+          },
+          "labels": {
+            "CSF": {
+              "name": "Rev5-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP Rev5 Certifications."
+            }
           }
         }
       },
@@ -1470,8 +1474,8 @@
           "CSX": {}
         },
         "rev5": {
-          "CSL": {
-            "CDS-CSL-TCM": {
+          "CSF": {
+            "CDS-CSF-TCM": {
               "name": "Trust Center Migration",
               "statement": "Providers MUST notify all necessary parties when migrating to a trust center and MUST provide information in their existing USDA Connect Community Portal secure folders explaining how to use the trust center to obtain FedRAMP Certification Data.",
               "primary_key_word": "MUST",
@@ -1496,7 +1500,7 @@
                 }
               ]
             },
-            "CDS-CSL-SCD": {
+            "CDS-CSF-SCD": {
               "name": "Structured Certification Data",
               "varies_by_class": {
                 "a": {
@@ -1556,27 +1560,6 @@
         "web_name": "collaborative-continuous-monitoring",
         "purpose": "The Collaborative Continuous Monitoring rules help agencies use shared, current authorization information from providers as part of each agency's own Information Security Continuous Monitoring strategy. These rules reduce unnecessary manual burden by encouraging automated monitoring and review while allowing each agency to make its own risk-based decisions about ongoing authorization.",
         "status": "stable",
-        "effective": {
-          "20x": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-07-04",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-05-04"
-            }
-          },
-          "rev5": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2027-01-01",
-              "maintain": "2027-04-02",
-              "grace_ends": "2027-10-01"
-            },
-            "signup_url": "ADDME"
-          }
-        },
         "labels": {
           "AGM": {
             "name": "Agency Guidance",
@@ -1589,6 +1572,29 @@
           "QTR": {
             "name": "Quarterly Reviews",
             "description": "These rules for Quarterly Reviews apply to providers with any type of FedRAMP Certification."
+          }
+        },
+        "20x": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2026-07-04",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-05-04"
+            }
+          }
+        },
+        "rev5": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2027-01-01",
+              "maintain": "2027-04-02",
+              "grace_ends": "2027-10-01"
+            },
+            "signup_url": "ADDME"
           }
         }
       },
@@ -2095,14 +2101,12 @@
         "purpose": "The FedRAMP Security Inbox rules ensure FedRAMP can reliably contact the security and compliance staff responsible for every FedRAMP-authorized cloud service offering. These rules also set expectations for urgent communications, response time testing, and routing important messages separately from general support or customer service channels.",
         "status": "stable",
         "effective": {
-          "all": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-01-05",
-              "maintain": "2026-01-05",
-              "grace_ends": "2026-07-01"
-            }
+          "is": "required",
+          "current_status": "Consolidated Rules for 2026",
+          "date": {
+            "obtain": "2026-01-05",
+            "maintain": "2026-01-05",
+            "grace_ends": "2026-07-01"
           }
         },
         "labels": {
@@ -2388,27 +2392,6 @@
         "web_name": "incident-communications-procedures",
         "purpose": "The Incident Communications Procedures rules explain how providers must communicate incident information to FedRAMP, CISA, and government customers.",
         "status": "placeholder",
-        "effective": {
-          "20x": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-07-04",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-05-04"
-            }
-          },
-          "rev5": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2027-01-01",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-06-01"
-            },
-            "signup_url": "ADDME"
-          }
-        },
         "labels": {
           "FRP": {
             "name": "FedRAMP Responsibilities",
@@ -2456,20 +2439,49 @@
                 "to": "ICP-CSO-IIR",
                 "description": "Follow the estimated PAIN timeframes."
               },
-              { "from": "ICP-CSO-IIR", "to": "ICP-CSO-OIR" },
+              {
+                "from": "ICP-CSO-IIR",
+                "to": "ICP-CSO-OIR"
+              },
               {
                 "from": "ICP-CSO-OIR",
                 "to": "ICP-CSO-OIR",
                 "description": "Ongoing reporting until incident is resolved, following PAIN timeframes."
               },
-              { "from": "ICP-CSO-OIR", "to": "ICP-CSO-FIR" },
+              {
+                "from": "ICP-CSO-OIR",
+                "to": "ICP-CSO-FIR"
+              },
               {
                 "from": "ICP-CSO-FIR",
                 "to": "Incident Communication Procedures are complete."
               }
             ]
           }
-        ]
+        ],
+        "20x": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2026-07-04",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-05-04"
+            }
+          }
+        },
+        "rev5": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2027-01-01",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-06-01"
+            },
+            "signup_url": "ADDME"
+          }
+        }
       },
       "data": {
         "all": {
@@ -3128,8 +3140,14 @@
         "web_name": "minimum-assessment-scope",
         "purpose": "The Minimum Assessment Scope rules help providers define assessment boundaries narrowly enough to avoid unnecessary review of components that do not affect the offering’s security. These rules still ensure the assessment includes the resources and connections needed to understand the offering’s confidentiality, integrity, and availability.",
         "status": "stable",
-        "effective": {
-          "20x": {
+        "labels": {
+          "CSO": {
+            "name": "General Provider Responsibilities",
+            "description": "These rules apply to providers for any type of FedRAMP Certification."
+          }
+        },
+        "20x": {
+          "effective": {
             "is": "required",
             "current_status": "Consolidated Rules for 2026",
             "date": {
@@ -3137,8 +3155,10 @@
               "maintain": "2027-01-01",
               "grace_ends": "2027-05-04"
             }
-          },
-          "rev5": {
+          }
+        },
+        "rev5": {
+          "effective": {
             "is": "required",
             "current_status": "Consolidated Rules for 2026",
             "date": {
@@ -3147,12 +3167,6 @@
               "grace_by_assessment_months": 2
             },
             "signup_url": "ADDME"
-          }
-        },
-        "labels": {
-          "CSO": {
-            "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers for any type of FedRAMP Certification."
           }
         }
       },
@@ -3282,26 +3296,6 @@
         "web_name": "marketplace-listing",
         "purpose": "The Marketplace Listing rules define how FedRAMP decides which cloud service offerings, assessors, and advisors may be listed in the FedRAMP Marketplace. These rules help agencies and other customers rely on the Marketplace as a consistent source of eligible services and supporting organizations, while requiring listed organizations to supply accurate, accessible, and machine-readable information.",
         "status": "placeholder",
-        "effective": {
-          "20x": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-07-04",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-05-04"
-            }
-          },
-          "rev5": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2027-01-01",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-06-01"
-            }
-          }
-        },
         "labels": {
           "FRP": {
             "name": "FedRAMP Responsibilities",
@@ -3322,6 +3316,28 @@
           "PRE": {
             "name": "Provider Responsibilities for Preparation Phase Listings",
             "description": "These rules apply to providers seeking a Preparation Phase listing in the FedRAMP Marketplace."
+          }
+        },
+        "20x": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2026-07-04",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-05-04"
+            }
+          }
+        },
+        "rev5": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2027-01-01",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-06-01"
+            }
           }
         }
       },
@@ -3571,14 +3587,12 @@
         "purpose": "The Secure Configuration Guide rules help agencies and other customers understand how to configure a cloud service offering securely. These rules require providers to clearly explain the security impact of common settings so customers can make informed configuration choices.",
         "status": "stable",
         "effective": {
-          "all": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-03-01",
-              "maintain": "2026-03-01",
-              "grace_ends": "2026-07-01"
-            }
+          "is": "required",
+          "current_status": "Consolidated Rules for 2026",
+          "date": {
+            "obtain": "2026-03-01",
+            "maintain": "2026-03-01",
+            "grace_ends": "2026-07-01"
           }
         },
         "labels": {
@@ -3752,27 +3766,6 @@
         "web_name": "significant-change-notifications",
         "purpose": "The Significant Change Notifications rules supply a simple framework allowing providers to make significant changes to their own products while keeping agency customers in the loop. These rules organize significant changes into clear categories so agencies can understand the expected risk and make authorization decisions accordingly.",
         "status": "stable",
-        "effective": {
-          "20x": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-07-04",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-05-04"
-            }
-          },
-          "rev5": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2027-01-01",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-06-01"
-            },
-            "signup_url": "ADDME"
-          }
-        },
         "labels": {
           "FRP": {
             "name": "FedRAMP Responsibilities",
@@ -3793,6 +3786,29 @@
           "TRF": {
             "name": "Transformative Changes",
             "description": "These rules apply to all transformative significant changes."
+          }
+        },
+        "20x": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2026-07-04",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-05-04"
+            }
+          }
+        },
+        "rev5": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2027-01-01",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-06-01"
+            },
+            "signup_url": "ADDME"
           }
         }
       },
@@ -4268,8 +4284,14 @@
         "web_name": "using-cryptographic-modules",
         "purpose": "The Using Cryptographic Modules rules clarify how providers should select and use cryptographic modules. These rules allow risk-based decisions for some services while still encouraging validated cryptographic modules whenever they are technically feasible and reasonable.",
         "status": "placeholder",
-        "effective": {
-          "20x": {
+        "labels": {
+          "CSO": {
+            "name": "Cloud Service Provider Responsibilities",
+            "description": "These rules apply to providers for FedRAMP Certifications."
+          }
+        },
+        "20x": {
+          "effective": {
             "is": "required",
             "current_status": "Consolidated Rules for 2026",
             "date": {
@@ -4277,8 +4299,10 @@
               "maintain": "2027-01-01",
               "grace_ends": "2027-05-04"
             }
-          },
-          "rev5": {
+          }
+        },
+        "rev5": {
+          "effective": {
             "is": "required",
             "current_status": "Consolidated Rules for 2026",
             "date": {
@@ -4286,12 +4310,6 @@
               "maintain": "2027-01-01",
               "grace_ends": "2027-06-01"
             }
-          }
-        },
-        "labels": {
-          "CSO": {
-            "name": "Cloud Service Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Certifications."
           }
         }
       },
@@ -4364,27 +4382,6 @@
         "web_name": "vulnerability-detection-and-response",
         "purpose": "The Vulnerability Detection and Response rules require providers to continuously identify, analyze, prioritize, mitigate, and remediate vulnerabilities and related exposures through automated systems. These rules give providers flexibility in implementation while ensuring agencies receive the information needed to support ongoing authorization decisions.",
         "status": "stable",
-        "effective": {
-          "20x": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-07-04",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-05-04"
-            }
-          },
-          "rev5": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2027-01-01",
-              "maintain": "2027-06-01",
-              "grace_ends": "2028-01-01"
-            },
-            "signup_url": "ADDME"
-          }
-        },
         "labels": {
           "FRP": {
             "name": "FedRAMP Responsibilities",
@@ -4413,6 +4410,29 @@
           "TFR": {
             "name": "Timeframes",
             "description": "These rules apply to timeframes for vulnerability detection and response."
+          }
+        },
+        "20x": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2026-07-04",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-05-04"
+            }
+          }
+        },
+        "rev5": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2027-01-01",
+              "maintain": "2027-06-01",
+              "grace_ends": "2028-01-01"
+            },
+            "signup_url": "ADDME"
           }
         }
       },
@@ -5689,26 +5709,6 @@
         "web_name": "fedramp-certification",
         "purpose": "The FedRAMP Certification rules define how cloud service offerings obtain and maintain FedRAMP Certification across certification classes and paths. They give providers, assessors, agencies, and FedRAMP a common set of expectations for required rule sets, current evidence, independent verification and validation, and ongoing certification decisions.",
         "status": "placeholder",
-        "effective": {
-          "20x": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-07-04",
-              "maintain": "2027-05-04",
-              "grace_ends": "2027-05-04"
-            }
-          },
-          "rev5": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2027-01-01",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-01-01"
-            }
-          }
-        },
         "labels": {
           "FRP": {
             "name": "FedRAMP Responsibilities",
@@ -5718,25 +5718,9 @@
             "name": "General Provider Responsibilities",
             "description": "These rules apply to cloud service providers obtaining and maintaining any FedRAMP Certification."
           },
-          "CSX": {
-            "name": "20x-Specific Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP 20x Certifications."
-          },
-          "CSL": {
-            "name": "Rev5-Specific Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Rev5 Certifications."
-          },
           "IAS": {
             "name": "General Independent Assessor Responsibilities",
             "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types."
-          },
-          "IAX": {
-            "name": "20x-Specific Independent Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications."
-          },
-          "IAL": {
-            "name": "Rev5-Specific Independent Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications."
           },
           "CLA": {
             "name": "FedRAMP Class A Certification Rules",
@@ -5749,6 +5733,48 @@
           "APS": {
             "name": "Applying for FedRAMP Certification with an Agency Sponsor",
             "description": "These rules apply to cloud service providers with an Agency Sponsor who have met all other relevant rules and are ready to apply for any FedRAMP Certification."
+          }
+        },
+        "20x": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2026-07-04",
+              "maintain": "2027-05-04",
+              "grace_ends": "2027-05-04"
+            }
+          },
+          "labels": {
+            "CSX": {
+              "name": "20x-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP 20x Certifications."
+            },
+            "IAX": {
+              "name": "20x-Specific Independent Assessor Responsibilities",
+              "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications."
+            }
+          }
+        },
+        "rev5": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2027-01-01",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-01-01"
+            }
+          },
+          "labels": {
+            "CSF": {
+              "name": "Rev5-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP Rev5 Certifications."
+            },
+            "IAF": {
+              "name": "Rev5-Specific Independent Assessor Responsibilities",
+              "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications."
+            }
           }
         }
       },
@@ -6649,8 +6675,8 @@
           }
         },
         "rev5": {
-          "CSL": {
-            "FRC-CSL-CDE": {
+          "CSF": {
+            "FRC-CSF-CDE": {
               "name": "Class D Program Certification Exclusion",
               "statement": "Providers seeking a FedRAMP Rev5 Class D Certification MUST use the FedRAMP Agency Certification path.",
               "note": "FedRAMP will not perform FedRAMP Rev5 Class D Program Certifications.",
@@ -6664,7 +6690,7 @@
                 }
               ]
             },
-            "FRC-CSL-PMV": {
+            "FRC-CSF-PMV": {
               "name": "Persistent Machine Verification and Validation",
               "varies_by_class": {
                 "a": {
@@ -6707,7 +6733,7 @@
                 }
               ]
             },
-            "FRC-CSL-RDY": {
+            "FRC-CSF-RDY": {
               "name": "FedRAMP Ready Conversion",
               "statement": "Providers with FedRAMP Rev5 Ready status MUST convert to a FedRAMP Certification before the furthest date of the expiration of their most recently yearly assessment or November 17, 2026; the legacy FedRAMP Ready status will be entirely removed on December 31, 2027.",
               "note": "Cloud services that do not wish to convert or do not meet conversion criteria will be renamed Legacy FedRAMP Ready and otherwise retired from FedRAMP Ready.",
@@ -6751,8 +6777,14 @@
         "web_name": "security-decision-record",
         "purpose": "The Security Decision Record replaced a traditional System Security Plan with a persistently maintained, verified, and validated record of the security decisions made by the cloud service provider over the lifecycle of their cloud service offering.",
         "status": "empty",
-        "effective": {
-          "20x": {
+        "labels": {
+          "CSO": {
+            "name": "General Provider Responsibilities",
+            "description": "These rules apply to providers for FedRAMP Certifications of any type."
+          }
+        },
+        "20x": {
+          "effective": {
             "is": "required",
             "current_status": "Consolidated Rules for 2026",
             "date": {
@@ -6761,7 +6793,15 @@
               "grace_ends": "2027-05-04"
             }
           },
-          "rev5": {
+          "labels": {
+            "CSX": {
+              "name": "20x-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP 20x Certifications."
+            }
+          }
+        },
+        "rev5": {
+          "effective": {
             "is": "required",
             "current_status": "Consolidated Rules for 2026",
             "date": {
@@ -6770,20 +6810,12 @@
               "grace_ends": "2028-02-01"
             },
             "signup_url": "ADDME"
-          }
-        },
-        "labels": {
-          "CSO": {
-            "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Certifications of any type."
           },
-          "CSX": {
-            "name": "20x-Specific Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP 20x Certifications."
-          },
-          "CSL": {
-            "name": "Rev5-Specific Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Rev5 Certifications."
+          "labels": {
+            "CSF": {
+              "name": "Rev5-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP Rev5 Certifications."
+            }
           }
         }
       },
@@ -6800,8 +6832,18 @@
         "web_name": "independent-assessment-plan",
         "purpose": "The Independent Assessment Plan rules explain how independent assessment services should approach the verification, validation, and attestation of a cloud service provider's own Security Decision Record on behalf of FedRAMP.",
         "status": "empty",
-        "effective": {
-          "20x": {
+        "labels": {
+          "CSO": {
+            "name": "General Provider Responsibilities",
+            "description": "These rules apply to providers for FedRAMP Certifications of any type."
+          },
+          "IAS": {
+            "name": "General Independent Assessor Responsibilities",
+            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types."
+          }
+        },
+        "20x": {
+          "effective": {
             "is": "required",
             "current_status": "Consolidated Rules for 2026",
             "date": {
@@ -6810,7 +6852,19 @@
               "grace_ends": "2027-05-04"
             }
           },
-          "rev5": {
+          "labels": {
+            "CSX": {
+              "name": "20x-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP 20x Certifications."
+            },
+            "IAX": {
+              "name": "20x-Specific Independent Assessor Responsibilities",
+              "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications."
+            }
+          }
+        },
+        "rev5": {
+          "effective": {
             "is": "required",
             "current_status": "Consolidated Rules for 2026",
             "date": {
@@ -6819,32 +6873,16 @@
               "grace_ends": "2028-02-01"
             },
             "signup_url": "ADDME"
-          }
-        },
-        "labels": {
-          "CSO": {
-            "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Certifications of any type."
           },
-          "CSX": {
-            "name": "20x-Specific Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP 20x Certifications."
-          },
-          "CSL": {
-            "name": "Rev5-Specific Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Rev5 Certifications."
-          },
-          "IAS": {
-            "name": "General Independent Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types."
-          },
-          "IAX": {
-            "name": "20x-Specific Independent Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications."
-          },
-          "IAL": {
-            "name": "Rev5-Specific Independent Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications."
+          "labels": {
+            "CSF": {
+              "name": "Rev5-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP Rev5 Certifications."
+            },
+            "IAF": {
+              "name": "Rev5-Specific Independent Assessor Responsibilities",
+              "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications."
+            }
           }
         }
       },
@@ -6861,8 +6899,18 @@
         "web_name": "independent-assessment-report",
         "purpose": "The Independent Assessment Report rules explain the minimum expectations for independent assessor attestations after the completion of an independent assessment for FedRAMP Certification.",
         "status": "empty",
-        "effective": {
-          "20x": {
+        "labels": {
+          "CSO": {
+            "name": "General Provider Responsibilities",
+            "description": "These rules apply to providers for FedRAMP Certifications of any type."
+          },
+          "IAS": {
+            "name": "General Independent Assessor Responsibilities",
+            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types."
+          }
+        },
+        "20x": {
+          "effective": {
             "is": "required",
             "current_status": "Consolidated Rules for 2026",
             "date": {
@@ -6871,7 +6919,19 @@
               "grace_ends": "2027-05-04"
             }
           },
-          "rev5": {
+          "labels": {
+            "CSX": {
+              "name": "20x-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP 20x Certifications."
+            },
+            "IAX": {
+              "name": "20x-Specific Independent Assessor Responsibilities",
+              "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications."
+            }
+          }
+        },
+        "rev5": {
+          "effective": {
             "is": "required",
             "current_status": "Consolidated Rules for 2026",
             "date": {
@@ -6880,32 +6940,16 @@
               "grace_ends": "2028-02-01"
             },
             "signup_url": "ADDME"
-          }
-        },
-        "labels": {
-          "CSO": {
-            "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Certifications of any type."
           },
-          "CSX": {
-            "name": "20x-Specific Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP 20x Certifications."
-          },
-          "CSL": {
-            "name": "Rev5-Specific Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Rev5 Certifications."
-          },
-          "IAS": {
-            "name": "General Independent Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types."
-          },
-          "IAX": {
-            "name": "20x-Specific Independent Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications."
-          },
-          "IAL": {
-            "name": "Rev5-Specific Independent Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications."
+          "labels": {
+            "CSF": {
+              "name": "Rev5-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP Rev5 Certifications."
+            },
+            "IAF": {
+              "name": "Rev5-Specific Independent Assessor Responsibilities",
+              "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications."
+            }
           }
         }
       },
@@ -6923,14 +6967,12 @@
         "purpose": "The Agency Use rules summarize the many demands made on agencies by the FedRAMP Authorization Act and OMB Memorandum M-24-15 in a simple, clear, easy-to-follow set of FedRAMP-style rules. These rules align agency policies, authorization letters, machine-readable tools, secure configuration review, continuous monitoring, and communication with FedRAMP so certifications can be reused consistently across government.",
         "status": "placeholder",
         "effective": {
-          "all": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-07-04",
-              "maintain": "2026-07-04",
-              "grace_ends": "2026-07-04"
-            }
+          "is": "required",
+          "current_status": "Consolidated Rules for 2026",
+          "date": {
+            "obtain": "2026-07-04",
+            "maintain": "2026-07-04",
+            "grace_ends": "2026-07-04"
           }
         },
         "labels": {
@@ -7280,23 +7322,12 @@
         "purpose": "The FedRAMP Recognition of Independent Assessment Services rules explain the requirements for assessors to obtain and maintain FedRAMP Recognition in order to support the FedRAMP Certification process.",
         "status": "placeholder",
         "effective": {
-          "20x": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-07-04",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-05-04"
-            }
-          },
-          "rev5": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2027-01-01",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-01-01"
-            }
+          "is": "required",
+          "current_status": "Consolidated Rules for 2026",
+          "date": {
+            "obtain": "2026-07-04",
+            "maintain": "2026-07-04",
+            "grace_ends": "2026-07-04"
           }
         },
         "labels": {

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -27,7 +27,7 @@
       "purpose": "FedRAMP Definitions establish a shared understanding for terms when the plain-language meaning is not precise enough to support consistent use across the rules. When a defined term appears in a rule, the definition is a critical part of that rule and must be followed precisely, even if the term is commonly used differently elsewhere; when no definition exists, the plain-language meaning is expected.",
       "status": "stable",
       "effective": {
-        "both": {
+        "all": {
           "is": "required",
           "current_status": "Consolidated Rules for 2026",
           "date": {
@@ -39,7 +39,7 @@
       }
     },
     "data": {
-      "both": {
+      "all": {
         "FRD-ACV": {
           "term": "Accepted Vulnerability",
           "definition": "A vulnerability that the provider does not intend to fully mitigate or remediate, OR that has not or will not be fully mitigated or remediated within the maximum overdue period in FedRAMP Vulnerability Detection and Response rules.",
@@ -1039,7 +1039,7 @@
         }
       },
       "data": {
-        "both": {
+        "all": {
           "CSO": {
             "CDS-CSO-PUB": {
               "name": "Public Information",
@@ -1063,7 +1063,7 @@
               "primary_key_word": "MUST",
               "affects": ["Providers"],
               "artifacts": {
-                "both": [
+                "all": [
                   "URL to the human-readable data.",
                   "URL to the machine-readable data."
                 ]
@@ -1090,7 +1090,7 @@
               "primary_key_word": "MUST",
               "affects": ["Providers"],
               "artifacts": {
-                "both": [
+                "all": [
                   "URL to the human-readable data.",
                   "URL to the machine-readable data (if applicable)."
                 ]
@@ -1190,7 +1190,7 @@
               "primary_key_word": "MUST",
               "affects": ["Providers"],
               "artifacts": {
-                "both": ["Explanation of how to access this information."]
+                "all": ["Explanation of how to access this information."]
               },
               "terms": [
                 "All Necessary Parties",
@@ -1212,7 +1212,7 @@
                   "statement": "Providers of Class A offerings MAY supply per-service FedRAMP Certification materials.",
                   "primary_key_word": "MAY",
                   "artifacts": {
-                    "both": [
+                    "all": [
                       "Explanation of the supplied materials, including how to access and use them."
                     ]
                   }
@@ -1221,7 +1221,7 @@
                   "statement": "Providers of Class B offerings MAY supply per-service FedRAMP Certification materials.",
                   "primary_key_word": "MAY",
                   "artifacts": {
-                    "both": [
+                    "all": [
                       "Explanation of the supplied materials, including how to access and use them."
                     ]
                   }
@@ -1230,7 +1230,7 @@
                   "statement": "Providers of Class C offerings MAY supply per-service FedRAMP Certification materials.",
                   "primary_key_word": "MAY",
                   "artifacts": {
-                    "both": [
+                    "all": [
                       "Explanation of the supplied materials, including how to access and use them."
                     ]
                   }
@@ -1244,7 +1244,7 @@
                     "grace_by_assessment_months": 2
                   },
                   "artifacts": {
-                    "both": [
+                    "all": [
                       "Explanation of the supplied materials, including how to access and use them."
                     ]
                   }
@@ -1269,7 +1269,7 @@
               "primary_key_word": "MAY",
               "affects": ["Providers"],
               "artifacts": {
-                "both": [
+                "all": [
                   "Explanation of if and how this information is shared with other parties."
                 ]
               },
@@ -1313,7 +1313,7 @@
               "primary_key_word": "MUST",
               "affects": ["Providers"],
               "artifacts": {
-                "both": ["URL to the documentation for programmatic access."]
+                "all": ["URL to the documentation for programmatic access."]
               },
               "terms": ["Certification Data", "Trust Center"],
               "updated": [
@@ -1329,7 +1329,7 @@
               "primary_key_word": "MUST",
               "affects": ["Providers"],
               "artifacts": {
-                "both": [
+                "all": [
                   "Explanation of how FedRAMP can obtain this information."
                 ]
               },
@@ -1347,7 +1347,7 @@
               "primary_key_word": "MUST",
               "affects": ["Providers"],
               "artifacts": {
-                "both": [
+                "all": [
                   "Explanation of how the appropriate parties can obtain this log information."
                 ]
               },
@@ -1382,7 +1382,7 @@
               "primary_key_word": "SHOULD",
               "affects": ["Providers"],
               "artifacts": {
-                "both": [
+                "all": [
                   "URL or explanation how to access documentation of these features and capabilities."
                 ]
               },
@@ -1406,7 +1406,7 @@
               "primary_key_word": "MUST",
               "affects": ["Providers"],
               "artifacts": {
-                "both": [
+                "all": [
                   "URL or explanation of the supplied materials, including how to access and use them."
                 ]
               },
@@ -1429,7 +1429,7 @@
               "primary_key_word": "SHOULD",
               "affects": ["Providers"],
               "artifacts": {
-                "both": [
+                "all": [
                   "URL or explanation of how to request these materials.",
                   "Explanation of how the provider decides whether or not to share these materials or other related policies."
                 ]
@@ -1593,7 +1593,7 @@
         }
       },
       "data": {
-        "both": {
+        "all": {
           "AGM": {
             "CCM-AGM-ROR": {
               "name": "Review Ongoing Reports",
@@ -2095,7 +2095,7 @@
         "purpose": "The FedRAMP Security Inbox rules ensure FedRAMP can reliably contact the security and compliance staff responsible for every FedRAMP-authorized cloud service offering. These rules also set expectations for urgent communications, response time testing, and routing important messages separately from general support or customer service channels.",
         "status": "stable",
         "effective": {
-          "both": {
+          "all": {
             "is": "required",
             "current_status": "Consolidated Rules for 2026",
             "date": {
@@ -2117,7 +2117,7 @@
         }
       },
       "data": {
-        "both": {
+        "all": {
           "FRP": {
             "FSI-FRP-VRE": {
               "name": "Verified Emails",
@@ -2472,7 +2472,7 @@
         ]
       },
       "data": {
-        "both": {
+        "all": {
           "FRP": {
             "ICP-FRP-ORV": {
               "name": "Ongoing Review",
@@ -3157,7 +3157,7 @@
         }
       },
       "data": {
-        "both": {
+        "all": {
           "CSO": {
             "MAS-CSO-IIR": {
               "name": "Identify Information Resources",
@@ -3326,7 +3326,7 @@
         }
       },
       "data": {
-        "both": {
+        "all": {
           "FRP": {
             "MKT-FRP-DSM": {
               "name": "Decision Summaries",
@@ -3571,7 +3571,7 @@
         "purpose": "The Secure Configuration Guide rules help agencies and other customers understand how to configure a cloud service offering securely. These rules require providers to clearly explain the security impact of common settings so customers can make informed configuration choices.",
         "status": "stable",
         "effective": {
-          "both": {
+          "all": {
             "is": "required",
             "current_status": "Consolidated Rules for 2026",
             "date": {
@@ -3593,7 +3593,7 @@
         }
       },
       "data": {
-        "both": {
+        "all": {
           "CSO": {
             "SCG-CSO-RSC": {
               "name": "Recommended Secure Configuration",
@@ -3797,7 +3797,7 @@
         }
       },
       "data": {
-        "both": {
+        "all": {
           "FRP": {
             "SCN-FRP-CAP": {
               "name": "Corrective Action Plan Conditions",
@@ -4296,7 +4296,7 @@
         }
       },
       "data": {
-        "both": {
+        "all": {
           "CSO": {
             "UCM-CSO-CMD": {
               "name": "Cryptographic Module Documentation",
@@ -4417,7 +4417,7 @@
         }
       },
       "data": {
-        "both": {
+        "all": {
           "FRP": {
             "VDR-FRP-ARP": {
               "name": "Additional Requirements",
@@ -5753,7 +5753,7 @@
         }
       },
       "data": {
-        "both": {
+        "all": {
           "FRP": {
             "FRC-FRP-MCM": {
               "name": "Minimum Continuous Monitoring",
@@ -6788,7 +6788,7 @@
         }
       },
       "data": {
-        "both": {},
+        "all": {},
         "20x": {},
         "rev5": {}
       }
@@ -6849,7 +6849,7 @@
         }
       },
       "data": {
-        "both": {},
+        "all": {},
         "20x": {},
         "rev5": {}
       }
@@ -6910,7 +6910,7 @@
         }
       },
       "data": {
-        "both": {},
+        "all": {},
         "20x": {},
         "rev5": {}
       }
@@ -6923,7 +6923,7 @@
         "purpose": "The Agency Use rules summarize the many demands made on agencies by the FedRAMP Authorization Act and OMB Memorandum M-24-15 in a simple, clear, easy-to-follow set of FedRAMP-style rules. These rules align agency policies, authorization letters, machine-readable tools, secure configuration review, continuous monitoring, and communication with FedRAMP so certifications can be reused consistently across government.",
         "status": "placeholder",
         "effective": {
-          "both": {
+          "all": {
             "is": "required",
             "current_status": "Consolidated Rules for 2026",
             "date": {
@@ -6949,7 +6949,7 @@
         }
       },
       "data": {
-        "both": {
+        "all": {
           "AGC": {
             "AGU-AGC-AIP": {
               "name": "Agency Internal Policies",
@@ -7311,7 +7311,7 @@
         }
       },
       "data": {
-        "both": {
+        "all": {
           "FRP": {
             "REC-FRP-RAO": {
               "name": "Recognized Assessors Only",

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -2418,7 +2418,58 @@
             "name": "General Provider Responsibilities",
             "description": "These rules apply to providers with FedRAMP Certifications of any type."
           }
-        }
+        },
+        "flows": [
+          {
+            "activity": "Incident Communications",
+            "description": "Evaluating and notifying affected parties about FedRAMP Reportable Incidents.",
+            "steps": [
+              {
+                "from": "Incident",
+                "to": "ICP-CSO-EFR",
+                "description": "Is it a FedRAMP Reportable Incident?"
+              },
+              {
+                "from": "ICP-CSO-EFR",
+                "to": "Incident Communication Procedures are complete.",
+                "if": "No"
+              },
+              {
+                "from": "ICP-CSO-EFR",
+                "to": "ICP-CSO-DPR",
+                "if": "Yes",
+                "description": "Yes, but the PAIN will not be estimated."
+              },
+              {
+                "from": "ICP-CSO-EFR",
+                "to": "ICP-CSO-EFI",
+                "if": "Yes",
+                "description": "Yes, and the PAIN will be estimated."
+              },
+              {
+                "from": "ICP-CSO-DPR",
+                "to": "ICP-CSO-IIR",
+                "description": "Following default PAIN-5 timeframes."
+              },
+              {
+                "from": "ICP-CSO-EFI",
+                "to": "ICP-CSO-IIR",
+                "description": "Follow the estimated PAIN timeframes."
+              },
+              { "from": "ICP-CSO-IIR", "to": "ICP-CSO-OIR" },
+              {
+                "from": "ICP-CSO-OIR",
+                "to": "ICP-CSO-OIR",
+                "description": "Ongoing reporting until incident is resolved, following PAIN timeframes."
+              },
+              { "from": "ICP-CSO-OIR", "to": "ICP-CSO-FIR" },
+              {
+                "from": "ICP-CSO-FIR",
+                "to": "Incident Communication Procedures are complete."
+              }
+            ]
+          }
+        ]
       },
       "data": {
         "both": {
@@ -2570,11 +2621,12 @@
                 },
                 {
                   "party": "Agency Customers",
-                  "method": "following agreement"
+                  "method": "update",
+                  "target": "contract agreements"
                 },
                 {
                   "party": "all necessary parties",
-                  "method": "whatever",
+                  "method": "update",
                   "target": "trust center"
                 }
               ],
@@ -2618,11 +2670,12 @@
                 },
                 {
                   "party": "Agency Customers",
-                  "method": "following agreement"
+                  "method": "update",
+                  "target": "contract agreements"
                 },
                 {
                   "party": "all necessary parties",
-                  "method": "whatever",
+                  "method": "update",
                   "target": "trust center"
                 }
               ],
@@ -2657,11 +2710,12 @@
                 },
                 {
                   "party": "Agency Customers",
-                  "method": "following agreement"
+                  "method": "update",
+                  "target": "contract agreements"
                 },
                 {
                   "party": "all necessary parties",
-                  "method": "whatever",
+                  "method": "update",
                   "target": "trust center"
                 }
               ],
@@ -6320,7 +6374,6 @@
                 "FSI-CSO-CRA",
                 "ICP-CSO-PAR",
                 "ICP-CSO-EFR",
-                "ICP-CSO-AAP",
                 "VDR-CSO-DET",
                 "CCM-OCR-AVL",
                 "CCM-OCR-NRD"

--- a/schemas/fedramp-consolidated-rules.schema.json
+++ b/schemas/fedramp-consolidated-rules.schema.json
@@ -120,6 +120,9 @@
           "type": "object",
           "propertyNames": { "$ref": "#/$defs/frr_info_label_name" },
           "additionalProperties": { "$ref": "#/$defs/frr_label_definition" }
+        },
+        "flows": {
+          "type": "array"
         }
       },
       "additionalProperties": false

--- a/schemas/fedramp-consolidated-rules.schema.json
+++ b/schemas/fedramp-consolidated-rules.schema.json
@@ -519,7 +519,13 @@
         "timeframe_type": { "type": "string" },
         "timeframe_num": { "type": "number" },
         "pain_timeframes": { "$ref": "#/$defs/pain_timeframes" },
-        "artifacts": { "$ref": "#/$defs/artifacts" }
+        "artifacts": { "$ref": "#/$defs/artifacts" },
+        "note": { "type": "string" },
+        "notes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 2
+        }
       },
       "additionalProperties": false
     },

--- a/schemas/fedramp-consolidated-rules.schema.json
+++ b/schemas/fedramp-consolidated-rules.schema.json
@@ -514,6 +514,10 @@
       "required": ["primary_key_word", "statement"],
       "properties": {
         "statement": { "type": "string" },
+        "following_information": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
         "primary_key_word": { "$ref": "#/$defs/primary_key_word_enum" },
         "effective_date": { "$ref": "#/$defs/effective_dates" },
         "timeframe_type": { "type": "string" },

--- a/schemas/fedramp-consolidated-rules.schema.json
+++ b/schemas/fedramp-consolidated-rules.schema.json
@@ -80,50 +80,51 @@
   "$defs": {
     "frd_document_info": {
       "type": "object",
-      "required": [
-        "name",
-        "short_name",
-        "web_name",
-        "purpose",
-        "status",
-        "effective"
-      ],
+      "required": ["name", "short_name", "web_name", "purpose", "status"],
       "properties": {
         "name": { "type": "string" },
         "short_name": { "type": "string", "pattern": "^[A-Z]{3}$" },
         "web_name": { "type": "string" },
         "purpose": { "type": "string" },
         "status": { "$ref": "#/$defs/document_status" },
-        "effective": { "$ref": "#/$defs/effective_map" }
+        "effective": { "$ref": "#/$defs/effective_entry" },
+        "20x": { "$ref": "#/$defs/frd_document_info_certification" },
+        "rev5": { "$ref": "#/$defs/frd_document_info_certification" }
+      },
+      "allOf": [{ "$ref": "#/$defs/document_info_effective_rules" }],
+      "additionalProperties": false
+    },
+    "frd_document_info_certification": {
+      "type": "object",
+      "properties": {
+        "effective": { "$ref": "#/$defs/effective_entry" }
       },
       "additionalProperties": false
     },
     "frr_document_info": {
       "type": "object",
-      "required": [
-        "name",
-        "short_name",
-        "web_name",
-        "purpose",
-        "status",
-        "effective",
-        "labels"
-      ],
+      "required": ["name", "short_name", "web_name", "purpose", "status"],
       "properties": {
         "name": { "type": "string" },
         "short_name": { "type": "string", "pattern": "^[A-Z]{3}$" },
         "web_name": { "type": "string" },
         "purpose": { "type": "string" },
         "status": { "$ref": "#/$defs/document_status" },
-        "effective": { "$ref": "#/$defs/effective_map" },
-        "labels": {
-          "type": "object",
-          "propertyNames": { "$ref": "#/$defs/frr_info_label_name" },
-          "additionalProperties": { "$ref": "#/$defs/frr_label_definition" }
-        },
-        "flows": {
-          "type": "array"
-        }
+        "effective": { "$ref": "#/$defs/effective_entry" },
+        "labels": { "$ref": "#/$defs/frr_info_labels" },
+        "flows": { "$ref": "#/$defs/info_flows" },
+        "20x": { "$ref": "#/$defs/frr_document_info_certification" },
+        "rev5": { "$ref": "#/$defs/frr_document_info_certification" }
+      },
+      "allOf": [{ "$ref": "#/$defs/document_info_effective_rules" }],
+      "additionalProperties": false
+    },
+    "frr_document_info_certification": {
+      "type": "object",
+      "properties": {
+        "effective": { "$ref": "#/$defs/effective_entry" },
+        "labels": { "$ref": "#/$defs/frr_info_labels" },
+        "flows": { "$ref": "#/$defs/info_flows" }
       },
       "additionalProperties": false
     },
@@ -136,8 +137,10 @@
         "FRP",
         "AGC",
         "CSO",
+        "CSF",
         "CSX",
         "CSL",
+        "IAF",
         "IAS",
         "IAX",
         "IAL",
@@ -175,31 +178,127 @@
       },
       "additionalProperties": false
     },
-    "effective_map": {
+    "frr_info_labels": {
       "type": "object",
-      "properties": {
-        "all": { "$ref": "#/$defs/effective_entry" },
-        "20x": { "$ref": "#/$defs/effective_entry" },
-        "rev5": { "$ref": "#/$defs/effective_entry" }
-      },
-      "oneOf": [
+      "propertyNames": { "$ref": "#/$defs/frr_info_label_name" },
+      "additionalProperties": { "$ref": "#/$defs/frr_label_definition" }
+    },
+    "info_flows": {
+      "type": "array"
+    },
+    "document_info_effective_rules": {
+      "type": "object",
+      "anyOf": [
         {
           "properties": {
-            "all": { "$ref": "#/$defs/effective_entry" }
+            "effective": true
           },
-          "required": ["all"],
-          "maxProperties": 1
+          "required": ["effective"]
         },
         {
           "properties": {
-            "20x": { "$ref": "#/$defs/effective_entry" },
-            "rev5": { "$ref": "#/$defs/effective_entry" }
+            "20x": {
+              "type": "object",
+              "properties": {
+                "effective": true
+              },
+              "required": ["effective"]
+            },
+            "rev5": {
+              "type": "object",
+              "properties": {
+                "effective": true
+              },
+              "required": ["effective"]
+            }
           },
-          "required": ["20x", "rev5"],
-          "maxProperties": 2
+          "required": ["20x", "rev5"]
         }
       ],
-      "additionalProperties": false
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "effective": true
+            },
+            "required": ["effective"]
+          },
+          "then": {
+            "properties": {
+              "20x": {
+                "not": {
+                  "type": "object",
+                  "properties": {
+                    "effective": true
+                  },
+                  "required": ["effective"]
+                }
+              },
+              "rev5": {
+                "not": {
+                  "type": "object",
+                  "properties": {
+                    "effective": true
+                  },
+                  "required": ["effective"]
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "20x": {
+                "type": "object",
+                "properties": {
+                  "effective": true
+                },
+                "required": ["effective"]
+              }
+            },
+            "required": ["20x"]
+          },
+          "then": {
+            "properties": {
+              "rev5": {
+                "type": "object",
+                "properties": {
+                  "effective": true
+                },
+                "required": ["effective"]
+              }
+            },
+            "required": ["rev5"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "rev5": {
+                "type": "object",
+                "properties": {
+                  "effective": true
+                },
+                "required": ["effective"]
+              }
+            },
+            "required": ["rev5"]
+          },
+          "then": {
+            "properties": {
+              "20x": {
+                "type": "object",
+                "properties": {
+                  "effective": true
+                },
+                "required": ["effective"]
+              }
+            },
+            "required": ["20x"]
+          }
+        }
+      ]
     },
     "effective_entry": {
       "type": "object",

--- a/schemas/fedramp-consolidated-rules.schema.json
+++ b/schemas/fedramp-consolidated-rules.schema.json
@@ -178,16 +178,16 @@
     "effective_map": {
       "type": "object",
       "properties": {
-        "both": { "$ref": "#/$defs/effective_entry" },
+        "all": { "$ref": "#/$defs/effective_entry" },
         "20x": { "$ref": "#/$defs/effective_entry" },
         "rev5": { "$ref": "#/$defs/effective_entry" }
       },
       "oneOf": [
         {
           "properties": {
-            "both": { "$ref": "#/$defs/effective_entry" }
+            "all": { "$ref": "#/$defs/effective_entry" }
           },
-          "required": ["both"],
+          "required": ["all"],
           "maxProperties": 1
         },
         {
@@ -241,9 +241,9 @@
     },
     "data_container_frd": {
       "type": "object",
-      "required": ["both"],
+      "required": ["all"],
       "properties": {
-        "both": { "$ref": "#/$defs/frd_definitions_map" },
+        "all": { "$ref": "#/$defs/frd_definitions_map" },
         "20x": { "$ref": "#/$defs/frd_definitions_map" },
         "rev5": { "$ref": "#/$defs/frd_definitions_map" }
       },
@@ -281,7 +281,7 @@
     "data_container_frr": {
       "type": "object",
       "properties": {
-        "both": { "$ref": "#/$defs/frr_requirements_map" },
+        "all": { "$ref": "#/$defs/frr_requirements_map" },
         "20x": { "$ref": "#/$defs/frr_requirements_map" },
         "rev5": { "$ref": "#/$defs/frr_requirements_map" }
       },
@@ -520,7 +520,7 @@
     "artifacts": {
       "type": "object",
       "properties": {
-        "both": { "$ref": "#/$defs/artifact_list" },
+        "all": { "$ref": "#/$defs/artifact_list" },
         "20x": { "$ref": "#/$defs/artifact_list" },
         "rev5": { "$ref": "#/$defs/artifact_list" }
       },

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,3 +1,5 @@
+.vscode
+
 # dependencies (bun install)
 node_modules
 

--- a/tools/export-spreadsheet.ts
+++ b/tools/export-spreadsheet.ts
@@ -10,7 +10,7 @@ function joinList(values: unknown): string {
   return values.filter((v): v is string => typeof v === "string").join("; ");
 }
 
-// artifacts: { "both"|"20x"|"rev5": { "all_classes"?: string[], "a"?: string[], ... } }
+// artifacts: { "all"|"20x"|"rev5": { "all_classes"?: string[], "a"?: string[], ... } }
 type ArtifactsByClass = Partial<Record<"all_classes" | "a" | "b" | "c" | "d", string[]>>;
 type ArtifactsField = Record<string, ArtifactsByClass>;
 

--- a/tools/fix.ts
+++ b/tools/fix.ts
@@ -1,3 +1,8 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { relative } from "node:path";
+
+import { format } from "prettier";
+
 import { green, getOptionValue, hasFlag, writeJsonFile } from "./src/cli";
 import { getResolvedPaths } from "./src/config";
 import {
@@ -60,6 +65,18 @@ const source = loadRulesDocument();
 const schema = loadSchemaDocument();
 const entryDate = dateOverride ?? source.info.last_updated;
 
+async function formatRulesFile(): Promise<void> {
+  const source = await readFile(rulesPath, "utf-8");
+  const formatted = await format(source, { filepath: rulesPath });
+  await writeFile(rulesPath, formatted, "utf-8");
+  console.log(green(`Formatted ${relative(process.cwd(), rulesPath)} with Prettier.`));
+}
+
+async function exitAfterFormatting(exitCode = 0): Promise<never> {
+  await formatRulesFile();
+  process.exit(exitCode);
+}
+
 console.log(`Using config: ${configPath}`);
 console.log(`Rules file: ${rulesPath}`);
 console.log(`Schema file: ${schemaPath}`);
@@ -79,7 +96,7 @@ if (scope === "auto") {
 
   if (!plan.needsTermsFix && !plan.needsIdsFix && !plan.needsOrderFix) {
     console.log(green("No automatic fixes were needed."));
-    process.exit(0);
+    await exitAfterFormatting();
   }
 
   const result = applyAutoFixes(cloneDocument(source), schema, {
@@ -113,18 +130,18 @@ if (scope === "auto") {
   const remaining = collectAutoFixPlan(result.document, schema);
   if (remaining.needsTermsFix || remaining.needsIdsFix || remaining.needsOrderFix) {
     console.error("Automatic fixes completed, but some fixable issues still remain.");
-    process.exit(1);
+    await exitAfterFormatting(1);
   }
 
   console.log(green("Applied all needed automatic fixes."));
-  process.exit(0);
+  await exitAfterFormatting();
 }
 
 if (scope === "terms") {
   const plan = collectTermsFixPlan(source);
   if (!plan.needsFix) {
     console.log(green("Terms are already synchronized."));
-    process.exit(0);
+    await exitAfterFormatting();
   }
 
   const result = applyTermsFix(cloneDocument(source), {
@@ -137,14 +154,14 @@ if (scope === "terms") {
       `Applied ${result.definitionTermFixedCount} definition fixes and synchronized ${result.termSyncFixedCount} entries.`,
     ),
   );
-  process.exit(0);
+  await exitAfterFormatting();
 }
 
 if (scope === "ids") {
   const plan = collectIdsFixPlan(source);
   if (!plan.needsFix) {
     console.log(green("All IDs are aligned with their parent keys."));
-    process.exit(0);
+    await exitAfterFormatting();
   }
 
   const result = applyIdsFix(cloneDocument(source), { entryDate });
@@ -161,15 +178,16 @@ if (scope === "ids") {
 
   writeDocument(result.document, outputPath);
   console.log(green(`Applied ${result.fixedCount} ID fixes.`));
-  process.exit(0);
+  await exitAfterFormatting();
 }
 
 const plan = collectOrderFixPlan(source, schema);
 if (!plan.needsFix) {
   console.log(green("All object properties follow the schema-defined order."));
-  process.exit(0);
+  await exitAfterFormatting();
 }
 
 const result = applyOrderFix(cloneDocument(source), schema);
 writeDocument(result.document, outputPath);
 console.log(green(`Applied ${result.fixedCount} property order fixes.`));
+await exitAfterFormatting();

--- a/tools/package.json
+++ b/tools/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "bun run typecheck && bun run test",
-    "test": "bun run test.ts",
+    "check": "bun run --silent typecheck && bun run --silent test",
+    "test": "bun run --silent test.ts",
     "typecheck": "tsc --noEmit",
     "fix": "bun run fix.ts",
     "summary": "bun run summary.ts",

--- a/tools/src/consistency.ts
+++ b/tools/src/consistency.ts
@@ -99,7 +99,9 @@ export function formatConsistencyReport(checks: ConsistencyCheck[]): string {
   ].join("\n");
 }
 
-export function collectConsistencyChecks(document: RulesDocument): ConsistencyCheck[] {
+export function collectConsistencyChecks(
+  document: RulesDocument,
+): ConsistencyCheck[] {
   return [
     {
       title: "Full ID alignment",
@@ -242,7 +244,10 @@ function collectIndicatorEntries(document: RulesDocument): Array<{
   for (const [themeKey, theme] of Object.entries(document.KSI ?? {})) {
     const indicators = Array.isArray(theme.indicators)
       ? Object.fromEntries(
-          theme.indicators.map((indicator, index) => [`${theme.id}-${index}`, indicator]),
+          theme.indicators.map((indicator, index) => [
+            `${theme.id}-${index}`,
+            indicator,
+          ]),
         )
       : theme.indicators;
 
@@ -272,7 +277,9 @@ function collectDefinitionEntries(document: RulesDocument): Array<{
     location: string;
   }> = [];
 
-  for (const [scopeKey, definitions] of Object.entries(document.FRD.data ?? {})) {
+  for (const [scopeKey, definitions] of Object.entries(
+    document.FRD.data ?? {},
+  )) {
     for (const [id, definition] of Object.entries(definitions ?? {})) {
       entries.push({
         scopeKey,
@@ -307,7 +314,9 @@ function walkJson(
   }
 }
 
-export function collectFullIdAlignmentIssues(document: RulesDocument): ConsistencyIssue[] {
+export function collectFullIdAlignmentIssues(
+  document: RulesDocument,
+): ConsistencyIssue[] {
   const issues: ConsistencyIssue[] = [];
 
   if (document.FRD.info.short_name !== "FRD") {
@@ -322,7 +331,10 @@ export function collectFullIdAlignmentIssues(document: RulesDocument): Consisten
   for (const entry of collectDefinitionEntries(document)) {
     if (!entry.id.startsWith("FRD-")) {
       issues.push(
-        issue(entry.location, `definition ID must start with FRD-, but found ${entry.id}.`),
+        issue(
+          entry.location,
+          `definition ID must start with FRD-, but found ${entry.id}.`,
+        ),
       );
     }
   }
@@ -342,7 +354,10 @@ export function collectFullIdAlignmentIssues(document: RulesDocument): Consisten
     const match = entry.id.match(FRR_ID_REGEX);
     if (!match) {
       issues.push(
-        issue(entry.location, `requirement ID ${entry.id} does not match ABC-LBL-XYZ format.`),
+        issue(
+          entry.location,
+          `requirement ID ${entry.id} does not match ABC-LBL-XYZ format.`,
+        ),
       );
       continue;
     }
@@ -390,7 +405,10 @@ export function collectFullIdAlignmentIssues(document: RulesDocument): Consisten
     const match = entry.id.match(KSI_ID_REGEX);
     if (!match) {
       issues.push(
-        issue(entry.location, `indicator ID ${entry.id} does not match KSI-ABC-XYZ format.`),
+        issue(
+          entry.location,
+          `indicator ID ${entry.id} does not match KSI-ABC-XYZ format.`,
+        ),
       );
       continue;
     }
@@ -409,19 +427,21 @@ export function collectFullIdAlignmentIssues(document: RulesDocument): Consisten
   return issues;
 }
 
-export function collectFrrLabelDeclarationIssues(document: RulesDocument): ConsistencyIssue[] {
+export function collectFrrLabelDeclarationIssues(
+  document: RulesDocument,
+): ConsistencyIssue[] {
   const issues: ConsistencyIssue[] = [];
 
   for (const [sectionKey, section] of Object.entries(document.FRR ?? {})) {
-    const declaredLabels = new Set(Object.keys(section.info.labels ?? {}));
-
     for (const [scopeKey, scope] of Object.entries(section.data ?? {})) {
+      const declaredLabels = collectDeclaredFrrLabels(section.info, scopeKey);
+
       for (const labelKey of Object.keys(scope ?? {})) {
         if (!declaredLabels.has(labelKey)) {
           issues.push(
             issue(
               `FRR.${sectionKey}.data.${scopeKey}.${labelKey}`,
-              `label bucket ${labelKey} is used in data but is not declared in FRR.${sectionKey}.info.labels.`,
+              `label bucket ${labelKey} is used in data but is not declared in FRR.${sectionKey}.info labels for the ${scopeKey} applicability scope.`,
             ),
           );
         }
@@ -430,6 +450,36 @@ export function collectFrrLabelDeclarationIssues(document: RulesDocument): Consi
   }
 
   return issues;
+}
+
+function collectDeclaredFrrLabels(
+  info: Record<string, unknown>,
+  scopeKey: string,
+): Set<string> {
+  const labels = new Set(Object.keys(getRecordProperty(info, "labels") ?? {}));
+
+  if (scopeKey === "20x" || scopeKey === "rev5") {
+    const certificationInfo = getRecordProperty(info, scopeKey);
+    for (const label of Object.keys(
+      getRecordProperty(certificationInfo, "labels") ?? {},
+    )) {
+      labels.add(label);
+    }
+  }
+
+  return labels;
+}
+
+function getRecordProperty(
+  value: Record<string, unknown> | undefined,
+  key: string,
+): Record<string, unknown> | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const property = value[key];
+  return isRecord(property) ? property : undefined;
 }
 
 function collectUpdatedHistoryIssues(
@@ -454,7 +504,9 @@ function collectUpdatedHistoryIssues(
     );
   }
 
-  const expectedOrder = [...dates].sort((left, right) => right.localeCompare(left));
+  const expectedOrder = [...dates].sort((left, right) =>
+    right.localeCompare(left),
+  );
   if (dates.some((date, index) => date !== expectedOrder[index])) {
     issues.push(
       issue(
@@ -467,7 +519,9 @@ function collectUpdatedHistoryIssues(
   return issues;
 }
 
-export function collectAuditHistoryIssues(document: RulesDocument): ConsistencyIssue[] {
+export function collectAuditHistoryIssues(
+  document: RulesDocument,
+): ConsistencyIssue[] {
   return [
     ...collectDefinitionEntries(document).flatMap((entry) =>
       collectUpdatedHistoryIssues(entry.location, entry.definition.updated),
@@ -481,7 +535,9 @@ export function collectAuditHistoryIssues(document: RulesDocument): ConsistencyI
   ];
 }
 
-export function collectTextHygieneIssues(document: RulesDocument): ConsistencyIssue[] {
+export function collectTextHygieneIssues(
+  document: RulesDocument,
+): ConsistencyIssue[] {
   const issues: ConsistencyIssue[] = [];
 
   walkJson(document, [], (value, path) => {
@@ -494,7 +550,9 @@ export function collectTextHygieneIssues(document: RulesDocument): ConsistencyIs
       issues.push(issue(location, "text value must not be empty."));
     }
     if (value !== value.trim()) {
-      issues.push(issue(location, "text value has leading or trailing whitespace."));
+      issues.push(
+        issue(location, "text value has leading or trailing whitespace."),
+      );
     }
     if (TEXT_CONTROL_CHARACTER_REGEX.test(value)) {
       issues.push(issue(location, "text value contains a control character."));
@@ -504,7 +562,9 @@ export function collectTextHygieneIssues(document: RulesDocument): ConsistencyIs
   return issues;
 }
 
-export function collectClassVariantStatementIssues(document: RulesDocument): ConsistencyIssue[] {
+export function collectClassVariantStatementIssues(
+  document: RulesDocument,
+): ConsistencyIssue[] {
   const issues: ConsistencyIssue[] = [];
 
   walkJson(document, [], (value, path) => {
@@ -528,7 +588,9 @@ export function collectClassVariantStatementIssues(document: RulesDocument): Con
       }
 
       const expectedClass = CLASS_NAMES[classKey];
-      const unexpectedClasses = mentionedClasses.filter((className) => className !== expectedClass);
+      const unexpectedClasses = mentionedClasses.filter(
+        (className) => className !== expectedClass,
+      );
       if (unexpectedClasses.length > 0) {
         issues.push(
           issue(
@@ -594,19 +656,27 @@ export function collectArtifactApplicabilityIssues(
   return issues;
 }
 
-function collectAffectsIssues(location: string, requirement: Requirement): ConsistencyIssue[] {
+function collectAffectsIssues(
+  location: string,
+  requirement: Requirement,
+): ConsistencyIssue[] {
   const issues: ConsistencyIssue[] = [];
   const affects = requirement.affects ?? [];
 
   if (affects.length === 0) {
-    issues.push(issue(`${location}.affects`, "affects must list at least one party."));
+    issues.push(
+      issue(`${location}.affects`, "affects must list at least one party."),
+    );
     return issues;
   }
 
   const duplicateAffects = collectDuplicateValues(affects);
   if (duplicateAffects.length > 0) {
     issues.push(
-      issue(`${location}.affects`, `affects contains duplicate values: ${duplicateAffects.join(", ")}.`),
+      issue(
+        `${location}.affects`,
+        `affects contains duplicate values: ${duplicateAffects.join(", ")}.`,
+      ),
     );
   }
 
@@ -624,16 +694,25 @@ function collectAffectsIssues(location: string, requirement: Requirement): Consi
   return issues;
 }
 
-function collectControlIssues(location: string, entity: RequirementLike): ConsistencyIssue[] {
+function collectControlIssues(
+  location: string,
+  entity: RequirementLike,
+): ConsistencyIssue[] {
   const issues: ConsistencyIssue[] = [];
-  const controls = isRecord(entity) && Array.isArray(entity.controls)
-    ? entity.controls.filter((control): control is string => typeof control === "string")
-    : [];
+  const controls =
+    isRecord(entity) && Array.isArray(entity.controls)
+      ? entity.controls.filter(
+          (control): control is string => typeof control === "string",
+        )
+      : [];
 
   const duplicateControls = collectDuplicateValues(controls);
   if (duplicateControls.length > 0) {
     issues.push(
-      issue(`${location}.controls`, `controls contains duplicate IDs: ${duplicateControls.join(", ")}.`),
+      issue(
+        `${location}.controls`,
+        `controls contains duplicate IDs: ${duplicateControls.join(", ")}.`,
+      ),
     );
   }
 
@@ -651,7 +730,10 @@ function collectControlIssues(location: string, entity: RequirementLike): Consis
   return issues;
 }
 
-function collectTimeframeIssues(value: unknown, path: JsonPathSegment[]): ConsistencyIssue[] {
+function collectTimeframeIssues(
+  value: unknown,
+  path: JsonPathSegment[],
+): ConsistencyIssue[] {
   const issues: ConsistencyIssue[] = [];
 
   walkJson(value, path, (node, nodePath) => {
@@ -676,7 +758,11 @@ function collectTimeframeIssues(value: unknown, path: JsonPathSegment[]): Consis
     }
 
     if (hasType && typeof node.timeframe_type === "string") {
-      if (!(ALLOWED_TIMEFRAME_TYPES as readonly string[]).includes(node.timeframe_type)) {
+      if (
+        !(ALLOWED_TIMEFRAME_TYPES as readonly string[]).includes(
+          node.timeframe_type,
+        )
+      ) {
         issues.push(
           issue(
             `${location}.timeframe_type`,
@@ -686,9 +772,16 @@ function collectTimeframeIssues(value: unknown, path: JsonPathSegment[]): Consis
       }
     }
 
-    if (hasNum && typeof node.timeframe_num === "number" && node.timeframe_num <= 0) {
+    if (
+      hasNum &&
+      typeof node.timeframe_num === "number" &&
+      node.timeframe_num <= 0
+    ) {
       issues.push(
-        issue(`${location}.timeframe_num`, "timeframe_num must be greater than zero."),
+        issue(
+          `${location}.timeframe_num`,
+          "timeframe_num must be greater than zero.",
+        ),
       );
     }
   });
@@ -696,7 +789,10 @@ function collectTimeframeIssues(value: unknown, path: JsonPathSegment[]): Consis
   return issues;
 }
 
-function collectNotificationIssues(value: unknown, path: JsonPathSegment[]): ConsistencyIssue[] {
+function collectNotificationIssues(
+  value: unknown,
+  path: JsonPathSegment[],
+): ConsistencyIssue[] {
   const issues: ConsistencyIssue[] = [];
 
   walkJson(value, path, (node, nodePath) => {
@@ -712,7 +808,9 @@ function collectNotificationIssues(value: unknown, path: JsonPathSegment[]): Con
       const location = `${formatPath(nodePath)}.notification[${index}]`;
       if (
         typeof notification.method === "string" &&
-        !(ALLOWED_NOTIFICATION_METHODS as readonly string[]).includes(notification.method)
+        !(ALLOWED_NOTIFICATION_METHODS as readonly string[]).includes(
+          notification.method,
+        )
       ) {
         issues.push(
           issue(
@@ -724,7 +822,9 @@ function collectNotificationIssues(value: unknown, path: JsonPathSegment[]): Con
 
       if (
         typeof notification.party === "string" &&
-        !(ALLOWED_NOTIFICATION_PARTIES as readonly string[]).includes(notification.party)
+        !(ALLOWED_NOTIFICATION_PARTIES as readonly string[]).includes(
+          notification.party,
+        )
       ) {
         issues.push(
           issue(
@@ -739,7 +839,9 @@ function collectNotificationIssues(value: unknown, path: JsonPathSegment[]): Con
   return issues;
 }
 
-export function collectControlledVocabularyIssues(document: RulesDocument): ConsistencyIssue[] {
+export function collectControlledVocabularyIssues(
+  document: RulesDocument,
+): ConsistencyIssue[] {
   const issues: ConsistencyIssue[] = [];
 
   visitRequirements(document, ({ location, requirement }) => {
@@ -761,14 +863,19 @@ function normalizeTermCandidate(candidate: string): string {
   return candidate.trim().toLowerCase();
 }
 
-export function collectFrdTermLookupIssues(document: RulesDocument): ConsistencyIssue[] {
+export function collectFrdTermLookupIssues(
+  document: RulesDocument,
+): ConsistencyIssue[] {
   const candidateMap = new Map<
     string,
     Map<string, { id: string; term: string; location: string }>
   >();
 
   for (const entry of collectDefinitionEntries(document)) {
-    const candidates = [entry.definition.term, ...(entry.definition.alts ?? [])];
+    const candidates = [
+      entry.definition.term,
+      ...(entry.definition.alts ?? []),
+    ];
     for (const candidate of candidates) {
       const normalized = normalizeTermCandidate(candidate);
       const definitions = candidateMap.get(normalized) ?? new Map();
@@ -798,7 +905,9 @@ export function collectFrdTermLookupIssues(document: RulesDocument): Consistency
     );
   }
 
-  return issues.sort((left, right) => left.message.localeCompare(right.message));
+  return issues.sort((left, right) =>
+    left.message.localeCompare(right.message),
+  );
 }
 
 function collectReferenceIds(document: RulesDocument): {
@@ -806,8 +915,12 @@ function collectReferenceIds(document: RulesDocument): {
   indicatorIds: Set<string>;
   webNames: Set<string>;
 } {
-  const requirementIds = new Set(collectRequirementEntries(document).map((entry) => entry.id));
-  const indicatorIds = new Set(collectIndicatorEntries(document).map((entry) => entry.id));
+  const requirementIds = new Set(
+    collectRequirementEntries(document).map((entry) => entry.id),
+  );
+  const indicatorIds = new Set(
+    collectIndicatorEntries(document).map((entry) => entry.id),
+  );
   const webNames = new Set<string>();
 
   for (const section of Object.values(document.FRR ?? {})) {
@@ -824,9 +937,12 @@ function collectReferenceIds(document: RulesDocument): {
   return { requirementIds, indicatorIds, webNames };
 }
 
-export function collectCrossReferenceIssues(document: RulesDocument): ConsistencyIssue[] {
+export function collectCrossReferenceIssues(
+  document: RulesDocument,
+): ConsistencyIssue[] {
   const issues: ConsistencyIssue[] = [];
-  const { requirementIds, indicatorIds, webNames } = collectReferenceIds(document);
+  const { requirementIds, indicatorIds, webNames } =
+    collectReferenceIds(document);
 
   walkJson(document, [], (value, path) => {
     const location = formatPath(path);
@@ -852,7 +968,9 @@ export function collectCrossReferenceIssues(document: RulesDocument): Consistenc
         continue;
       }
       if (!indicatorIds.has(id)) {
-        issues.push(issue(location, `referenced KSI indicator ID ${id} does not exist.`));
+        issues.push(
+          issue(location, `referenced KSI indicator ID ${id} does not exist.`),
+        );
       }
     }
 
@@ -862,7 +980,12 @@ export function collectCrossReferenceIssues(document: RulesDocument): Consistenc
         continue;
       }
       if (!requirementIds.has(id)) {
-        issues.push(issue(location, `referenced FRR requirement ID ${id} does not exist.`));
+        issues.push(
+          issue(
+            location,
+            `referenced FRR requirement ID ${id} does not exist.`,
+          ),
+        );
       }
     }
   });

--- a/tools/src/consistency.ts
+++ b/tools/src/consistency.ts
@@ -23,7 +23,7 @@ type JsonPathSegment = string | number;
 type JsonRecord = Record<string, unknown>;
 
 const CLASS_KEYS = ["a", "b", "c", "d"] as const;
-const APPLICABILITY_KEYS = ["both", "20x", "rev5"] as const;
+const APPLICABILITY_KEYS = ["all", "20x", "rev5"] as const;
 type ApplicabilityKey = (typeof APPLICABILITY_KEYS)[number];
 const CLASS_NAMES: Record<ClassKey, string> = {
   a: "Class A",
@@ -35,7 +35,7 @@ const ALLOWED_ARTIFACT_KEYS_BY_PARENT: Record<
   ApplicabilityKey,
   readonly ApplicabilityKey[]
 > = {
-  both: APPLICABILITY_KEYS,
+  all: APPLICABILITY_KEYS,
   "20x": ["20x"],
   rev5: ["rev5"],
 };

--- a/tools/src/consistency.ts
+++ b/tools/src/consistency.ts
@@ -88,15 +88,20 @@ export function formatConsistencyReport(checks: ConsistencyCheck[]): string {
     0,
   );
   const issueLabel = issueCount === 1 ? "issue" : "issues";
-
-  return [
-    `Consistency validation failed with ${issueCount} ${issueLabel}.`,
-    "",
-    ...failedChecks.flatMap((check) => [
-      formatConsistencyIssues(check.title, check.issues),
-      "",
-    ]),
+  const summaryIssues = failedChecks.flatMap((check) =>
+    check.issues.map(
+      (issue) => `- ${check.title}: ${issue.location}: ${issue.message}`,
+    ),
+  );
+  const summary = [
+    `Consistency validation failed with ${issueCount} ${issueLabel}:`,
+    ...summaryIssues,
   ].join("\n");
+  const checkReports = failedChecks.map((check) =>
+    formatConsistencyIssues(check.title, check.issues),
+  );
+
+  return [summary, ...checkReports].join("\n\n");
 }
 
 export function collectConsistencyChecks(

--- a/tools/src/consistency.ts
+++ b/tools/src/consistency.ts
@@ -59,6 +59,7 @@ const ALLOWED_NOTIFICATION_PARTIES = [
   "Provider",
   "all necessary parties",
   "public",
+  "Agency Customers",
 ] as const;
 const ALLOWED_TIMEFRAME_TYPES = [
   "bizdays",

--- a/tools/src/property-order.ts
+++ b/tools/src/property-order.ts
@@ -160,7 +160,7 @@ function getPreferredOrder(
   value: JsonObject,
   path: string,
 ): string[] {
-  if (path === "FRD.data.both") {
+  if (path === "FRD.data.all") {
     return Object.entries(value)
       .sort(compareFrdDefinitionEntries)
       .map(([key]) => key);

--- a/tools/src/property-order.ts
+++ b/tools/src/property-order.ts
@@ -29,7 +29,10 @@ function resolveRef(rootSchema: JsonSchema, ref: string): JsonSchema | null {
   return isRecord(current) ? current : null;
 }
 
-function dereferenceSchema(rootSchema: JsonSchema, schema: unknown): JsonSchema | null {
+function dereferenceSchema(
+  rootSchema: JsonSchema,
+  schema: unknown,
+): JsonSchema | null {
   if (!isRecord(schema)) {
     return null;
   }
@@ -58,7 +61,9 @@ function getPropertiesSchema(schema: JsonSchema | null): JsonObject | null {
   return schema.properties;
 }
 
-function getPatternPropertiesSchema(schema: JsonSchema | null): JsonObject | null {
+function getPatternPropertiesSchema(
+  schema: JsonSchema | null,
+): JsonObject | null {
   if (!schema || !isRecord(schema.patternProperties)) {
     return null;
   }
@@ -66,7 +71,9 @@ function getPatternPropertiesSchema(schema: JsonSchema | null): JsonObject | nul
   return schema.patternProperties;
 }
 
-function getAdditionalPropertiesSchema(schema: JsonSchema | null): JsonSchema | null {
+function getAdditionalPropertiesSchema(
+  schema: JsonSchema | null,
+): JsonSchema | null {
   if (!schema || !isRecord(schema.additionalProperties)) {
     return null;
   }
@@ -90,14 +97,19 @@ function getPropertyNamesSchema(schema: JsonSchema | null): JsonSchema | null {
   return schema.propertyNames;
 }
 
-function getOrderedNamesFromSchema(rootSchema: JsonSchema, schema: unknown): string[] | null {
+function getOrderedNamesFromSchema(
+  rootSchema: JsonSchema,
+  schema: unknown,
+): string[] | null {
   const resolvedSchema = dereferenceSchema(rootSchema, schema);
   if (!resolvedSchema) {
     return null;
   }
 
   if (Array.isArray(resolvedSchema.enum)) {
-    const enumValues = resolvedSchema.enum.filter((value): value is string => typeof value === "string");
+    const enumValues = resolvedSchema.enum.filter(
+      (value): value is string => typeof value === "string",
+    );
     if (enumValues.length > 0) {
       return enumValues;
     }
@@ -151,7 +163,29 @@ function compareFrdDefinitionEntries(
   const rightTerm = getFrdDefinitionTerm(right[1]) ?? right[0];
   const termComparison = leftTerm.localeCompare(rightTerm);
 
-  return termComparison === 0 ? left[0].localeCompare(right[0]) : termComparison;
+  return termComparison === 0
+    ? left[0].localeCompare(right[0])
+    : termComparison;
+}
+
+function formatPropertyList(values: string[]): string {
+  return values.join(", ");
+}
+
+export function formatPropertyOrderReport(
+  issues: PropertyOrderIssue[],
+): string {
+  const issueLabel = issues.length === 1 ? "issue" : "issues";
+
+  return [
+    `Schema-defined property order failed with ${issues.length} ${issueLabel}:`,
+    ...issues.map(
+      (issue) =>
+        `- ${issue.path}: expected order ${formatPropertyList(
+          issue.expectedOrder,
+        )}; found order ${formatPropertyList(issue.actualOrder)}.`,
+    ),
+  ].join("\n");
 }
 
 function getPreferredOrder(
@@ -169,7 +203,7 @@ function getPreferredOrder(
   const properties = getPropertiesSchema(schema);
   const propertyNameSchema = getPropertyNamesSchema(schema);
   const propertyNameOrder = propertyNameSchema
-    ? getOrderedNamesFromSchema(rootSchema, propertyNameSchema) ?? []
+    ? (getOrderedNamesFromSchema(rootSchema, propertyNameSchema) ?? [])
     : [];
 
   const preferredKeys = properties ? Object.keys(properties) : [];
@@ -186,12 +220,18 @@ function getPreferredOrder(
   }
 
   const presentPreferredKeys = orderedKeys.filter((key) => key in value);
-  const remainingKeys = Object.keys(value).filter((key) => !orderedKeys.includes(key));
+  const remainingKeys = Object.keys(value).filter(
+    (key) => !orderedKeys.includes(key),
+  );
 
   return [...presentPreferredKeys, ...remainingKeys];
 }
 
-function getChildSchema(rootSchema: JsonSchema, parentSchema: JsonSchema | null, key: string): JsonSchema | null {
+function getChildSchema(
+  rootSchema: JsonSchema,
+  parentSchema: JsonSchema | null,
+  key: string,
+): JsonSchema | null {
   const properties = getPropertiesSchema(parentSchema);
   if (properties && isRecord(properties[key])) {
     return properties[key];
@@ -230,7 +270,13 @@ function collectIssuesForValue(
     }
 
     value.forEach((item, index) => {
-      collectIssuesForValue(item, itemsSchema, rootSchema, `${path}[${index}]`, issues);
+      collectIssuesForValue(
+        item,
+        itemsSchema,
+        rootSchema,
+        `${path}[${index}]`,
+        issues,
+      );
     });
     return;
   }
@@ -240,9 +286,17 @@ function collectIssuesForValue(
   }
 
   const actualOrder = Object.keys(value);
-  const expectedOrder = getPreferredOrder(rootSchema, resolvedSchema, value, path);
+  const expectedOrder = getPreferredOrder(
+    rootSchema,
+    resolvedSchema,
+    value,
+    path,
+  );
 
-  if (actualOrder.length > 1 && actualOrder.some((key, index) => key !== expectedOrder[index])) {
+  if (
+    actualOrder.length > 1 &&
+    actualOrder.some((key, index) => key !== expectedOrder[index])
+  ) {
     issues.push({
       path,
       actualOrder,
@@ -257,7 +311,13 @@ function collectIssuesForValue(
     }
 
     const childPath = path ? `${path}.${key}` : key;
-    collectIssuesForValue(childValue, childSchema, rootSchema, childPath, issues);
+    collectIssuesForValue(
+      childValue,
+      childSchema,
+      rootSchema,
+      childPath,
+      issues,
+    );
   }
 }
 
@@ -290,14 +350,28 @@ function reorderValue(
   for (const [key, childValue] of Object.entries(value)) {
     const childSchema = getChildSchema(rootSchema, resolvedSchema, key);
     withReorderedChildren[key] = childSchema
-      ? reorderValue(childValue, childSchema, rootSchema, path ? `${path}.${key}` : key, issues)
+      ? reorderValue(
+          childValue,
+          childSchema,
+          rootSchema,
+          path ? `${path}.${key}` : key,
+          issues,
+        )
       : childValue;
   }
 
   const actualOrder = Object.keys(withReorderedChildren);
-  const expectedOrder = getPreferredOrder(rootSchema, resolvedSchema, withReorderedChildren, path);
+  const expectedOrder = getPreferredOrder(
+    rootSchema,
+    resolvedSchema,
+    withReorderedChildren,
+    path,
+  );
 
-  if (actualOrder.length > 1 && actualOrder.some((key, index) => key !== expectedOrder[index])) {
+  if (
+    actualOrder.length > 1 &&
+    actualOrder.some((key, index) => key !== expectedOrder[index])
+  ) {
     issues.push({
       path,
       actualOrder,
@@ -317,7 +391,10 @@ export function collectPropertyOrderIssues(
   document: RulesDocument,
   schemaDocument: unknown,
 ): PropertyOrderIssue[] {
-  const rootSchema = dereferenceSchema(schemaDocument as JsonSchema, schemaDocument);
+  const rootSchema = dereferenceSchema(
+    schemaDocument as JsonSchema,
+    schemaDocument,
+  );
   if (!rootSchema) {
     return [];
   }
@@ -330,8 +407,15 @@ export function collectPropertyOrderIssues(
 export function fixPropertyOrder(
   document: RulesDocument,
   schemaDocument: unknown,
-): { document: RulesDocument; issues: PropertyOrderIssue[]; fixedCount: number } {
-  const rootSchema = dereferenceSchema(schemaDocument as JsonSchema, schemaDocument);
+): {
+  document: RulesDocument;
+  issues: PropertyOrderIssue[];
+  fixedCount: number;
+} {
+  const rootSchema = dereferenceSchema(
+    schemaDocument as JsonSchema,
+    schemaDocument,
+  );
   if (!rootSchema) {
     return {
       document,
@@ -341,7 +425,13 @@ export function fixPropertyOrder(
   }
 
   const issues: PropertyOrderIssue[] = [];
-  const reorderedDocument = reorderValue(document, rootSchema, rootSchema, "", issues) as RulesDocument;
+  const reorderedDocument = reorderValue(
+    document,
+    rootSchema,
+    rootSchema,
+    "",
+    issues,
+  ) as RulesDocument;
 
   return {
     document: reorderedDocument,

--- a/tools/src/summary-rules.ts
+++ b/tools/src/summary-rules.ts
@@ -5,7 +5,13 @@ import { getRepoRoot } from "./config";
 import { loadRulesDocument } from "./rules";
 import type { Requirement, RulesDocument, UpdatedEntry } from "./types";
 
-const DEFAULT_KEYWORD_ORDER = ["MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY"];
+const DEFAULT_KEYWORD_ORDER = [
+  "MUST",
+  "MUST NOT",
+  "SHOULD",
+  "SHOULD NOT",
+  "MAY",
+];
 
 interface ProcessSummary {
   shortName: string;
@@ -42,7 +48,10 @@ function getInfoString(
   return typeof current === "string" && current.length > 0 ? current : fallback;
 }
 
-function incrementKeywordCount(keywordCounts: Map<string, number>, keyword?: string): void {
+function incrementKeywordCount(
+  keywordCounts: Map<string, number>,
+  keyword?: string,
+): void {
   if (!keyword) {
     return;
   }
@@ -62,7 +71,10 @@ function getLatestUpdatedDate(updated?: UpdatedEntry[]): string | null {
   return latest;
 }
 
-function updateLatestDate(currentLatest: string | null, candidate: string | null): string | null {
+function updateLatestDate(
+  currentLatest: string | null,
+  candidate: string | null,
+): string | null {
   if (!candidate) {
     return currentLatest;
   }
@@ -74,31 +86,72 @@ function updateLatestDate(currentLatest: string | null, candidate: string | null
   return currentLatest;
 }
 
+function getInfoRecord(
+  value: Record<string, unknown>,
+  path: string[],
+): Record<string, unknown> | null {
+  let current: unknown = value;
+
+  for (const segment of path) {
+    if (!current || typeof current !== "object" || Array.isArray(current)) {
+      return null;
+    }
+
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  return current && typeof current === "object" && !Array.isArray(current)
+    ? (current as Record<string, unknown>)
+    : null;
+}
+
+function getEffectiveInfo(
+  value: Record<string, unknown>,
+  framework: "rev5" | "20x",
+): Record<string, unknown> | null {
+  return (
+    getInfoRecord(value, [framework, "effective"]) ??
+    getInfoRecord(value, ["effective"])
+  );
+}
+
 function getEffectiveDate(
   value: Record<string, unknown>,
   framework: "rev5" | "20x",
   dateKey: "obtain" | "maintain" | "grace_ends",
 ): string {
-  const applicability = getInfoString(value, ["effective", framework, "is"], "");
+  const effective = getEffectiveInfo(value, framework);
+  if (!effective) {
+    return "N/A";
+  }
+
+  const applicability = getInfoString(effective, ["is"], "");
   if (applicability === "no") {
     return "N/A";
   }
 
-  return getInfoString(value, ["effective", framework, "date", dateKey], "N/A");
+  return getInfoString(effective, ["date", dateKey], "N/A");
 }
 
-function summarizeProcess(shortName: string, process: RulesDocument["FRR"][string]): ProcessSummary {
+function summarizeProcess(
+  shortName: string,
+  process: RulesDocument["FRR"][string],
+): ProcessSummary {
   const keywordCounts = new Map<string, number>();
   let latestUpdated: string | null = null;
   let requirementCount = 0;
 
   for (const labelGroups of Object.values(process.data)) {
     for (const rulesById of Object.values(labelGroups)) {
-      for (const requirement of Object.values(rulesById as Record<string, Requirement>)) {
+      for (const requirement of Object.values(
+        rulesById as Record<string, Requirement>,
+      )) {
         requirementCount += 1;
         incrementKeywordCount(keywordCounts, requirement.primary_key_word);
 
-        for (const classVariant of Object.values(requirement.varies_by_class ?? {})) {
+        for (const classVariant of Object.values(
+          requirement.varies_by_class ?? {},
+        )) {
           incrementKeywordCount(keywordCounts, classVariant?.primary_key_word);
         }
 
@@ -115,11 +168,15 @@ function summarizeProcess(shortName: string, process: RulesDocument["FRR"][strin
     name: getInfoString(process.info, ["name"]),
     documentStatus: getInfoString(process.info, ["status"]),
     requirementCount,
-    rev5Status: getInfoString(process.info, ["effective", "rev5", "current_status"]),
+    rev5Status: getInfoString(getEffectiveInfo(process.info, "rev5") ?? {}, [
+      "current_status",
+    ]),
     rev5ObtainDate: getEffectiveDate(process.info, "rev5", "obtain"),
     rev5MaintainDate: getEffectiveDate(process.info, "rev5", "maintain"),
     rev5GraceEndsDate: getEffectiveDate(process.info, "rev5", "grace_ends"),
-    twentyXStatus: getInfoString(process.info, ["effective", "20x", "current_status"]),
+    twentyXStatus: getInfoString(getEffectiveInfo(process.info, "20x") ?? {}, [
+      "current_status",
+    ]),
     twentyXObtainDate: getEffectiveDate(process.info, "20x", "obtain"),
     twentyXMaintainDate: getEffectiveDate(process.info, "20x", "maintain"),
     twentyXGraceEndsDate: getEffectiveDate(process.info, "20x", "grace_ends"),
@@ -137,7 +194,9 @@ function getKeywordColumns(summaries: ProcessSummary[]): string[] {
     }
   }
 
-  const ordered = DEFAULT_KEYWORD_ORDER.filter((keyword) => discovered.has(keyword));
+  const ordered = DEFAULT_KEYWORD_ORDER.filter((keyword) =>
+    discovered.has(keyword),
+  );
   const additional = [...discovered]
     .filter((keyword) => !DEFAULT_KEYWORD_ORDER.includes(keyword))
     .sort((left, right) => left.localeCompare(right));
@@ -149,7 +208,10 @@ function escapeTableCell(value: string): string {
   return value.replaceAll("|", "\\|");
 }
 
-function renderTable(summaries: ProcessSummary[], keywordColumns: string[]): string {
+function renderTable(
+  summaries: ProcessSummary[],
+  keywordColumns: string[],
+): string {
   const header = [
     "Short Name",
     "Name",
@@ -191,7 +253,9 @@ function renderTable(summaries: ProcessSummary[], keywordColumns: string[]): str
     ];
   });
 
-  return [header, divider, ...rows].map((row) => `| ${row.join(" | ")} |`).join("\n");
+  return [header, divider, ...rows]
+    .map((row) => `| ${row.join(" | ")} |`)
+    .join("\n");
 }
 
 function countFrdDefinitions(document: RulesDocument): number {

--- a/tools/test.ts
+++ b/tools/test.ts
@@ -1,8 +1,98 @@
 import {
   collectConsistencyChecks,
-  formatConsistencyReport,
+  type ConsistencyCheck,
 } from "./src/consistency";
-import { loadRulesDocument } from "./src/rules";
+import { collectPropertyOrderIssues } from "./src/property-order";
+import { loadRulesDocument, loadSchemaDocument } from "./src/rules";
+import type { PropertyOrderIssue } from "./src/types";
+
+const RED = "\x1b[31m";
+const YELLOW = "\x1b[33m";
+const GREEN = "\x1b[32m";
+const CYAN = "\x1b[36m";
+const BOLD = "\x1b[1m";
+const DIM = "\x1b[2m";
+const RESET = "\x1b[0m";
+
+function useColor(): boolean {
+  return !process.env.NO_COLOR && process.env.TERM !== "dumb";
+}
+
+function color(value: string, code: string): string {
+  if (!useColor()) {
+    return value;
+  }
+
+  return `${code}${value}${RESET}`;
+}
+
+function plural(count: number, singular: string): string {
+  return count === 1 ? singular : `${singular}s`;
+}
+
+function formatPath(path: string): string {
+  return color(path, CYAN);
+}
+
+function formatProblem(value: string): string {
+  return color(value, RED);
+}
+
+function formatExpected(values: string[]): string {
+  return color(values.join(", "), GREEN);
+}
+
+function formatActual(values: string[]): string {
+  return color(values.join(", "), YELLOW);
+}
+
+function formatConsistencyFailureSummary(checks: ConsistencyCheck[]): string {
+  const failedChecks = checks.filter((check) => check.issues.length > 0);
+  const issueCount = failedChecks.reduce(
+    (total, check) => total + check.issues.length,
+    0,
+  );
+  const lines = [
+    `${formatProblem("Consistency validation failed")} with ${formatProblem(
+      `${issueCount} ${plural(issueCount, "issue")}`,
+    )}:`,
+  ];
+
+  for (const check of failedChecks) {
+    lines.push(
+      "",
+      `${color(check.title, BOLD)} ${color(
+        `(${check.issues.length} ${plural(check.issues.length, "issue")})`,
+        DIM,
+      )}`,
+    );
+
+    for (const issue of check.issues) {
+      lines.push("", `  - ${formatPath(issue.location)}`);
+      lines.push(`    ${issue.message}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function formatPropertyOrderFailureSummary(
+  issues: PropertyOrderIssue[],
+): string {
+  const lines = [
+    `${formatProblem(
+      "Schema-defined property order failed",
+    )} with ${formatProblem(`${issues.length} ${plural(issues.length, "issue")}`)}:`,
+  ];
+
+  for (const issue of issues) {
+    lines.push("", `  - ${formatPath(issue.path)}`);
+    lines.push(`    expected: ${formatExpected(issue.expectedOrder)}`);
+    lines.push(`    found:    ${formatActual(issue.actualOrder)}`);
+  }
+
+  return lines.join("\n");
+}
 
 const testResult = Bun.spawnSync({
   cmd: ["bun", "test"],
@@ -10,17 +100,36 @@ const testResult = Bun.spawnSync({
   stderr: "inherit",
 });
 
-const consistencyChecks = collectConsistencyChecks(loadRulesDocument());
-const consistencyFailed = consistencyChecks.some((check) => check.issues.length > 0);
+const rulesDocument = loadRulesDocument();
+const schemaDocument = loadSchemaDocument();
+const consistencyChecks = collectConsistencyChecks(rulesDocument);
+const consistencyFailed = consistencyChecks.some(
+  (check) => check.issues.length > 0,
+);
+const propertyOrderIssues = collectPropertyOrderIssues(
+  rulesDocument,
+  schemaDocument,
+);
+const propertyOrderFailed = propertyOrderIssues.length > 0;
+const finalReports: string[] = [];
 
 if (consistencyFailed) {
-  console.error("");
-  console.error("");
-  console.error("=".repeat(80));
-  console.error("");
-  console.error("Final consistency validation summary:");
-  console.error("");
-  console.error(formatConsistencyReport(consistencyChecks));
+  finalReports.push(formatConsistencyFailureSummary(consistencyChecks));
 }
 
-process.exit(testResult.exitCode ?? 1);
+if (propertyOrderFailed) {
+  finalReports.push(formatPropertyOrderFailureSummary(propertyOrderIssues));
+}
+
+if (finalReports.length > 0) {
+  console.error(
+    `\n${color("-----", DIM)}\n\n${color(
+      "⚠️ 🙈",
+      `${BOLD}${RED}`,
+    )}\n\n${finalReports.map((report) => report.trimEnd()).join("\n\n")}\n\n`,
+  );
+}
+
+process.exit(
+  consistencyFailed || propertyOrderFailed ? 1 : (testResult.exitCode ?? 1),
+);

--- a/tools/tests/artifact-applicability.test.ts
+++ b/tools/tests/artifact-applicability.test.ts
@@ -27,7 +27,7 @@ test("artifact applicability permits all keys under all and matching keys under 
   (document as any).FRR.FRC.data["20x"].CSX["FRC-CSX-MAS"].artifacts = {
     "20x": ["20x-only evidence."],
   };
-  (document as any).FRR.CDS.data.rev5.CSL["CDS-CSL-SCD"].artifacts = {
+  (document as any).FRR.CDS.data.rev5.CSF["CDS-CSF-SCD"].artifacts = {
     rev5: ["Rev5-only evidence."],
   };
 
@@ -49,12 +49,12 @@ test("artifact applicability reports human-readable errors for mismatched keys",
   ].varies_by_class.b.artifacts = {
     rev5: ["Wrong class-level evidence."],
   };
-  (document as any).FRR.CDS.data.rev5.CSL["CDS-CSL-SCD"].artifacts = {
+  (document as any).FRR.CDS.data.rev5.CSF["CDS-CSF-SCD"].artifacts = {
     "20x": ["Wrong parent evidence."],
     rev5: ["Allowed evidence."],
   };
-  (document as any).FRR.CDS.data.rev5.CSL[
-    "CDS-CSL-SCD"
+  (document as any).FRR.CDS.data.rev5.CSF[
+    "CDS-CSF-SCD"
   ].varies_by_class.a.artifacts = {
     all: ["Wrong class-level evidence."],
   };
@@ -63,13 +63,12 @@ test("artifact applicability reports human-readable errors for mismatched keys",
 
   expect(issues).toEqual([
     {
-      location: "FRR.CDS.data.rev5.CSL.CDS-CSL-SCD.artifacts",
+      location: "FRR.CDS.data.rev5.CSF.CDS-CSF-SCD.artifacts",
       message:
         "artifacts is inside data.rev5, so it may only use applicability keys: rev5. Found disallowed keys: 20x.",
     },
     {
-      location:
-        "FRR.CDS.data.rev5.CSL.CDS-CSL-SCD.varies_by_class.a.artifacts",
+      location: "FRR.CDS.data.rev5.CSF.CDS-CSF-SCD.varies_by_class.a.artifacts",
       message:
         "artifacts is inside data.rev5, so it may only use applicability keys: rev5. Found disallowed keys: all.",
     },
@@ -79,8 +78,7 @@ test("artifact applicability reports human-readable errors for mismatched keys",
         "artifacts is inside data.20x, so it may only use applicability keys: 20x. Found disallowed keys: all, rev5.",
     },
     {
-      location:
-        "FRR.FRC.data.20x.CSX.FRC-CSX-PMV.varies_by_class.b.artifacts",
+      location: "FRR.FRC.data.20x.CSX.FRC-CSX-PMV.varies_by_class.b.artifacts",
       message:
         "artifacts is inside data.20x, so it may only use applicability keys: 20x. Found disallowed keys: rev5.",
     },

--- a/tools/tests/artifact-applicability.test.ts
+++ b/tools/tests/artifact-applicability.test.ts
@@ -1,86 +1,188 @@
 import { expect, test } from "bun:test";
 
-import { collectArtifactApplicabilityIssues } from "../src/consistency";
+import {
+  collectArtifactApplicabilityIssues,
+  type ConsistencyIssue,
+} from "../src/consistency";
 import { cloneDocument, loadRulesDocument } from "../src/rules";
+import type { RulesDocument } from "../src/types";
+
+const APPLICABILITY_KEYS = ["all", "20x", "rev5"] as const;
+type ApplicabilityKey = (typeof APPLICABILITY_KEYS)[number];
+
+const ALLOWED_ARTIFACT_KEYS_BY_PARENT: Record<
+  ApplicabilityKey,
+  readonly ApplicabilityKey[]
+> = {
+  all: APPLICABILITY_KEYS,
+  "20x": ["20x"],
+  rev5: ["rev5"],
+};
+
+type ArtifactHolder = Record<string, unknown> & {
+  artifacts?: Record<string, string[]>;
+  varies_by_class?: Record<string, unknown>;
+};
+
+interface ArtifactHolderTarget {
+  location: string;
+  parentApplicability: ApplicabilityKey;
+  holder: ArtifactHolder;
+}
+
+function isApplicabilityKey(value: string): value is ApplicabilityKey {
+  return (APPLICABILITY_KEYS as readonly string[]).includes(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function collectArtifactHolderTargets(
+  document: RulesDocument,
+): ArtifactHolderTarget[] {
+  const targets: ArtifactHolderTarget[] = [];
+
+  for (const [sectionKey, section] of Object.entries(document.FRR ?? {})) {
+    for (const [scopeKey, scope] of Object.entries(section.data ?? {})) {
+      if (!isApplicabilityKey(scopeKey)) {
+        continue;
+      }
+
+      for (const [labelKey, requirements] of Object.entries(scope ?? {})) {
+        for (const [id, requirement] of Object.entries(requirements ?? {})) {
+          const requirementHolder = requirement as unknown as ArtifactHolder;
+          const requirementLocation = `FRR.${sectionKey}.data.${scopeKey}.${labelKey}.${id}`;
+
+          targets.push({
+            location: requirementLocation,
+            parentApplicability: scopeKey,
+            holder: requirementHolder,
+          });
+
+          if (!isRecord(requirementHolder.varies_by_class)) {
+            continue;
+          }
+
+          for (const [classKey, classEntry] of Object.entries(
+            requirementHolder.varies_by_class,
+          )) {
+            if (!isRecord(classEntry)) {
+              continue;
+            }
+
+            targets.push({
+              location: `${requirementLocation}.varies_by_class.${classKey}`,
+              parentApplicability: scopeKey,
+              holder: classEntry as ArtifactHolder,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  return targets;
+}
+
+function artifactListFor(key: string): string[] {
+  return [`${key} evidence.`];
+}
+
+function setArtifacts(
+  target: ArtifactHolderTarget,
+  keys: readonly ApplicabilityKey[],
+): void {
+  target.holder.artifacts = Object.fromEntries(
+    keys.map((key) => [key, artifactListFor(key)]),
+  );
+}
+
+function expectedIssueForTarget(
+  target: ArtifactHolderTarget,
+): ConsistencyIssue | null {
+  if (!isRecord(target.holder.artifacts)) {
+    return null;
+  }
+
+  const allowedKeys =
+    ALLOWED_ARTIFACT_KEYS_BY_PARENT[target.parentApplicability];
+  const disallowedKeys = Object.keys(target.holder.artifacts).filter(
+    (key) => !allowedKeys.includes(key as ApplicabilityKey),
+  );
+
+  if (disallowedKeys.length === 0) {
+    return null;
+  }
+
+  return {
+    location: `${target.location}.artifacts`,
+    message:
+      `artifacts is inside data.${target.parentApplicability}, ` +
+      `so it may only use applicability keys: ${allowedKeys.join(", ")}. ` +
+      `Found disallowed keys: ${disallowedKeys.join(", ")}.`,
+  };
+}
+
+function collectExpectedArtifactApplicabilityIssues(
+  document: RulesDocument,
+): ConsistencyIssue[] {
+  return collectArtifactHolderTargets(document).flatMap((target) => {
+    const issue = expectedIssueForTarget(target);
+    return issue ? [issue] : [];
+  });
+}
+
+function sortIssues(issues: ConsistencyIssue[]): ConsistencyIssue[] {
+  return [...issues].sort(
+    (left, right) =>
+      left.location.localeCompare(right.location) ||
+      left.message.localeCompare(right.message),
+  );
+}
 
 test("current artifact applicability keys match their containing data scope", () => {
-  const issues = collectArtifactApplicabilityIssues(loadRulesDocument());
+  const document = loadRulesDocument();
+  const issues = collectArtifactApplicabilityIssues(document);
+  const expectedIssues = collectExpectedArtifactApplicabilityIssues(document);
 
+  expect(sortIssues(issues)).toEqual(sortIssues(expectedIssues));
   expect(issues).toEqual([]);
 });
 
-test("artifact applicability permits all keys under all and matching keys under 20x or rev5", () => {
+test("artifact applicability permits keys based on every FRR data scope in the rules", () => {
   const document = cloneDocument(loadRulesDocument());
+  const targets = collectArtifactHolderTargets(document);
 
-  (document as any).FRR.CDS.data.all.CSO["CDS-CSO-PUB"].artifacts = {
-    all: ["all evidence."],
-    "20x": ["20x evidence."],
-    rev5: ["Rev5 evidence."],
-  };
-  (document as any).FRR.CDS.data.all.CSO[
-    "CDS-CSO-PSM"
-  ].varies_by_class.a.artifacts = {
-    all: ["Both class evidence."],
-    "20x": ["20x class evidence."],
-    rev5: ["Rev5 class evidence."],
-  };
-  (document as any).FRR.FRC.data["20x"].CSX["FRC-CSX-MAS"].artifacts = {
-    "20x": ["20x-only evidence."],
-  };
-  (document as any).FRR.CDS.data.rev5.CSF["CDS-CSF-SCD"].artifacts = {
-    rev5: ["Rev5-only evidence."],
-  };
+  expect(targets.length).toBeGreaterThan(0);
+
+  for (const target of targets) {
+    setArtifacts(
+      target,
+      ALLOWED_ARTIFACT_KEYS_BY_PARENT[target.parentApplicability],
+    );
+  }
 
   const issues = collectArtifactApplicabilityIssues(document);
 
   expect(issues).toEqual([]);
 });
 
-test("artifact applicability reports human-readable errors for mismatched keys", () => {
+test("artifact applicability reports mismatches based on every restricted FRR data scope", () => {
   const document = cloneDocument(loadRulesDocument());
+  const restrictedTargets = collectArtifactHolderTargets(document).filter(
+    (target) => target.parentApplicability !== "all",
+  );
 
-  (document as any).FRR.FRC.data["20x"].CSX["FRC-CSX-MAS"].artifacts = {
-    all: ["Wrong parent evidence."],
-    "20x": ["Allowed evidence."],
-    rev5: ["Wrong parent evidence."],
-  };
-  (document as any).FRR.FRC.data["20x"].CSX[
-    "FRC-CSX-PMV"
-  ].varies_by_class.b.artifacts = {
-    rev5: ["Wrong class-level evidence."],
-  };
-  (document as any).FRR.CDS.data.rev5.CSF["CDS-CSF-SCD"].artifacts = {
-    "20x": ["Wrong parent evidence."],
-    rev5: ["Allowed evidence."],
-  };
-  (document as any).FRR.CDS.data.rev5.CSF[
-    "CDS-CSF-SCD"
-  ].varies_by_class.a.artifacts = {
-    all: ["Wrong class-level evidence."],
-  };
+  expect(restrictedTargets.length).toBeGreaterThan(0);
+
+  for (const target of restrictedTargets) {
+    setArtifacts(target, APPLICABILITY_KEYS);
+  }
 
   const issues = collectArtifactApplicabilityIssues(document);
+  const expectedIssues = collectExpectedArtifactApplicabilityIssues(document);
 
-  expect(issues).toEqual([
-    {
-      location: "FRR.CDS.data.rev5.CSF.CDS-CSF-SCD.artifacts",
-      message:
-        "artifacts is inside data.rev5, so it may only use applicability keys: rev5. Found disallowed keys: 20x.",
-    },
-    {
-      location: "FRR.CDS.data.rev5.CSF.CDS-CSF-SCD.varies_by_class.a.artifacts",
-      message:
-        "artifacts is inside data.rev5, so it may only use applicability keys: rev5. Found disallowed keys: all.",
-    },
-    {
-      location: "FRR.FRC.data.20x.CSX.FRC-CSX-MAS.artifacts",
-      message:
-        "artifacts is inside data.20x, so it may only use applicability keys: 20x. Found disallowed keys: all, rev5.",
-    },
-    {
-      location: "FRR.FRC.data.20x.CSX.FRC-CSX-PMV.varies_by_class.b.artifacts",
-      message:
-        "artifacts is inside data.20x, so it may only use applicability keys: 20x. Found disallowed keys: rev5.",
-    },
-  ]);
+  expect(issues.length).toBe(restrictedTargets.length);
+  expect(sortIssues(issues)).toEqual(sortIssues(expectedIssues));
 });

--- a/tools/tests/artifact-applicability.test.ts
+++ b/tools/tests/artifact-applicability.test.ts
@@ -9,18 +9,18 @@ test("current artifact applicability keys match their containing data scope", ()
   expect(issues).toEqual([]);
 });
 
-test("artifact applicability permits all keys under both and matching keys under 20x or rev5", () => {
+test("artifact applicability permits all keys under all and matching keys under 20x or rev5", () => {
   const document = cloneDocument(loadRulesDocument());
 
-  (document as any).FRR.CDS.data.both.CSO["CDS-CSO-PUB"].artifacts = {
-    both: ["Both evidence."],
+  (document as any).FRR.CDS.data.all.CSO["CDS-CSO-PUB"].artifacts = {
+    all: ["all evidence."],
     "20x": ["20x evidence."],
     rev5: ["Rev5 evidence."],
   };
-  (document as any).FRR.CDS.data.both.CSO[
+  (document as any).FRR.CDS.data.all.CSO[
     "CDS-CSO-PSM"
   ].varies_by_class.a.artifacts = {
-    both: ["Both class evidence."],
+    all: ["Both class evidence."],
     "20x": ["20x class evidence."],
     rev5: ["Rev5 class evidence."],
   };
@@ -40,7 +40,7 @@ test("artifact applicability reports human-readable errors for mismatched keys",
   const document = cloneDocument(loadRulesDocument());
 
   (document as any).FRR.FRC.data["20x"].CSX["FRC-CSX-MAS"].artifacts = {
-    both: ["Wrong parent evidence."],
+    all: ["Wrong parent evidence."],
     "20x": ["Allowed evidence."],
     rev5: ["Wrong parent evidence."],
   };
@@ -56,7 +56,7 @@ test("artifact applicability reports human-readable errors for mismatched keys",
   (document as any).FRR.CDS.data.rev5.CSL[
     "CDS-CSL-SCD"
   ].varies_by_class.a.artifacts = {
-    both: ["Wrong class-level evidence."],
+    all: ["Wrong class-level evidence."],
   };
 
   const issues = collectArtifactApplicabilityIssues(document);
@@ -71,12 +71,12 @@ test("artifact applicability reports human-readable errors for mismatched keys",
       location:
         "FRR.CDS.data.rev5.CSL.CDS-CSL-SCD.varies_by_class.a.artifacts",
       message:
-        "artifacts is inside data.rev5, so it may only use applicability keys: rev5. Found disallowed keys: both.",
+        "artifacts is inside data.rev5, so it may only use applicability keys: rev5. Found disallowed keys: all.",
     },
     {
       location: "FRR.FRC.data.20x.CSX.FRC-CSX-MAS.artifacts",
       message:
-        "artifacts is inside data.20x, so it may only use applicability keys: 20x. Found disallowed keys: both, rev5.",
+        "artifacts is inside data.20x, so it may only use applicability keys: 20x. Found disallowed keys: all, rev5.",
     },
     {
       location:

--- a/tools/tests/fix.test.ts
+++ b/tools/tests/fix.test.ts
@@ -38,7 +38,7 @@ test("auto-fix applies ID, term, and property-order fixes in one pass", () => {
           data: {
             type: "object",
             properties: {
-              both: {
+              all: {
                 type: "object",
                 patternProperties: {
                   "^FRD-[A-Z]{3}$": {
@@ -60,7 +60,7 @@ test("auto-fix applies ID, term, and property-order fixes in one pass", () => {
               data: {
                 type: "object",
                 properties: {
-                  both: {
+                  all: {
                     $ref: "#/$defs/frr_requirements_map",
                   },
                 },
@@ -121,7 +121,7 @@ test("auto-fix applies ID, term, and property-order fixes in one pass", () => {
     FRD: {
       info: {},
       data: {
-        both: {
+        all: {
           "FRD-AGY": {
             term: "agency",
             alts: ["agency"],
@@ -135,7 +135,7 @@ test("auto-fix applies ID, term, and property-order fixes in one pass", () => {
       MAS: {
         info: {},
         data: {
-          both: {
+          all: {
             CSO: {
               "MAS-CSX-TST": {
                 primary_key_word: "MUST",
@@ -173,10 +173,10 @@ test("auto-fix applies ID, term, and property-order fixes in one pass", () => {
   expect(result.propertyOrderFixedCount).toBe(1);
   expect(result.document.info.version).toBe("1.0.1");
   expect(result.document.info.last_updated).toBe("2026-04-19");
-  expect(result.document.FRD.data.both!["FRD-AGY"]!.term).toBe("Agency");
-  expect(result.document.FRR.MAS!.data.both!.CSO!["MAS-CSO-TST"]!.terms).toEqual(["Agency"]);
-  expect(result.document.FRR.MAS!.data.both!.CSO!["MAS-CSO-TST"]!.fka).toBe("MAS-CSX-TST");
-  expect(Object.keys(result.document.FRR.MAS!.data.both!.CSO!["MAS-CSO-TST"]!)).toEqual([
+  expect(result.document.FRD.data.all!["FRD-AGY"]!.term).toBe("Agency");
+  expect(result.document.FRR.MAS!.data.all!.CSO!["MAS-CSO-TST"]!.terms).toEqual(["Agency"]);
+  expect(result.document.FRR.MAS!.data.all!.CSO!["MAS-CSO-TST"]!.fka).toBe("MAS-CSX-TST");
+  expect(Object.keys(result.document.FRR.MAS!.data.all!.CSO!["MAS-CSO-TST"]!)).toEqual([
     "name",
     "statement",
     "primary_key_word",

--- a/tools/tests/property-order.test.ts
+++ b/tools/tests/property-order.test.ts
@@ -49,7 +49,7 @@ test("property order fixes use schema property order as the source of truth", ()
   const document = {
     FRD: {
       data: {
-        both: {
+        all: {
           "FRD-TST": {
             definition: "Test definition",
             term: "Test Term",
@@ -65,7 +65,7 @@ test("property order fixes use schema property order as the source of truth", ()
   const checkIssues = collectPropertyOrderIssues(document, schema);
   expect(checkIssues).toEqual([
     {
-      path: "FRD.data.both.FRD-TST",
+      path: "FRD.data.all.FRD-TST",
       actualOrder: ["definition", "term", "updated", "note", "alts"],
       expectedOrder: ["term", "alts", "definition", "note", "updated"],
     },
@@ -73,7 +73,7 @@ test("property order fixes use schema property order as the source of truth", ()
 
   const fixed = fixPropertyOrder(document, schema);
   expect(fixed.fixedCount).toBe(1);
-  expect(Object.keys(fixed.document.FRD.data.both!["FRD-TST"]!)).toEqual([
+  expect(Object.keys(fixed.document.FRD.data.all!["FRD-TST"]!)).toEqual([
     "term",
     "alts",
     "definition",
@@ -86,7 +86,7 @@ test("property order fixes sort FRD shared definitions by term instead of ID", (
   const document = {
     FRD: {
       data: {
-        both: {
+        all: {
           "FRD-AAA": {
             term: "Zeta Term",
             definition: "Zeta definition",
@@ -114,7 +114,7 @@ test("property order fixes sort FRD shared definitions by term instead of ID", (
   const checkIssues = collectPropertyOrderIssues(document, schema);
   expect(checkIssues).toEqual([
     {
-      path: "FRD.data.both",
+      path: "FRD.data.all",
       actualOrder: ["FRD-AAA", "FRD-MMM", "FRD-ZZZ"],
       expectedOrder: ["FRD-ZZZ", "FRD-MMM", "FRD-AAA"],
     },
@@ -122,7 +122,7 @@ test("property order fixes sort FRD shared definitions by term instead of ID", (
 
   const fixed = fixPropertyOrder(document, schema);
   expect(fixed.fixedCount).toBe(1);
-  expect(Object.keys(fixed.document.FRD.data.both!)).toEqual(["FRD-ZZZ", "FRD-MMM", "FRD-AAA"]);
+  expect(Object.keys(fixed.document.FRD.data.all!)).toEqual(["FRD-ZZZ", "FRD-MMM", "FRD-AAA"]);
 });
 
 test("property order fixes use schema propertyNames enum order for FRR labels and label groups", () => {
@@ -148,7 +148,7 @@ test("property order fixes use schema propertyNames enum order for FRR labels an
               data: {
                 type: "object",
                 properties: {
-                  both: { $ref: "#/$defs/frr_requirements_map" },
+                  all: { $ref: "#/$defs/frr_requirements_map" },
                 },
               },
             },
@@ -201,7 +201,7 @@ test("property order fixes use schema propertyNames enum order for FRR labels an
           },
         },
         data: {
-          both: {
+          all: {
             UTC: {
               "ABC-UTC-001": { name: "UTC rule" },
             },
@@ -225,7 +225,7 @@ test("property order fixes use schema propertyNames enum order for FRR labels an
       expectedOrder: ["FRP", "CSX", "UTC", "IAL"],
     },
     {
-      path: "FRR.ABC.data.both",
+      path: "FRR.ABC.data.all",
       actualOrder: ["UTC", "FRP", "CSX"],
       expectedOrder: ["FRP", "CSX", "UTC"],
     },
@@ -234,7 +234,7 @@ test("property order fixes use schema propertyNames enum order for FRR labels an
   const fixed = fixPropertyOrder(document, schema);
   expect(fixed.fixedCount).toBe(2);
   expect(Object.keys(fixed.document.FRR.ABC!.info.labels as object)).toEqual(["FRP", "CSX", "UTC", "IAL"]);
-  expect(Object.keys(fixed.document.FRR.ABC!.data.both!)).toEqual(["FRP", "CSX", "UTC"]);
+  expect(Object.keys(fixed.document.FRR.ABC!.data.all!)).toEqual(["FRP", "CSX", "UTC"]);
 });
 
 test("property order fixes follow schema order for referenced data containers", () => {
@@ -269,7 +269,7 @@ test("property order fixes follow schema order for referenced data containers", 
       data_container_frd: {
         type: "object",
         properties: {
-          both: { type: "object" },
+          all: { type: "object" },
           "20x": { type: "object" },
           rev5: { type: "object" },
         },
@@ -277,7 +277,7 @@ test("property order fixes follow schema order for referenced data containers", 
       data_container_frr: {
         type: "object",
         properties: {
-          both: { type: "object" },
+          all: { type: "object" },
           "20x": { type: "object" },
           rev5: { type: "object" },
         },
@@ -296,7 +296,7 @@ test("property order fixes follow schema order for referenced data containers", 
         },
         data: {
           rev5: {},
-          both: {},
+          all: {},
           "20x": {},
         },
       },
@@ -307,13 +307,13 @@ test("property order fixes follow schema order for referenced data containers", 
   expect(checkIssues).toEqual([
     {
       path: "FRR.ABC.data",
-      actualOrder: ["rev5", "both", "20x"],
-      expectedOrder: ["both", "20x", "rev5"],
+      actualOrder: ["rev5", "all", "20x"],
+      expectedOrder: ["all", "20x", "rev5"],
     },
   ]);
 
   const fixed = fixPropertyOrder(document, schema);
   expect(fixed.fixedCount).toBe(1);
-  expect(Object.keys(fixed.document.FRR.ABC!.data)).toEqual(["both", "20x", "rev5"]);
+  expect(Object.keys(fixed.document.FRR.ABC!.data)).toEqual(["all", "20x", "rev5"]);
   expect(Object.keys(fixed.document.FRR.ABC!.info.effective as object)).toEqual(["rev5", "20x"]);
 });

--- a/tools/tests/property-order.test.ts
+++ b/tools/tests/property-order.test.ts
@@ -1,11 +1,23 @@
 import { expect, test } from "bun:test";
 
-import { collectPropertyOrderIssues, fixPropertyOrder } from "../src/property-order";
+import {
+  collectPropertyOrderIssues,
+  fixPropertyOrder,
+  formatPropertyOrderReport,
+} from "../src/property-order";
 import { loadRulesDocument, loadSchemaDocument } from "../src/rules";
 import type { RulesDocument } from "../src/types";
 
 test("the consolidated rules document follows the schema-defined property order", () => {
-  const issues = collectPropertyOrderIssues(loadRulesDocument(), loadSchemaDocument());
+  const issues = collectPropertyOrderIssues(
+    loadRulesDocument(),
+    loadSchemaDocument(),
+  );
+
+  if (issues.length > 0) {
+    throw new Error(formatPropertyOrderReport(issues));
+  }
+
   expect(issues).toEqual([]);
 });
 
@@ -122,7 +134,11 @@ test("property order fixes sort FRD shared definitions by term instead of ID", (
 
   const fixed = fixPropertyOrder(document, schema);
   expect(fixed.fixedCount).toBe(1);
-  expect(Object.keys(fixed.document.FRD.data.all!)).toEqual(["FRD-ZZZ", "FRD-MMM", "FRD-AAA"]);
+  expect(Object.keys(fixed.document.FRD.data.all!)).toEqual([
+    "FRD-ZZZ",
+    "FRD-MMM",
+    "FRD-AAA",
+  ]);
 });
 
 test("property order fixes use schema propertyNames enum order for FRR labels and label groups", () => {
@@ -141,7 +157,9 @@ test("property order fixes use schema propertyNames enum order for FRR labels an
                   labels: {
                     type: "object",
                     propertyNames: { $ref: "#/$defs/frr_info_label_name" },
-                    additionalProperties: { $ref: "#/$defs/frr_label_definition" },
+                    additionalProperties: {
+                      $ref: "#/$defs/frr_label_definition",
+                    },
                   },
                 },
               },
@@ -233,8 +251,17 @@ test("property order fixes use schema propertyNames enum order for FRR labels an
 
   const fixed = fixPropertyOrder(document, schema);
   expect(fixed.fixedCount).toBe(2);
-  expect(Object.keys(fixed.document.FRR.ABC!.info.labels as object)).toEqual(["FRP", "CSX", "UTC", "IAL"]);
-  expect(Object.keys(fixed.document.FRR.ABC!.data.all!)).toEqual(["FRP", "CSX", "UTC"]);
+  expect(Object.keys(fixed.document.FRR.ABC!.info.labels as object)).toEqual([
+    "FRP",
+    "CSX",
+    "UTC",
+    "IAL",
+  ]);
+  expect(Object.keys(fixed.document.FRR.ABC!.data.all!)).toEqual([
+    "FRP",
+    "CSX",
+    "UTC",
+  ]);
 });
 
 test("property order fixes follow schema order for referenced data containers", () => {
@@ -314,6 +341,12 @@ test("property order fixes follow schema order for referenced data containers", 
 
   const fixed = fixPropertyOrder(document, schema);
   expect(fixed.fixedCount).toBe(1);
-  expect(Object.keys(fixed.document.FRR.ABC!.data)).toEqual(["all", "20x", "rev5"]);
-  expect(Object.keys(fixed.document.FRR.ABC!.info.effective as object)).toEqual(["rev5", "20x"]);
+  expect(Object.keys(fixed.document.FRR.ABC!.data)).toEqual([
+    "all",
+    "20x",
+    "rev5",
+  ]);
+  expect(Object.keys(fixed.document.FRR.ABC!.info.effective as object)).toEqual(
+    ["rev5", "20x"],
+  );
 });

--- a/tools/tests/schema-validation.test.ts
+++ b/tools/tests/schema-validation.test.ts
@@ -82,7 +82,7 @@ test("property name errors identify the invalid keys and allowed names", () => {
 test("notes array with fewer than 2 entries in FRD definition fails validation", () => {
   const errors: ErrorObject[] = [
     {
-      instancePath: "/FRD/data/both/FRD-ACV/notes",
+      instancePath: "/FRD/data/all/FRD-ACV/notes",
       schemaPath: "#/$defs/frd_definition/properties/notes/minItems",
       keyword: "minItems",
       params: { limit: 2 },
@@ -91,14 +91,14 @@ test("notes array with fewer than 2 entries in FRD definition fails validation",
   ];
 
   expect(formatSchemaErrors(errors, {})).toEqual([
-    "FRD.data.both.FRD-ACV.notes must have at least 2 items.",
+    "FRD.data.all.FRD-ACV.notes must have at least 2 items.",
   ]);
 });
 
 test("notes array with fewer than 2 entries in FRR requirement fails validation", () => {
   const errors: ErrorObject[] = [
     {
-      instancePath: "/FRR/MAS/data/both/MAS-CSO-CNT-010/notes",
+      instancePath: "/FRR/MAS/data/all/MAS-CSO-CNT-010/notes",
       schemaPath: "#/$defs/frr_requirement/properties/notes/minItems",
       keyword: "minItems",
       params: { limit: 2 },
@@ -107,6 +107,6 @@ test("notes array with fewer than 2 entries in FRR requirement fails validation"
   ];
 
   expect(formatSchemaErrors(errors, {})).toEqual([
-    "FRR.MAS.data.both.MAS-CSO-CNT-010.notes must have at least 2 items.",
+    "FRR.MAS.data.all.MAS-CSO-CNT-010.notes must have at least 2 items.",
   ]);
 });

--- a/tools/tests/schema.test.ts
+++ b/tools/tests/schema.test.ts
@@ -34,7 +34,7 @@ function expectSchemaRejects(title: string, document: RulesDocument): void {
 test("the schema rejects FRR requirements that mix top-level and class-specific statements", () => {
   const singleStatementDocument = cloneDocument(loadRulesDocument());
   const singleStatementRequirement =
-    (singleStatementDocument as any).FRR.MAS.data.both.CSO["MAS-CSO-FLO"];
+    (singleStatementDocument as any).FRR.MAS.data.all.CSO["MAS-CSO-FLO"];
   singleStatementRequirement.varies_by_class = {
     b: {
       statement: singleStatementRequirement.statement,

--- a/tools/tests/schema.test.ts
+++ b/tools/tests/schema.test.ts
@@ -1,8 +1,62 @@
 import { expect, test } from "bun:test";
 
 import { validateSchema } from "../src/schema-validation";
-import { cloneDocument, loadRulesDocument, loadSchemaDocument } from "../src/rules";
+import {
+  cloneDocument,
+  loadRulesDocument,
+  loadSchemaDocument,
+} from "../src/rules";
 import type { RulesDocument } from "../src/types";
+
+function effectiveEntry() {
+  return {
+    is: "required",
+    current_status: "Test status",
+    date: {
+      obtain: "2026-01-01",
+      maintain: "2026-01-01",
+      grace_ends: "2026-07-01",
+    },
+  };
+}
+
+function minimalRulesDocument(): RulesDocument {
+  return {
+    info: {
+      title: "Test Rules",
+      description: "Minimal schema fixture.",
+      version: "2026.01.01-test",
+      last_updated: "2026-01-01",
+    },
+    FRD: {
+      info: {
+        name: "FedRAMP Definitions",
+        short_name: "FRD",
+        web_name: "definitions",
+        purpose: "Define terms.",
+        status: "stable",
+        effective: effectiveEntry(),
+      },
+      data: {
+        all: {},
+      },
+    },
+    FRR: {
+      ABC: {
+        info: {
+          name: "Example Rules",
+          short_name: "ABC",
+          web_name: "example-rules",
+          purpose: "Exercise schema rules.",
+          status: "stable",
+          effective: effectiveEntry(),
+        },
+        data: {},
+      },
+    },
+    KSI: {},
+  } as RulesDocument;
+}
 
 test("the consolidated rules document matches the configured schema", () => {
   const result = validateSchema();
@@ -19,22 +73,104 @@ test("the consolidated rules document matches the configured schema", () => {
   expect(result.valid).toBe(true);
 });
 
-function expectSchemaRejects(title: string, document: RulesDocument): void {
+function expectSchemaAccepts(title: string, document: RulesDocument): void {
+  const result = validateSchema(document, loadSchemaDocument());
+
+  if (!result.valid) {
+    throw new Error(
+      [
+        `${title}: schema rejected a valid document.`,
+        ...result.humanReadableErrors.map((error) => `- ${error}`),
+      ].join("\n"),
+    );
+  }
+
+  expect(result.valid).toBe(true);
+}
+
+function expectSchemaRejects(
+  title: string,
+  document: RulesDocument,
+  details = "schema accepted an invalid document.",
+): void {
   const result = validateSchema(document, loadSchemaDocument());
 
   if (result.valid) {
-    throw new Error(
-      `${title}: schema accepted an invalid document. Entries must use either top-level statement/primary_key_word or varies_by_class, but not both.`,
-    );
+    throw new Error(`${title}: ${details}`);
   }
 
   expect(result.valid).toBe(false);
 }
 
+test("the schema accepts common FRR info with certification-specific labels and flows", () => {
+  const document = minimalRulesDocument();
+  (document as any).FRR.ABC.info.labels = {
+    CSO: { name: "Common", description: "Common label." },
+  };
+  (document as any).FRR.ABC.info.flows = ["Common flow"];
+  (document as any).FRR.ABC.info["20x"] = {
+    labels: {
+      CSX: { name: "20x", description: "20x label." },
+    },
+    flows: ["20x flow"],
+  };
+  (document as any).FRR.ABC.info.rev5 = {
+    labels: {
+      CSF: { name: "Rev5", description: "Rev5 label." },
+    },
+    flows: ["Rev5 flow"],
+  };
+
+  expectSchemaAccepts(
+    "FRR certification-specific labels and flows overlay common info",
+    document,
+  );
+});
+
+test("the schema requires certification-specific effective entries to be paired", () => {
+  const document = minimalRulesDocument();
+  delete (document as any).FRR.ABC.info.effective;
+  (document as any).FRR.ABC.info["20x"] = {
+    effective: effectiveEntry(),
+  };
+
+  expectSchemaRejects(
+    "FRR certification-specific effective without rev5 counterpart",
+    document,
+  );
+});
+
+test("the schema rejects mixed common and certification-specific effective entries", () => {
+  const document = minimalRulesDocument();
+  (document as any).FRR.ABC.info["20x"] = {
+    effective: effectiveEntry(),
+  };
+  (document as any).FRR.ABC.info.rev5 = {
+    effective: effectiveEntry(),
+  };
+
+  expectSchemaRejects(
+    "FRR common effective mixed with certification-specific effective",
+    document,
+  );
+});
+
+test("the schema keeps common-only info properties out of certification blocks", () => {
+  const document = minimalRulesDocument();
+  (document as any).FRR.ABC.info["20x"] = {
+    status: "stable",
+  };
+
+  expectSchemaRejects(
+    "FRR certification block with common-only status",
+    document,
+  );
+});
+
 test("the schema rejects FRR requirements that mix top-level and class-specific statements", () => {
   const singleStatementDocument = cloneDocument(loadRulesDocument());
-  const singleStatementRequirement =
-    (singleStatementDocument as any).FRR.MAS.data.all.CSO["MAS-CSO-FLO"];
+  const singleStatementRequirement = (singleStatementDocument as any).FRR.MAS
+    .data.all.CSO["MAS-CSO-FLO"];
   singleStatementRequirement.varies_by_class = {
     b: {
       statement: singleStatementRequirement.statement,
@@ -52,7 +188,9 @@ test("the schema rejects FRR requirements that mix top-level and class-specific 
   );
 
   const classSpecificDocument = cloneDocument(loadRulesDocument());
-  (classSpecificDocument as any).FRR.FRC.data["20x"].CSX["FRC-CSX-PMV"].statement =
+  (classSpecificDocument as any).FRR.FRC.data["20x"].CSX[
+    "FRC-CSX-PMV"
+  ].statement =
     "This invalid top-level statement should not be allowed next to varies_by_class.";
 
   expectSchemaRejects(
@@ -63,12 +201,16 @@ test("the schema rejects FRR requirements that mix top-level and class-specific 
 
 test("the schema rejects KSI indicators that mix top-level and class-specific statements", () => {
   const singleStatementDocument = cloneDocument(loadRulesDocument());
-  (singleStatementDocument as any).KSI.CMT.indicators["KSI-CMT-LMC"].varies_by_class = {
+  (singleStatementDocument as any).KSI.CMT.indicators[
+    "KSI-CMT-LMC"
+  ].varies_by_class = {
     b: {
-      statement: "This invalid class-specific statement should not be allowed next to a top-level statement.",
+      statement:
+        "This invalid class-specific statement should not be allowed next to a top-level statement.",
     },
     c: {
-      statement: "This invalid class-specific statement should not be allowed next to a top-level statement.",
+      statement:
+        "This invalid class-specific statement should not be allowed next to a top-level statement.",
     },
   };
 

--- a/tools/tests/schema.test.ts
+++ b/tools/tests/schema.test.ts
@@ -6,7 +6,14 @@ import {
   loadRulesDocument,
   loadSchemaDocument,
 } from "../src/rules";
+import { visitIndicators, visitRequirements } from "../src/traversal";
 import type { RulesDocument } from "../src/types";
+
+type MutableRuleEntity = Record<string, unknown> & {
+  statement?: string;
+  primary_key_word?: string;
+  varies_by_class?: Record<string, unknown>;
+};
 
 function effectiveEntry() {
   return {
@@ -56,6 +63,72 @@ function minimalRulesDocument(): RulesDocument {
     },
     KSI: {},
   } as RulesDocument;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasSingleRequirementStatement(entity: MutableRuleEntity): boolean {
+  return (
+    typeof entity.statement === "string" &&
+    typeof entity.primary_key_word === "string" &&
+    !isRecord(entity.varies_by_class)
+  );
+}
+
+function hasSingleIndicatorStatement(entity: MutableRuleEntity): boolean {
+  return (
+    typeof entity.statement === "string" && !isRecord(entity.varies_by_class)
+  );
+}
+
+function hasClassSpecificStatement(entity: MutableRuleEntity): boolean {
+  return (
+    isRecord(entity.varies_by_class) && typeof entity.statement !== "string"
+  );
+}
+
+function findFrrRequirement(
+  document: RulesDocument,
+  predicate: (entity: MutableRuleEntity) => boolean,
+  description: string,
+): MutableRuleEntity {
+  let match: MutableRuleEntity | undefined;
+
+  visitRequirements(document, ({ requirement }) => {
+    const entity = requirement as unknown as MutableRuleEntity;
+    if (!match && predicate(entity)) {
+      match = entity;
+    }
+  });
+
+  if (!match) {
+    throw new Error(`Expected the rules document to contain ${description}.`);
+  }
+
+  return match;
+}
+
+function findKsiIndicator(
+  document: RulesDocument,
+  predicate: (entity: MutableRuleEntity) => boolean,
+  description: string,
+): MutableRuleEntity {
+  let match: MutableRuleEntity | undefined;
+
+  visitIndicators(document, ({ indicator }) => {
+    const entity = indicator as unknown as MutableRuleEntity;
+    if (!match && predicate(entity)) {
+      match = entity;
+    }
+  });
+
+  if (!match) {
+    throw new Error(`Expected the rules document to contain ${description}.`);
+  }
+
+  return match;
 }
 
 test("the consolidated rules document matches the configured schema", () => {
@@ -169,8 +242,11 @@ test("the schema keeps common-only info properties out of certification blocks",
 
 test("the schema rejects FRR requirements that mix top-level and class-specific statements", () => {
   const singleStatementDocument = cloneDocument(loadRulesDocument());
-  const singleStatementRequirement = (singleStatementDocument as any).FRR.MAS
-    .data.all.CSO["MAS-CSO-FLO"];
+  const singleStatementRequirement = findFrrRequirement(
+    singleStatementDocument,
+    hasSingleRequirementStatement,
+    "an FRR requirement with a top-level statement",
+  );
   singleStatementRequirement.varies_by_class = {
     b: {
       statement: singleStatementRequirement.statement,
@@ -188,9 +264,11 @@ test("the schema rejects FRR requirements that mix top-level and class-specific 
   );
 
   const classSpecificDocument = cloneDocument(loadRulesDocument());
-  (classSpecificDocument as any).FRR.FRC.data["20x"].CSX[
-    "FRC-CSX-PMV"
-  ].statement =
+  findFrrRequirement(
+    classSpecificDocument,
+    hasClassSpecificStatement,
+    "an FRR requirement with class-specific statements",
+  ).statement =
     "This invalid top-level statement should not be allowed next to varies_by_class.";
 
   expectSchemaRejects(
@@ -201,9 +279,11 @@ test("the schema rejects FRR requirements that mix top-level and class-specific 
 
 test("the schema rejects KSI indicators that mix top-level and class-specific statements", () => {
   const singleStatementDocument = cloneDocument(loadRulesDocument());
-  (singleStatementDocument as any).KSI.CMT.indicators[
-    "KSI-CMT-LMC"
-  ].varies_by_class = {
+  findKsiIndicator(
+    singleStatementDocument,
+    hasSingleIndicatorStatement,
+    "a KSI indicator with a top-level statement",
+  ).varies_by_class = {
     b: {
       statement:
         "This invalid class-specific statement should not be allowed next to a top-level statement.",
@@ -220,7 +300,11 @@ test("the schema rejects KSI indicators that mix top-level and class-specific st
   );
 
   const classSpecificDocument = cloneDocument(loadRulesDocument());
-  (classSpecificDocument as any).KSI.CNA.indicators["KSI-CNA-EIS"].statement =
+  findKsiIndicator(
+    classSpecificDocument,
+    hasClassSpecificStatement,
+    "a KSI indicator with class-specific statements",
+  ).statement =
     "This invalid top-level statement should not be allowed next to varies_by_class.";
 
   expectSchemaRejects(

--- a/tools/tests/terms.test.ts
+++ b/tools/tests/terms.test.ts
@@ -37,7 +37,7 @@ test("definition title fixes update the term without appending to updated histor
     FRD: {
       info: {},
       data: {
-        both: {
+        all: {
           "FRD-TLA": {
             term: "Top-level administrative account",
             definition: "Test definition",
@@ -60,13 +60,13 @@ test("definition title fixes update the term without appending to updated histor
   expect(changes).toEqual([
     {
       id: "FRD-TLA",
-      location: "FRD.data.both.FRD-TLA",
+      location: "FRD.data.all.FRD-TLA",
       currentTerm: "Top-level administrative account",
       nextTerm: "Top-Level Administrative Account",
     },
   ]);
-  expect(document.FRD.data.both!["FRD-TLA"]!.term).toBe("Top-Level Administrative Account");
-  expect(document.FRD.data.both!["FRD-TLA"]!.updated).toEqual([
+  expect(document.FRD.data.all!["FRD-TLA"]!.term).toBe("Top-Level Administrative Account");
+  expect(document.FRD.data.all!["FRD-TLA"]!.updated).toEqual([
     {
       date: "2026-02-04",
       comment: "Existing note.",
@@ -85,7 +85,7 @@ test("term sync updates terms without appending to updated history by default", 
     FRD: {
       info: {},
       data: {
-        both: {
+        all: {
           "FRD-AGY": {
             term: "Agency",
             definition: "Test definition",
@@ -98,7 +98,7 @@ test("term sync updates terms without appending to updated history by default", 
       MAS: {
         info: {},
         data: {
-          both: {
+          all: {
             CSO: {
               "MAS-CSO-TST": {
                 name: "Test requirement",
@@ -124,8 +124,8 @@ test("term sync updates terms without appending to updated history by default", 
   const changes = applyTermSync(document, { entryDate: "2026-04-12" });
 
   expect(changes).toHaveLength(1);
-  expect(document.FRR.MAS!.data.both!.CSO!["MAS-CSO-TST"]!.terms).toEqual(["Agency"]);
-  expect(document.FRR.MAS!.data.both!.CSO!["MAS-CSO-TST"]!.updated).toEqual([
+  expect(document.FRR.MAS!.data.all!.CSO!["MAS-CSO-TST"]!.terms).toEqual(["Agency"]);
+  expect(document.FRR.MAS!.data.all!.CSO!["MAS-CSO-TST"]!.updated).toEqual([
     {
       date: "2026-02-04",
       comment: "Existing note.",
@@ -144,7 +144,7 @@ test("term sync prepends an updated entry when comment mode is enabled", () => {
     FRD: {
       info: {},
       data: {
-        both: {
+        all: {
           "FRD-AGY": {
             term: "Agency",
             definition: "Test definition",
@@ -157,7 +157,7 @@ test("term sync prepends an updated entry when comment mode is enabled", () => {
       MAS: {
         info: {},
         data: {
-          both: {
+          all: {
             CSO: {
               "MAS-CSO-TST": {
                 name: "Test requirement",
@@ -183,7 +183,7 @@ test("term sync prepends an updated entry when comment mode is enabled", () => {
   const changes = applyTermSync(document, { addComment: true, entryDate: "2026-04-12" });
 
   expect(changes).toHaveLength(1);
-  expect(document.FRR.MAS!.data.both!.CSO!["MAS-CSO-TST"]!.updated).toEqual([
+  expect(document.FRR.MAS!.data.all!.CSO!["MAS-CSO-TST"]!.updated).toEqual([
     {
       date: "2026-04-12",
       comment: TERM_UPDATE_COMMENT,
@@ -206,7 +206,7 @@ test("term sync appends to an existing comment when comment mode is enabled and 
     FRD: {
       info: {},
       data: {
-        both: {
+        all: {
           "FRD-AGY": {
             term: "Agency",
             definition: "Test definition",
@@ -219,7 +219,7 @@ test("term sync appends to an existing comment when comment mode is enabled and 
       MAS: {
         info: {},
         data: {
-          both: {
+          all: {
             CSO: {
               "MAS-CSO-TST": {
                 name: "Test requirement",
@@ -245,7 +245,7 @@ test("term sync appends to an existing comment when comment mode is enabled and 
   const changes = applyTermSync(document, { addComment: true, entryDate: "2026-04-12" });
 
   expect(changes).toHaveLength(1);
-  expect(document.FRR.MAS!.data.both!.CSO!["MAS-CSO-TST"]!.updated).toEqual([
+  expect(document.FRR.MAS!.data.all!.CSO!["MAS-CSO-TST"]!.updated).toEqual([
     {
       date: "2026-04-12",
       comment: `Reviewed wording. ${TERM_UPDATE_COMMENT}`,

--- a/tools/tests/zz-consistency-report.test.ts
+++ b/tools/tests/zz-consistency-report.test.ts
@@ -1,10 +1,12 @@
-import { test } from "bun:test";
+import { expect, test } from "bun:test";
 
 import {
+  collectFrrLabelDeclarationIssues,
   collectConsistencyChecks,
   formatConsistencyReport,
 } from "../src/consistency";
 import { loadRulesDocument } from "../src/rules";
+import type { RulesDocument } from "../src/types";
 
 test("consistency validation report", () => {
   const checks = collectConsistencyChecks(loadRulesDocument());
@@ -12,4 +14,43 @@ test("consistency validation report", () => {
   if (checks.some((check) => check.issues.length > 0)) {
     throw new Error(formatConsistencyReport(checks));
   }
+});
+
+test("FRR label declarations include certification-specific info labels", () => {
+  const document = {
+    FRR: {
+      ABC: {
+        info: {
+          labels: {
+            CSO: { name: "Common", description: "Common label." },
+          },
+          "20x": {
+            labels: {
+              CSX: { name: "20x", description: "20x label." },
+            },
+          },
+          rev5: {
+            labels: {
+              CSF: { name: "Rev5", description: "Rev5 label." },
+            },
+          },
+        },
+        data: {
+          all: {
+            CSO: {},
+          },
+          "20x": {
+            CSO: {},
+            CSX: {},
+          },
+          rev5: {
+            CSO: {},
+            CSF: {},
+          },
+        },
+      },
+    },
+  } as unknown as RulesDocument;
+
+  expect(collectFrrLabelDeclarationIssues(document)).toEqual([]);
 });


### PR DESCRIPTION
Scope note: This changelog compares committed branch `pwx-icp` from local `main` (`c4df429`) to `HEAD` (`3beb70d`).

## Rules Content Changes

- `FRD-CAE`, `FRD-LAE`, `FRD-NAE`, and `FRD-SAE` were replaced by `FRD-DCE`, `FRD-DCF`, `FRD-MCE`, and `FRD-NCE` to describe PAIN rating outcomes as customer effects.
- `FRD-FRI` was renamed from Federal Reportable Incident to FedRAMP Reportable Incident.
- `FRD-PAI` was renamed from Potential Adverse Impact to Potential Agency Impact and scoped to agency customer impacts.
- `FRD-FMV` and `FRD-PMV` now reference Potential Agency Impact ratings.
- KSI indicator wording did not change, but FRD and KSI `updated` histories were reset to `2026-07-04`.
- Rev5 provider rule IDs moved from `CSL` to `CSF`, including `CDS-CSF-SCD`, `CDS-CSF-TCM`, `FRC-CSF-CDE`, `FRC-CSF-PMV`, and `FRC-CSF-RDY`.
- `CDS-CSO-PAR` replaces `ICP-CSO-PAR`, moves public availability reporting into Certification Data Sharing, and strengthens Class B from `SHOULD` to `MUST`.
- `CCM-OCR-AVL` now requires Ongoing Certification Reports to cover FedRAMP Reportable Incidents and related lessons learned.
- `ICP-CSO-AAP`, `ICP-CSO-CSA`, and `ICP-CSO-IRT` were removed in favor of the updated incident-reporting flow.
- `ICP-CSO-AIR` adds a new recommendation to automate FedRAMP Reportable Incident reporting.
- `ICP-CSO-DPR` adds a default PAIN 5 treatment unless providers promptly estimate PAIN.
- `ICP-CSO-EFI` changes incident impact estimation from a `MUST` to a `SHOULD`, adopts Potential Agency Impact, and maps N1-N5 to customer effects.
- `ICP-CSO-EFR` now embeds the FedRAMP Reportable Incident consequence directly in the statement.
- `ICP-CSO-IIR`, `ICP-CSO-OIR`, and `ICP-CSO-FIR` now vary by class, add notification targets, and include PAIN-based reporting timeframes.
- `VDR-EVA-EPA`, `VDR-AGM-RVR`, `VDR-RPT-AVI`, `VDR-RPT-VDT`, and `VDR-TFR-PVR` were updated from Potential Adverse Impact terminology to Potential Agency Impact terminology.
- `VDR-TFR-IRI` and `VDR-TFR-NRI` now treat qualifying high-risk vulnerabilities as FedRAMP Reportable Incidents rather than generic security incidents.
- Several class-specific rules now say “Providers with Class X Certifications” instead of “Providers of Class X offerings,” including `CCM-QTR-MTG`, `CDS-CSO-PSM`, `FRC-CSO-IVV`, `UCM-CSO-UVM`, and the affected `VDR-TFR-*` rules.

## Schema And Structure Changes

- Dataset metadata changed from version `2026.05.17.01-preview` / `2026-05-17` to `2026.05.22.01-preview` / `2026-05-22`.
- Applicability bucket `both` was renamed to `all` across FRD, FRR, and artifact structures.
- Document `info.effective` changed from an applicability map to either a common `effective` object or paired certification-specific `20x` and `rev5` blocks.
- FRR and FRD info objects now support certification-specific metadata blocks.
- FRR info objects now support `flows`, used by ICP for incident communication flow steps.
- Schema validation now requires paired `20x` and `rev5` effective entries and rejects mixing common and certification-specific effective entries.
- Schema label vocabulary added `CSF` and `IAF`, while branch data uses `CSF` for Rev5 provider buckets.
- Class-specific FRR variants can now include `following_information`, `note`, and `notes`.
- Notification party vocabulary now includes `Agency Customers`.

## Tooling And Test Changes

- Consistency validation now understands `all`, certification-specific label declarations, and `Agency Customers` notifications.
- Property-order tooling now reports schema-defined order failures and handles `FRD.data.all` sorting.
- Summary rendering now reads the new common or certification-specific effective metadata shape.
- The fix CLI now formats the rules file with Prettier after fix runs, including no-op runs.
- The test runner now adds final consistency and property-order summaries.
- Tests were expanded for schema effective rules, certification labels/flows, artifact applicability, property ordering, term/fix fixtures, and schema-validation paths.
- `tools/package.json` made `check` and `test` quieter with `--silent`; `tools/.gitignore` now ignores `.vscode`.

Validation: `bun run check` passed from `tools` with 36 tests.