### PR TITLE
Updates to 2026.05.31.01-preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,22 @@ source of truth for the FedRAMP Consolidated Rules for 2026 Public Preview.
 [schemas/fedramp-consolidated-rules.schema.json](schemas/fedramp-consolidated-rules.schema.json)
 is the source of truth for the expected data shape.
 
+## Rules JSON Edit Guardrail
+
+Do not modify
+[fedramp-consolidated-rules.json](fedramp-consolidated-rules.json) unless the
+user specifically instructs you to edit that file.
+
+If a task appears to require changing
+[fedramp-consolidated-rules.json](fedramp-consolidated-rules.json), stop before
+editing it. Propose a concise plan that identifies the specific rule,
+definition, indicator, metadata, or structural paths you intend to change, then
+wait for the user's explicit confirmation before making those edits.
+
+Analysis, validation, structured reads, and reports may use
+[fedramp-consolidated-rules.json](fedramp-consolidated-rules.json) without
+additional permission. The guardrail applies to file modifications.
+
 ## Dataset Structure
 
 The JSON file has four top-level sections:
@@ -79,8 +95,8 @@ scopes, or process buckets. Requirement IDs follow the
 
 Each requirement contains either:
 
-- a single `statement` and `primary_key_word`, or
-- a `varies_by_class` object with class-specific statements and keywords.
+- a single `statement` and `force`, or
+- a `varies_by_class` object with class-specific statements and force values.
 
 Class-specific variants may also include `following_information`, `artifacts`,
 notes, effective dates, simple timeframes, and `pain_timeframes`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,15 +200,25 @@ unless the user explicitly asks for one.
 - Compare the initial branch state to the final branch state, not commit by
   commit, unless a commit-level explanation is specifically requested.
 - Detect and highlight breaking changes when summarizing underlying changes to
-  [fedramp-consolidated-rules.json](fedramp-consolidated-rules.json). Treat a
-  change as breaking when existing consumers, validators, exporters, queries, or
-  downstream mappings that understand the previous dataset shape or vocabulary
-  would likely fail, silently miss data, or need code changes. Examples include
-  renamed or removed properties, moved containers, changed required fields,
-  renamed applicability or subset buckets, ID format changes, controlled
-  vocabulary changes that invalidate existing values, statement shape changes,
-  array/object type changes, and changes that move rule content to a different
-  path.
+  [fedramp-consolidated-rules.json](fedramp-consolidated-rules.json) or the
+  schema. Use the software compatibility meaning of breaking change: a
+  backwards-incompatible change to the machine-readable public contract that
+  would make existing parsers, validators, exporters, queries, or integrations
+  fail, reject previously valid data, silently misread data, or require code
+  changes to continue processing the dataset. Examples include renamed or
+  removed properties such as `primary_key_word` to `force`, changed required
+  fields, changed property types, changed statement shapes, changed ID formats,
+  controlled vocabulary changes that invalidate existing values, renamed
+  top-level sections, renamed applicability or subset bucket keys when those
+  keys are part of the schema contract, or stricter validation rules that reject
+  files accepted by the previous schema.
+- Do not mark rule-content taxonomy changes as breaking merely because a rule,
+  definition, or indicator moves to a different ruleset, process, applicability
+  path, subset, or ID. Treat those as Rules Content Changes and describe the
+  user-visible mapping or migration impact. Only mark such movement as breaking
+  when it also changes the documented data shape, schema vocabulary, required
+  fields, or other machine-readable contract in a way that breaks existing
+  tooling.
 - Mark every breaking change bullet with `**Breaking:**` at the start of the
   bullet in the relevant changelog section. Include the old shape and the new
   shape when known, and briefly state the practical impact. For example,

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -368,7 +368,8 @@
           "tag": "Vulnerability",
           "alts": [
             "fully mitigated vulnerability",
-            "fully mitigated vulnerabilities"
+            "fully mitigated vulnerabilities",
+            "fully mitigate vulnerabilities"
           ],
           "updated": [
             {
@@ -653,7 +654,8 @@
           "tag": "Vulnerability",
           "alts": [
             "partially mitigated vulnerability",
-            "partially mitigated vulnerabilities"
+            "partially mitigated vulnerabilities",
+            "partially mitigate vulnerabilities"
           ],
           "updated": [
             {
@@ -773,7 +775,11 @@
           "term": "Remediated Vulnerability",
           "definition": "A vulnerability that has been neutralized or eliminated and is no longer detected.",
           "tag": "Vulnerability",
-          "alts": ["remediated vulnerability", "remediated vulnerabilities"],
+          "alts": [
+            "remediated vulnerability",
+            "remediated vulnerabilities",
+            "remediate vulnerabilities"
+          ],
           "updated": [
             {
               "date": "2026-07-04",
@@ -6852,55 +6858,21 @@
           "CSO": {
             "VDR-CSO-DET": {
               "name": "Vulnerability Detection",
-              "statement": "Providers MUST systematically, persistently, and promptly discover and identify vulnerabilities within their cloud service offering using appropriate techniques such as assessment, scanning, threat intelligence, vulnerability disclosure mechanisms, bug bounties, supply chain monitoring, and other relevant capabilities; this process is called vulnerability detection.",
+              "statement": "Providers MUST systematically, persistently, and promptly discover and identify vulnerabilities within their cloud service offering using appropriate techniques such as assessment, scanning, threat intelligence, vulnerability disclosure mechanisms, bug bounties, penetration testing, incident response, automated control testing, supply chain monitoring, and other relevant capabilities; this process is called vulnerability detection. Vulnerability detection includes persistently verifying and validating that information resources and processes are operating as intended and documented for controls, Key Security Indicators, and FedRAMP Rules.",
+              "danger": "Vulnerability Detection and Response includes all efforts to identify weaknesses in a system and is NOT limited to traditional vulnerability scanning or testing. An out-of-date control statement in the Security Decision Record is a vulnerability that must be detected and remediated just like any other vulnerability.",
+              "notes": [
+                "FedRAMP's vulnerability detection (and response) rules are intended to set modern expectations for maintaining the security of a cloud service. Historical FedRAMP guidance on vulnerability scanning or continuous monitoring generally focused only on CVE-type vulnerabilities while leaving other types of vulnerabilities and exposures unaddressed.",
+                "Providers are encouraged to leverage their existing holistic security review, architecture review, and similar processes to meet these requirements. FedRAMP strongly discourages providers from implementing separate vulnerability detection and response processes for FedRAMP reporting that are operated by independent compliance branches unless these processes are consuming data directly from the areas of the cloud service that actively maintain it."
+              ],
               "primary_key_word": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
+                "Incident",
+                "Information Resource",
                 "Persistently",
                 "Promptly",
                 "Provider",
-                "Vulnerability",
-                "Vulnerability Detection"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "VDR-CSO-PVV": {
-              "name": "Persistent Verification and Validation",
-              "statement": "Providers MUST persistently verify and validate that their information resources are operating as intended; this process is called Persistent Verification and Validation (PVV) and is part of vulnerability detection.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "Information Resource",
-                "Persistently",
-                "Provider",
-                "Validation",
-                "Verification",
-                "Vulnerability",
-                "Vulnerability Detection"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "VDR-CSO-FAV": {
-              "name": "Failures Are Vulnerabilities",
-              "statement": "Providers MUST treat problems detected during persistent verification and validation as vulnerabilities, including failures of the verification and validation process it; FedRAMP Vulnerability Detection and Response rules MUST be followed for such findings.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "Persistently",
-                "Provider",
-                "Validation",
-                "Verification",
                 "Vulnerability",
                 "Vulnerability Detection",
                 "Vulnerability Response"
@@ -6915,13 +6887,38 @@
             "VDR-CSO-RES": {
               "name": "Vulnerability Response",
               "statement": "Providers MUST systematically, persistently, and promptly track, evaluate, monitor, mitigate, remediate, assess exploitation of, report, and otherwise manage all detected vulnerabilities within their cloud service offering; this process is called vulnerability response.",
-              "note": "If it is not possible to fully mitigate or remediate detected vulnerabilities, providers SHOULD instead partially mitigate vulnerabilities promptly, progressively, and persistently.",
+              "notes": [
+                "If it is not possible to fully mitigate vulnerabilities or remediate vulnerabilities, providers SHOULD instead partially mitigate vulnerabilities promptly, progressively, and persistently.",
+                "FedRAMP does not use the terms \"mitigation\" and \"remediation\" interchangeably. Mitigation is the process of reducing the risk and impact of a vulnerability through partial mitigation and even full mitigation; remediation is the process of entirely eliminating the vulnerability. A fully mitigated vulnerability will still exist (with negligible risk) until it has been remediated. This separation is based on the plain language definitions of these words.",
+                "Please refer to FedRAMP Definitions for strict interpretation in the FedRAMP context."
+              ],
               "primary_key_word": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
+                "Fully Mitigated Vulnerability",
+                "Partially Mitigated Vulnerability",
                 "Persistently",
                 "Promptly",
+                "Provider",
+                "Remediated Vulnerability",
+                "Vulnerability",
+                "Vulnerability Detection",
+                "Vulnerability Response"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "VDR-CSO-FAV": {
+              "name": "Failures Are Vulnerabilities",
+              "statement": "Providers MUST treat problems or failures with their vulnerability detection and response processes as vulnerabilities.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": [
                 "Provider",
                 "Vulnerability",
                 "Vulnerability Detection",
@@ -7733,7 +7730,7 @@
               "name": "Mitigation and Remediation Expectations",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers with Class A Certifications SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower potential adverse impact within the timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability.",
+                  "statement": "Providers with Class A Certifications SHOULD partially mitigate vulnerabilities, fully mitigate vulnerabilities, or remediate vulnerabilities to a lower potential adverse impact within the timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability.",
                   "primary_key_word": "SHOULD",
                   "pain_timeframes": {
                     "1": {},
@@ -7808,7 +7805,7 @@
                   }
                 },
                 "b": {
-                  "statement": "Providers with Class B Certifications SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower potential adverse impact within the timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
+                  "statement": "Providers with Class B Certifications SHOULD partially mitigate vulnerabilities, fully mitigate vulnerabilities, or remediate vulnerabilities to a lower potential adverse impact within the timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
                   "primary_key_word": "SHOULD",
                   "pain_timeframes": {
                     "1": {},
@@ -7883,7 +7880,7 @@
                   }
                 },
                 "c": {
-                  "statement": "Providers with Class C Certifications SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower Potential Agency Impact N-rating within the timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
+                  "statement": "Providers with Class C Certifications SHOULD partially mitigate vulnerabilities, fully mitigate vulnerabilities, or remediate vulnerabilities to a lower Potential Agency Impact N-rating within the timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
                   "primary_key_word": "SHOULD",
                   "pain_timeframes": {
                     "1": {},
@@ -7958,7 +7955,7 @@
                   }
                 },
                 "d": {
-                  "statement": "Providers with Class D Certifications SHOULD partially mitigate, fully mitigate, or remediate vulnerabilities to a lower Potential Agency Impact N-rating within the maximum timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
+                  "statement": "Providers with Class D Certifications SHOULD partially mitigate vulnerabilities, fully mitigate vulnerabilities, or remediate vulnerabilities to a lower Potential Agency Impact N-rating within the maximum timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
                   "primary_key_word": "SHOULD",
                   "pain_timeframes": {
                     "1": {},
@@ -8036,9 +8033,12 @@
               "affects": ["Providers"],
               "terms": [
                 "Agency",
+                "Fully Mitigated Vulnerability",
                 "Likely",
+                "Partially Mitigated Vulnerability",
                 "Potential Agency Impact",
                 "Provider",
+                "Remediated Vulnerability",
                 "Vulnerability"
               ],
               "updated": [
@@ -8065,19 +8065,19 @@
               "name": "Internet-Reachable Incidents",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers with Class A Certifications MAY treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated to N3 or below.",
+                  "statement": "Providers with Class A Certifications MAY treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated vulnerabilities at N3 or below.",
                   "primary_key_word": "MAY"
                 },
                 "b": {
-                  "statement": "Providers with Class B Certifications MAY treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated to N3 or below.",
+                  "statement": "Providers with Class B Certifications MAY treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated vulnerabilities at N3 or below.",
                   "primary_key_word": "MAY"
                 },
                 "c": {
-                  "statement": "Providers with Class C Certifications SHOULD treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated to N3 or below.",
+                  "statement": "Providers with Class C Certifications SHOULD treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated vulnerabilities at N3 or below.",
                   "primary_key_word": "SHOULD"
                 },
                 "d": {
-                  "statement": "Providers with Class D Certifications SHOULD treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated to N3 or below.",
+                  "statement": "Providers with Class D Certifications SHOULD treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated vulnerabilities at N3 or below.",
                   "primary_key_word": "SHOULD"
                 }
               },
@@ -8088,6 +8088,7 @@
                 "Incident",
                 "Likely",
                 "Likely Exploitable Vulnerability (LEV)",
+                "Partially Mitigated Vulnerability",
                 "Potential Agency Impact",
                 "Provider",
                 "Vulnerability"
@@ -8103,19 +8104,19 @@
               "name": "Non-Internet-Reachable Incidents",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers with Class A Certifications MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated to N4 or below.",
+                  "statement": "Providers with Class A Certifications MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated vulnerabilities at N4 or below.",
                   "primary_key_word": "MAY"
                 },
                 "b": {
-                  "statement": "Providers with Class B Certifications MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated to N4 or below.",
+                  "statement": "Providers with Class B Certifications MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated vulnerabilities at N4 or below.",
                   "primary_key_word": "MAY"
                 },
                 "c": {
-                  "statement": "Providers with Class C Certifications MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated to N4 or below.",
+                  "statement": "Providers with Class C Certifications MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated vulnerabilities at N4 or below.",
                   "primary_key_word": "MAY"
                 },
                 "d": {
-                  "statement": "Providers with Class D Certifications SHOULD treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated to N4 or below.",
+                  "statement": "Providers with Class D Certifications SHOULD treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated vulnerabilities at N4 or below.",
                   "primary_key_word": "SHOULD"
                 }
               },
@@ -8126,6 +8127,7 @@
                 "Incident",
                 "Likely",
                 "Likely Exploitable Vulnerability (LEV)",
+                "Partially Mitigated Vulnerability",
                 "Potential Agency Impact",
                 "Provider",
                 "Vulnerability"

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -2,8 +2,8 @@
   "info": {
     "title": "FedRAMP Consolidated Rules for 2026 Public Preview",
     "description": "This datafile contains the Consolidated Rules for FedRAMP in structured machine-readable text. It includes definitions, requirements, recommendations, and key security indicators.",
-    "version": "2026.05.28.01-preview",
-    "last_updated": "2026-05-28",
+    "version": "2026.05.31.01-preview",
+    "last_updated": "2026-05-31",
     "default_artifacts": {
       "FRR": [
         "Explanation of how the rule is followed, or an explanation of the reason and resulting risk to customers for not following the rule.",
@@ -1046,7 +1046,7 @@
             "AGU-AGC-AIP": {
               "name": "Agency Internal Policies",
               "statement": "Agencies MUST maintain agency-wide policy that aligns with the requirements in OMB Memorandum M-24-15.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Agencies"],
               "terms": ["Agency"],
               "updated": [
@@ -1063,7 +1063,7 @@
                 "A copy of the Authorization to Operate letter",
                 "All other supplementary information outlined at https://help.fedramp.gov/ato"
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Agencies"],
               "notification": [
                 {
@@ -1087,7 +1087,7 @@
                 "Open Security Controls Assessment Language (OSCAL)",
                 "JSON"
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Agencies"],
               "terms": ["Agency", "Artifacts", "Machine-Readable"],
               "updated": [
@@ -1101,7 +1101,7 @@
               "name": "Notify Additional Information Requests",
               "statement": "Agencies MUST notify FedRAMP after requesting any additional information or materials from a FedRAMP Certified cloud service offering beyond those FedRAMP requires.",
               "note": "Agencies are expected to notify FedRAMP under OMB Memorandum M-24-15 section IV (a).",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Agencies"],
               "notification": [
                 {
@@ -1126,7 +1126,7 @@
               "name": "No Additional Security Requirements",
               "statement": "Agencies MUST NOT require additional information or materials from FedRAMP Certified cloud service offerings beyond those required by FedRAMP UNLESS the head of the agency or an authorized delegate determines there is a demonstrable need; this does not apply to seeking clarification or asking general questions about FedRAMP Certification Data.",
               "note": "This is related to the Presumption of Adequacy for a FedRAMP Certification.",
-              "primary_key_word": "MUST NOT",
+              "force": "MUST NOT",
               "affects": ["Agencies"],
               "terms": [
                 "Agency",
@@ -1144,7 +1144,7 @@
             "AGU-AGC-WKG": {
               "name": "FedRAMP Working Groups",
               "statement": "Agencies SHOULD participate in FedRAMP working groups, communities of practice, and stakeholder engagements to supply feedback and align practices across government.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Agencies"],
               "terms": ["Agency"],
               "updated": [
@@ -1159,7 +1159,7 @@
               "statement": "Agencies SHOULD assign at least 1 federal employee to be an active participant in the FedRAMP Agency Liaison program.",
               "reference": "Agency Liaison Program",
               "reference_url": "https://www.fedramp.gov/preview/2026/agencies/support/liaisons",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Agencies"],
               "terms": ["Agency"],
               "updated": [
@@ -1173,7 +1173,7 @@
               "name": "Shared FedRAMP Inbox",
               "statement": "Agencies SHOULD establish and maintain a dedicated shared FedRAMP agency inbox to serve as the official point of contact for communications between FedRAMP and the agency.",
               "note": "A shared FedRAMP agency inbox may follow an agency-specific format such as agency-fedramp@agency.gov.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Agencies"],
               "terms": ["Agency"],
               "updated": [
@@ -1191,7 +1191,7 @@
               "note": "FedRAMP provides technical assistance to help agencies navigate this process.",
               "reference": "Using a FedRAMP Certified Cloud Service Offering",
               "reference_url": "https://fedramp.gov/preview/2026/agencies/use",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Agencies"],
               "terms": [
                 "Agency",
@@ -1208,7 +1208,7 @@
             "AGU-USE-RCF": {
               "name": "Resolve Certification Package Conflicts",
               "statement": "Agencies MUST collaborate with FedRAMP when discrepancies or conflicts arise between agency-specific security determinations and the baseline FedRAMP Certification package.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Agencies"],
               "terms": ["Agency", "Certification Package"],
               "updated": [
@@ -1221,7 +1221,7 @@
             "AGU-USE-RSG": {
               "name": "Review Secure Configuration Guides",
               "statement": "Agencies MUST review the Secure Configuration Guides supplied by Providers and configure relevant security settings.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Agencies"],
               "terms": ["Agency", "Provider"],
               "updated": [
@@ -1234,7 +1234,7 @@
             "AGU-USE-AFR": {
               "name": "Accept FedRAMP Rules",
               "statement": "Agencies MUST allow FedRAMP Certified cloud service offerings to follow FedRAMP rules.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Agencies"],
               "terms": [
                 "Agency",
@@ -1252,7 +1252,7 @@
               "name": "Notify FedRAMP of Concerns",
               "statement": "Agencies MUST notify FedRAMP if information presented in an Ongoing Authorization Report, Quarterly Review, or other FedRAMP Certification Data causes significant concerns for the authorizing official that would likely result in rescission of their Authorization to Operate.",
               "note": "Agencies are expected to notify FedRAMP under OMB Memorandum M-24-15 section IV (a).",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Agencies"],
               "notification": [
                 {
@@ -1278,7 +1278,7 @@
               "name": "Review Ongoing Authorization Reports",
               "statement": "Agencies SHOULD review each Ongoing Authorization Report to understand how changes to the cloud service offering may impact the risk tolerance documented in the agency Authorization to Operate for the federal information system that includes the cloud service offering in its boundary.",
               "note": "This agency review supports agency responsibilities under 44 USC § 35, OMB Circular A-130, FIPS-200, and OMB Memorandum M-24-15.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Agencies"],
               "terms": ["Agency", "Cloud Service Offering"],
               "updated": [
@@ -1291,7 +1291,7 @@
             "AGU-USE-DSO": {
               "name": "Designate Senior Official",
               "statement": "Agencies SHOULD designate a federal senior information security official to review Ongoing Authorization Reports and represent the agency at Quarterly Reviews for cloud service offerings included in agency information systems.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Agencies"],
               "terms": ["Agency", "Cloud Service Offering", "Quarterly Review"],
               "updated": [
@@ -1304,7 +1304,7 @@
             "AGU-USE-NPC": {
               "name": "Notify Provider of Concerns",
               "statement": "Agencies SHOULD formally notify the Provider if information presented in an Ongoing Authorization Report, Quarterly Review, or other FedRAMP Certification Data causes significant concerns for the authorizing official that would likely result in rescission of their Authorization to Operate.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Agencies"],
               "notification": [
                 {
@@ -1330,7 +1330,7 @@
             "AGU-USE-RIR": {
               "name": "Review All Information Resources",
               "statement": "Agencies SHOULD consider third-party information resources used by the cloud service offering during initial and ongoing authorization activities.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Agencies"],
               "terms": [
                 "Agency",
@@ -1350,7 +1350,7 @@
             "AGU-SPN-MRC": {
               "name": "Most Recent Consolidated Rules",
               "statement": "Agencies MUST follow the most recent FedRAMP Consolidated Rules when initiating agency-sponsored FedRAMP Certification.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Agencies"],
               "terms": ["Agency"],
               "updated": [
@@ -1434,7 +1434,7 @@
               "name": "Review Ongoing Reports",
               "statement": "Agencies MUST review each Ongoing Certification Report to understand how changes to the cloud service offering may impact the previously agreed-upon risk tolerance documented in the agency's Authorization to Operate of a federal information system that includes the cloud service offering in its boundary.",
               "note": "This is required by 44 USC § 35, OMB A-130, FIPS-200, and M-24-15.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Agencies"],
               "terms": [
                 "Agency",
@@ -1453,7 +1453,7 @@
               "name": "Notify FedRAMP of Concerns",
               "statement": "Agencies MUST notify FedRAMP by sending an email to info@fedramp.gov if the information presented in an Ongoing Certification Report, Quarterly Review, or other ongoing FedRAMP Certification Data causes significant concerns that may lead the agency to stop operation of the cloud service offering.",
               "note": "Agencies are required to notify FedRAMP by OMB Memorandum M-24-15 section IV (a).",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Agencies"],
               "notification": [
                 {
@@ -1481,7 +1481,7 @@
               "name": "Notify FedRAMP After Requests",
               "statement": "Agencies MUST notify FedRAMP after requesting any additional information or materials from a cloud service provider beyond those FedRAMP requires by sending an email to info@fedramp.gov.",
               "note": "Agencies are required to notify FedRAMP by OMB Memorandum M-24-15 section IV (a).",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Agencies"],
               "notification": [
                 {
@@ -1502,7 +1502,7 @@
               "name": "No Additional Requirements",
               "statement": "Agencies MUST NOT place additional security requirements on cloud service providers beyond those required by FedRAMP UNLESS the head of the agency or an authorized delegate makes a determination that there is a demonstrable need for such; this does not apply to seeking clarification or asking general questions about FedRAMP Certification Data.",
               "note": "This is a statutory requirement in 44 USC § 3613 (e) related to the Presumption of Adequacy for a FedRAMP Certification.",
-              "primary_key_word": "MUST NOT",
+              "force": "MUST NOT",
               "affects": ["Agencies"],
               "terms": [
                 "Agency",
@@ -1520,7 +1520,7 @@
             "CCM-AGM-CSC": {
               "name": "Consider Security Category",
               "statement": "Agencies SHOULD consider the Security Category noted in their Authorization to Operate of the federal information system that includes the cloud service offering in its boundary and assign appropriate information security resources for reviewing Ongoing Certification Reports, attending Quarterly Reviews, and other ongoing FedRAMP Certification Data.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Agencies"],
               "terms": [
                 "Agency",
@@ -1540,7 +1540,7 @@
             "CCM-AGM-NPC": {
               "name": "Notify Provider of Concerns",
               "statement": "Agencies SHOULD formally notify the provider if the information presented in an Ongoing Certification Report, Quarterly Review, or other ongoing FedRAMP Certification Data causes significant concerns that may lead the agency to remove the cloud service offering from operation.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Agencies"],
               "notification": [
                 {
@@ -1580,7 +1580,7 @@
                 "FedRAMP Reportable Incidents or an attestation that no such incidents occurred",
                 "Lessons learned and changes planned or made as a result of FedRAMP Reportable Incidents (if such occurred)"
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Accepted Vulnerability",
@@ -1606,7 +1606,7 @@
             "CCM-OCR-NRD": {
               "name": "Next Report Date",
               "statement": "Providers MUST supply the target date for their next Ongoing Certification Report with other public FedRAMP Certification Data.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Certification Data",
@@ -1625,7 +1625,7 @@
               "name": "Feedback Mechanism",
               "statement": "Providers MUST supply an asynchronous mechanism for all necessary parties to provide feedback or ask questions about each Ongoing Certification Report.",
               "note": "This could be email by default but providers are encouraged to consider something more interactive as appropriate.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "All Necessary Parties",
@@ -1644,7 +1644,7 @@
               "name": "Anonymized Feedback Summary",
               "statement": "Providers MUST supply an anonymized and desensitized summary of the feedback, questions, and answers about each Ongoing Certification Report as an addendum to the Ongoing Certification Report.",
               "note": "This is intended to encourage sharing of information and decrease the burden on the cloud service provider - providing this summary will reduce duplicate questions from agencies and ensure FedRAMP has access to this information. It is generally in the provider's interest to update this addendum frequently throughout the quarter.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Agency",
@@ -1662,7 +1662,7 @@
             "CCM-OCR-LSI": {
               "name": "Limit Sensitive Information",
               "statement": "Providers MUST NOT irresponsibly disclose sensitive information in an Ongoing Certification Report that would likely have an adverse effect on the cloud service offering.",
-              "primary_key_word": "MUST NOT",
+              "force": "MUST NOT",
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
@@ -1682,7 +1682,7 @@
               "name": "Spread Out Reports",
               "statement": "Providers SHOULD establish a regular 3 month cycle for Ongoing Certification Reports that is spread out from the beginning, middle, or end of each quarter.",
               "note": "This recommendation is intended to discourage hundreds of cloud service providers from releasing their Ongoing Certification Reports during the first or last week of each quarter because that is the easiest way for a single provider to track this deliverable; the result would overwhelm agencies with many cloud services. Widely used cloud service providers are encouraged to work with their customers to identify ideal timeframes for this cycle.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": [
                 "Agency",
@@ -1700,7 +1700,7 @@
             "CCM-OCR-RPS": {
               "name": "Responsible Public Sharing",
               "statement": "Providers MAY responsibly supply some or all of the information an Ongoing Certification Report to the public or other parties if the provider determines doing so will NOT likely have an adverse effect on the cloud service offering.",
-              "primary_key_word": "MAY",
+              "force": "MAY",
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
@@ -1724,25 +1724,25 @@
               "varies_by_class": {
                 "a": {
                   "statement": "Providers with Class A Certifications MAY host a synchronous Quarterly Review every 3 months, open to all necessary parties, to review aspects of the most recent Ongoing Certification Reports that the provider determines are of the most relevance to agencies.",
-                  "primary_key_word": "MAY",
+                  "force": "MAY",
                   "timeframe_type": "months",
                   "timeframe_num": 3
                 },
                 "b": {
                   "statement": "Providers with Class B Certifications SHOULD host a synchronous Quarterly Review every 3 months, open to all necessary parties, to review aspects of the most recent Ongoing Certification Reports that the provider determines are of the most relevance to agencies.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "months",
                   "timeframe_num": 3
                 },
                 "c": {
                   "statement": "Providers with Class C Certifications MUST host a synchronous Quarterly Review every 3 months, open to all necessary parties, to review aspects of the most recent Ongoing Certification Reports that the provider determines are of the most relevance to agencies.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "timeframe_type": "months",
                   "timeframe_num": 3
                 },
                 "d": {
                   "statement": "Providers with Class D Certifications MUST host a synchronous Quarterly Review every 3 months, open to all necessary parties, to review aspects of the most recent Ongoing Certification Reports that the provider determines are of the most relevance to agencies.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "timeframe_type": "months",
                   "timeframe_num": 3
                 }
@@ -1765,7 +1765,7 @@
             "CCM-QTR-REG": {
               "name": "Meeting Registration Info",
               "statement": "Providers MUST supply either a registration link or a downloadable calendar file with meeting information for Quarterly Reviews to all necessary parties.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "All Necessary Parties",
@@ -1782,7 +1782,7 @@
             "CCM-QTR-NRD": {
               "name": "Next Review Date",
               "statement": "Providers MUST publicly supply the target date for their next Quarterly Review with other public FedRAMP Certification Data.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Certification Data", "Provider", "Quarterly Review"],
               "updated": [
@@ -1795,7 +1795,7 @@
             "CCM-QTR-NID": {
               "name": "No Irresponsible Disclosure",
               "statement": "Providers MUST NOT irresponsibly disclose sensitive information in a Quarterly Review that would likely have an adverse effect on the cloud service offering.",
-              "primary_key_word": "MUST NOT",
+              "force": "MUST NOT",
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
@@ -1813,7 +1813,7 @@
             "CCM-QTR-SAR": {
               "name": "Schedule Around Reports",
               "statement": "Providers SHOULD regularly schedule Quarterly Reviews to occur at least 3 business days after releasing an Ongoing Certification Report AND within 10 business days of such release.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": [
                 "Ongoing Certification",
@@ -1832,7 +1832,7 @@
             "CCM-QTR-ACT": {
               "name": "Additional Content",
               "statement": "Providers SHOULD supply additional information in Quarterly Reviews that the provider determines is of interest, use, or otherwise relevant to agencies.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": ["Agency", "Provider", "Quarterly Review"],
               "updated": [
@@ -1845,7 +1845,7 @@
             "CCM-QTR-RTR": {
               "name": "Record/Transcribe Reviews",
               "statement": "Providers SHOULD record or transcribe Quarterly Reviews and supply them to all necessary parties.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": [
                 "All Necessary Parties",
@@ -1863,7 +1863,7 @@
               "name": "Restrict Third Parties",
               "statement": "Providers SHOULD NOT invite third parties to attend Quarterly Reviews intended for agencies unless they have specific relevance.",
               "note": "This is because agencies are less likely to actively participate in meetings with third parties; the cloud service provider's independent assessor should be considered relevant by default.",
-              "primary_key_word": "SHOULD NOT",
+              "force": "SHOULD NOT",
               "affects": ["Providers"],
               "terms": [
                 "Agency",
@@ -1882,7 +1882,7 @@
             "CCM-QTR-SRR": {
               "name": "Share Recordings Responsibly",
               "statement": "Providers MAY responsibly supply recordings or transcriptions of Quarterly Reviews to the public or other parties ONLY if the provider removes all agency information (comments, questions, names, etc.) AND determines doing so will NOT likely have an adverse effect on the cloud service offering.",
-              "primary_key_word": "MAY",
+              "force": "MAY",
               "affects": ["Providers"],
               "terms": [
                 "Agency",
@@ -1902,7 +1902,7 @@
             "CCM-QTR-SCR": {
               "name": "Share Content Responsibly",
               "statement": "Providers MAY responsibly supply content prepared for a Quarterly Review to the public or other parties if the provider determines doing so will NOT likely have an adverse effect on the cloud service offering.",
-              "primary_key_word": "MAY",
+              "force": "MAY",
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
@@ -2032,7 +2032,7 @@
               ],
               "note": "Generally, this information should be available on a public webpage.",
               "related": ["CDS-CSO-SVC", "CCM-OCR-NRD"],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "artifacts": {
                 "all": [
@@ -2059,7 +2059,7 @@
             "CDS-CSO-SVC": {
               "name": "Service List",
               "statement": "Providers MUST publicly share a detailed list of specific services and their security categories that are included in the cloud service offering using clear feature or service names that align with standard public marketing materials; this list MUST be complete enough for a potential customer to determine which services are and are not included in the FedRAMP Minimum Assessment Scope without requesting access to underlying FedRAMP Certification Data.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "artifacts": {
                 "all": [
@@ -2085,22 +2085,22 @@
               "varies_by_class": {
                 "a": {
                   "statement": "Providers with Class A Certifications SHOULD maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service SHOULD be available even if the primary cloud service offering is unavailable.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "note": "This service may be separate from the trust center."
                 },
                 "b": {
                   "statement": "Providers with Class B Certifications MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service MUST be available even if the primary cloud service offering is unavailable.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "note": "This service may be separate from the trust center."
                 },
                 "c": {
                   "statement": "Providers with Class C Certifications MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service MUST be available even if the primary cloud service offering is unavailable.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "note": "This service may be separate from the trust center."
                 },
                 "d": {
                   "statement": "Providers with Class D Certifications MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service MUST be available even if the primary cloud service offering is unavailable.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "note": "This service may be separate from the trust center."
                 }
               },
@@ -2123,7 +2123,7 @@
               "name": "Use Trust Centers",
               "statement": "Providers MUST use a FedRAMP-compatible trust center to store and share FedRAMP Certification Data with all necessary parties.",
               "note": "Rules for FedRAMP-Compatible Trust Centers are explained in the Certification Data Sharing Rules under the FedRAMP-Compatible Trust Centers section (id: CDS-TRC).",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "All Necessary Parties",
@@ -2141,7 +2141,7 @@
             "CDS-CSO-CBF": {
               "name": "Consistency Between Formats",
               "statement": "Providers MUST use automation to ensure information remains consistent between human-readable and machine-readable formats when FedRAMP Certification Data is provided in both formats.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Certification Data", "Machine-Readable", "Provider"],
               "updated": [
@@ -2155,7 +2155,7 @@
               "name": "Responsible Information Sharing",
               "statement": "Providers MUST provide sufficient information in FedRAMP Certification Data to support agency authorization decisions but SHOULD NOT include sensitive information that would likely enable a threat actor to gain unauthorized access, cause harm, disrupt operations, or otherwise have a negative adverse impact on the cloud service offering.",
               "note": "This is not a license to exclude accurate risk information, but specifics that would likely lead to compromise should be abstracted. A breach of confidentiality with FedRAMP Certification Data should be anticipated by a secure cloud service provider.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "examples": [
                 {
@@ -2198,7 +2198,7 @@
                 "maintain": "2027-05-04",
                 "grace_by_assessment_months": 2
               },
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "artifacts": {
                 "all": ["Explanation of how to access this information."]
@@ -2221,7 +2221,7 @@
               "varies_by_class": {
                 "a": {
                   "statement": "Providers with Class A Certifications MAY supply per-service FedRAMP Certification materials.",
-                  "primary_key_word": "MAY",
+                  "force": "MAY",
                   "artifacts": {
                     "all": [
                       "Explanation of the supplied materials, including how to access and use them."
@@ -2230,7 +2230,7 @@
                 },
                 "b": {
                   "statement": "Providers with Class B Certifications MAY supply per-service FedRAMP Certification materials.",
-                  "primary_key_word": "MAY",
+                  "force": "MAY",
                   "artifacts": {
                     "all": [
                       "Explanation of the supplied materials, including how to access and use them."
@@ -2239,7 +2239,7 @@
                 },
                 "c": {
                   "statement": "Providers with Class C Certifications MAY supply per-service FedRAMP Certification materials.",
-                  "primary_key_word": "MAY",
+                  "force": "MAY",
                   "artifacts": {
                     "all": [
                       "Explanation of the supplied materials, including how to access and use them."
@@ -2248,7 +2248,7 @@
                 },
                 "d": {
                   "statement": "Providers with Class D Certifications MUST supply per-service FedRAMP Certification materials.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "effective_date": {
                     "obtain": "2027-05-04",
                     "maintain": "2027-05-04",
@@ -2277,7 +2277,7 @@
             "CDS-CSO-RPS": {
               "name": "Responsible Public Sharing",
               "statement": "Providers MAY responsibly share some or all of the information in a FedRAMP Certification Package publicly or with other parties if the provider determines doing so will NOT likely have an adverse effect on the cloud service offering.",
-              "primary_key_word": "MAY",
+              "force": "MAY",
               "affects": ["Providers"],
               "artifacts": {
                 "all": [
@@ -2304,7 +2304,7 @@
               "name": "Uninterrupted Sharing",
               "statement": "Trust centers MUST share FedRAMP Certification Data with all necessary parties without interruption.",
               "note": "\"Without interruption\" means that parties should not have to request manual approval each time they need to access FedRAMP Certification Data or go through a complicated process. The preferred way of ensuring access without interruption is to use on-demand just-in-time access provisioning.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "All Necessary Parties",
@@ -2321,7 +2321,7 @@
             "CDS-TRC-PAC": {
               "name": "Programmatic Access",
               "statement": "Trust centers MUST provide documented programmatic access to all FedRAMP Certification Data, including programmatic access to human-readable materials.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "artifacts": {
                 "all": ["URL to the documentation for programmatic access."]
@@ -2337,7 +2337,7 @@
             "CDS-TRC-AAI": {
               "name": "Agency Access Inventory",
               "statement": "Trust centers MUST maintain an inventory and history of federal agency users or systems with access to FedRAMP Certification Data and MUST make this information available to FedRAMP upon request.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "artifacts": {
                 "all": [
@@ -2355,7 +2355,7 @@
             "CDS-TRC-ACL": {
               "name": "Access Logging",
               "statement": "Trust centers MUST log access to FedRAMP Certification Data and store summaries of access for at least six months; such information, as it pertains to specific parties, SHOULD be made available upon request by those parties.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "artifacts": {
                 "all": [
@@ -2373,7 +2373,7 @@
             "CDS-TRC-HMR": {
               "name": "Human and Machine-Readable",
               "statement": "Trust centers SHOULD make FedRAMP Certification Data available to view and download in both human-readable and machine-readable formats.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": [
                 "Certification Data",
@@ -2390,7 +2390,7 @@
             "CDS-TRC-SSM": {
               "name": "Self-Service Access Management",
               "statement": "Trust centers SHOULD include features that encourage all necessary parties to provision and manage access to FedRAMP Certification Data for their users and services directly.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "artifacts": {
                 "all": [
@@ -2414,7 +2414,7 @@
             "CDS-UTC-PGD": {
               "name": "Public Guidance",
               "statement": "Providers MUST publicly provide plain-language policies and guidance for all necessary parties that explains how they can obtain and manage access to FedRAMP Certification Data stored in the trust center.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "artifacts": {
                 "all": [
@@ -2437,7 +2437,7 @@
             "CDS-UTC-AAD": {
               "name": "Agency Access Denial",
               "statement": "Providers MUST notify FedRAMP by email to info@fedramp.gov within 5 business days of denying an agency access request for FedRAMP Certification Data.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "timeframe_type": "bizdays",
               "timeframe_num": 5,
@@ -2459,7 +2459,7 @@
             "CDS-UTC-AGA": {
               "name": "Agency Access",
               "statement": "Providers SHOULD share the FedRAMP Certification package with agencies upon request.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "artifacts": {
                 "all": [
@@ -2485,7 +2485,7 @@
             "CDS-CSF-TCM": {
               "name": "Trust Center Migration",
               "statement": "Providers MUST notify all necessary parties when migrating to a trust center and MUST provide information in their existing USDA Connect Community Portal secure folders explaining how to use the trust center to obtain FedRAMP Certification Data.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "notification": [
                 {
@@ -2512,7 +2512,7 @@
               "varies_by_class": {
                 "a": {
                   "statement": "Providers with Class A Certifications MUST supply semi-structured text-based FedRAMP Certification Data.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "effective_date": {
                     "obtain": "2027-01-01",
                     "maintain": "2027-05-04",
@@ -2521,7 +2521,7 @@
                 },
                 "b": {
                   "statement": "Providers with Class B Certifications MUST supply semi-structured text-based FedRAMP Certification Data.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "effective_date": {
                     "obtain": "2027-01-01",
                     "maintain": "2027-05-04",
@@ -2530,7 +2530,7 @@
                 },
                 "c": {
                   "statement": "Providers with Class C Certifications MUST supply semi-structured text-based FedRAMP Certification Data.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "effective_date": {
                     "obtain": "2027-01-01",
                     "maintain": "2027-05-04",
@@ -2539,7 +2539,7 @@
                 },
                 "d": {
                   "statement": "Providers with Class D Certifications MUST supply comprehensive machine-readable FedRAMP Certification Data.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "effective_date": {
                     "obtain": "2027-05-04",
                     "maintain": "2027-05-04",
@@ -2702,7 +2702,7 @@
             "FRC-FRP-MCM": {
               "name": "Minimum Continuous Monitoring",
               "statement": "FedRAMP MUST perform a minimum level of continuous monitoring for cloud service offerings with FedRAMP Program Certification, including at least reviewing Ongoing Certification Reports.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["FedRAMP"],
               "terms": ["Cloud Service Offering", "Ongoing Certification"],
               "updated": [
@@ -2720,7 +2720,7 @@
                 "Exemptions will typically be part of a public prioritization process and criteria will be published publicly.",
                 "Do not ask FedRAMP for an exemption unless the publicly published criteria is met."
               ],
-              "primary_key_word": "MAY",
+              "force": "MAY",
               "affects": ["FedRAMP"],
               "terms": [],
               "updated": [
@@ -2737,7 +2737,7 @@
               "statement": "Providers MUST follow and persistently address the FedRAMP Certification Data Sharing (CDS) rules, based on the applicability and effective date(s) in those rules.",
               "reference": "FedRAMP Certification Data Sharing",
               "reference_url_web_name": "certification-data-sharing",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "controls": [
                 "ac-3",
@@ -2763,7 +2763,7 @@
               "statement": "Providers MUST follow and persistently address the Collaborative Continuous Monitoring (CCM) rules, based on the applicability and effective date(s) in those rules.",
               "reference": "Collaborative Continuous Monitoring",
               "reference_url_web_name": "collaborative-continuous-monitoring",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Persistently", "Provider"],
               "updated": [
@@ -2778,7 +2778,7 @@
               "statement": "Providers MUST follow and persistently address the FedRAMP Security Inbox (FSI) rules, based on the applicability and effective date(s) in those rules.",
               "reference": "FedRAMP Security Inbox",
               "reference_url_web_name": "fedramp-security-inbox",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["FedRAMP Security Inbox", "Persistently", "Provider"],
               "updated": [
@@ -2793,7 +2793,7 @@
               "statement": "Providers MUST follow and persistently address the FedRAMP Incident Communications Procedures (ICP) rules, based on the applicability and effective date(s) in those rules.",
               "reference": "Incident Communications Procedures",
               "reference_url_web_name": "incident-communications-procedures",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Incident", "Persistently", "Provider"],
               "updated": [
@@ -2808,7 +2808,7 @@
               "statement": "Providers MUST follow and persistently address the FedRAMP Minimum Assessment Scope (MAS) rules, based on the applicability and effective date(s) in those rules.",
               "reference": "Minimum Assessment Scope",
               "reference_url_web_name": "minimum-assessment-scope",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "controls": [
                 "ac-1",
@@ -2854,7 +2854,7 @@
               "statement": "Providers MUST follow and persistently address the FedRAMP Secure Configuration Guide (SCG) rules, based on the applicability and effective date(s) in those rules.",
               "reference": "Secure Configuration Guide",
               "reference_url_web_name": "secure-configuration-guide",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Persistently", "Provider"],
               "updated": [
@@ -2869,7 +2869,7 @@
               "statement": "Providers MUST follow and persistently address the FedRAMP Significant Change Notifications (SCN) rules, based on the applicability and effective date(s) in those rules.",
               "reference": "Significant Change Notifications",
               "reference_url_web_name": "significant-change-notifications",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "controls": [
                 "ca-7.4",
@@ -2903,7 +2903,7 @@
               "statement": "Providers MUST follow and persistently address the FedRAMP Using Cryptographic Modules (UCM) rules, based on the applicability and effective date(s) in those rules.",
               "reference": "Using Cryptographic Modules",
               "reference_url_web_name": "using-cryptographic-modules",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Persistently", "Provider"],
               "updated": [
@@ -2918,7 +2918,7 @@
               "statement": "Providers MUST follow and persistently address the FedRAMP Vulnerability Detection and Response (VDR) rules, based on the applicability and effective date(s) in those rules.",
               "reference": "Vulnerability Detection and Response",
               "reference_url_web_name": "vulnerability-detection-and-response",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "controls": [
                 "ca-2",
@@ -2983,25 +2983,25 @@
               "varies_by_class": {
                 "a": {
                   "statement": "Providers with Class A Certifications MAY persistently complete an independent verification and validation assessment at least once per year; these assessments MAY be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MAY be included in their FedRAMP Certification Data without inappropriate modification.",
-                  "primary_key_word": "MAY",
+                  "force": "MAY",
                   "timeframe_type": "years",
                   "timeframe_num": 1
                 },
                 "b": {
                   "statement": "Providers with Class B Certifications MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "timeframe_type": "years",
                   "timeframe_num": 1
                 },
                 "c": {
                   "statement": "Providers with Class C Certifications MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "timeframe_type": "years",
                   "timeframe_num": 1
                 },
                 "d": {
                   "statement": "Providers with Class D Certifications MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "timeframe_type": "years",
                   "timeframe_num": 1
                 }
@@ -3033,7 +3033,7 @@
               "name": "Pick One Program Certification Type",
               "statement": "Providers MUST NOT seek both FedRAMP Rev5 Program Certification and FedRAMP 20x Program Certification for the same cloud service offering; pick one type.",
               "note": "This rule does not prevent a provider from seeking and maintaining a FedRAMP Rev5 Agency Certification and a FedRAMP 20x Program Certification for the same cloud service offering, however, doing so is strongly discouraged due to the increased complexity and risk of confusion for all parties.",
-              "primary_key_word": "MUST NOT",
+              "force": "MUST NOT",
               "affects": ["Providers"],
               "terms": ["Agency", "Cloud Service Offering", "Provider"],
               "updated": [
@@ -3046,7 +3046,7 @@
             "FRC-CSO-STE": {
               "name": "Supply Technical Evidence",
               "statement": "Providers SHOULD supply all necessary accessors with technical explanations, demonstrations, and other relevant supporting information about the technical capabilities they employ to address FedRAMP rules; this SHOULD be supplied as necessary to ensure the assessor can effectively complete verification and validation.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": ["Assessor", "Provider", "Validation", "Verification"],
               "updated": [
@@ -3059,7 +3059,7 @@
             "FRC-CSO-RAA": {
               "name": "Receiving Assessor Advice",
               "statement": "Providers MAY ask for and accept advice from their assessor during assessment regarding techniques and procedures that will improve their security posture or the effectiveness, clarity, and accuracy of their verification, validation and reporting procedures, UNLESS doing so is likely to compromise the objectivity and integrity of the assessment.",
-              "primary_key_word": "MAY",
+              "force": "MAY",
               "affects": ["Providers"],
               "terms": [
                 "Assessor",
@@ -3080,7 +3080,7 @@
             "FRC-IAS-VVP": {
               "name": "Verify and Validate Processes",
               "statement": "Assessors MUST verify and validate the implementation of processes derived from FedRAMP requirements, including rules, controls and Key Security Indicators, to determine whether or not the provider has accurately documented their process and security goals for the cloud service offering.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "terms": [
                 "Assessor",
@@ -3099,7 +3099,7 @@
             "FRC-IAS-OUC": {
               "name": "Outcome Consistency",
               "statement": "Assessors MUST verify and validate whether or not the underlying processes are consistently creating the desired security outcome documented by the provider.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "terms": ["Assessor", "Provider", "Validation", "Verification"],
               "updated": [
@@ -3113,7 +3113,7 @@
               "name": "Procedure Adherence",
               "statement": "Assessors MUST assess whether or not procedures are consistently followed, including evaluating the processes in place to ensure this occurs, without relying solely on the existence of procedure documents.",
               "note": "This includes evaluating tests or plans for activities that may occur in the future but have not yet occurred.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "terms": ["Assessor"],
               "updated": [
@@ -3126,7 +3126,7 @@
             "FRC-IAS-MME": {
               "name": "Mixed Methods Evaluation",
               "statement": "Assessors MUST perform verification and validation using a combination of quantitative and expert qualitative assessment as appropriate AND document which is applied to which aspect of the assessment.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "terms": ["Assessor", "Validation", "Verification"],
               "updated": [
@@ -3139,7 +3139,7 @@
             "FRC-IAS-SUM": {
               "name": "Assessment Summary",
               "statement": "Assessors MUST deliver a high-level summary of their assessment process and findings for each FedRAMP requirement, including rules, controls, and Key Security Indicators; this summary will be included in the FedRAMP Certification Data for the cloud service offering.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "terms": [
                 "Assessor",
@@ -3157,7 +3157,7 @@
               "name": "Overall Summary of Assessment",
               "statement": "Assessors MUST supply an overall summary of the verification and validation assessment results, including any resulting failures or areas of dispute, to the provider and all necessary assessors.",
               "note": "FedRAMP will make the final FedRAMP Certification decision based on the assessor's findings and other relevant information.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "terms": [
                 "All Necessary Assessors",
@@ -3176,7 +3176,7 @@
             "FRC-IAS-EPX": {
               "name": "Engage Provider Experts",
               "statement": "Assessors SHOULD engage provider experts in discussion to understand the decisions made by the provider and inform expert qualitative assessment, and SHOULD perform independent research to test such information as part of the expert qualitative assessment process.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Assessors"],
               "terms": ["Assessor", "Provider"],
               "updated": [
@@ -3189,7 +3189,7 @@
             "FRC-IAS-SHA": {
               "name": "Sharing Advice",
               "statement": "Assessors MAY share advice with providers they are assessing about techniques and procedures that will improve the provider's security posture or the effectiveness, clarity, and accuracy of their verification, validation and reporting procedures, UNLESS doing so is likely to compromise the objectivity and integrity of the assessment.",
-              "primary_key_word": "MAY",
+              "force": "MAY",
               "affects": ["Assessors"],
               "terms": [
                 "Assessor",
@@ -3215,7 +3215,7 @@
                 "SOC 2 Type II",
                 "GovRAMP"
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Provider"],
               "updated": [
@@ -3228,7 +3228,7 @@
             "FRC-CLA-EAM": {
               "name": "External Assessment Materials",
               "statement": "Providers seeking a FedRAMP Class A Certification MUST supply the full materials from the alternative security assessment to all necessary parties as part of the FedRAMP Certification Package.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "All Necessary Parties",
@@ -3276,7 +3276,7 @@
                 "CCM-OCR-AVL",
                 "CCM-OCR-NRD"
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Agency",
@@ -3304,7 +3304,7 @@
             "FRC-CLA-IVV": {
               "name": "Optional Independent Verification and Validation",
               "statement": "Providers seeking a FedRAMP Class A Certification MAY have the FedRAMP Certification Package independently verified and validated by a FedRAMP Recognized assessor before submission to FedRAMP.",
-              "primary_key_word": "MAY",
+              "force": "MAY",
               "affects": ["Providers"],
               "terms": [
                 "Assessor",
@@ -3327,7 +3327,7 @@
               "name": "Marketplace Listing First",
               "statement": "Providers MUST be listed in the FedRAMP Marketplace before applying for FedRAMP Certification.",
               "note": "See FedRAMP's Marketplace Listing rules for information about being listed in the Marketplace in the Preparation Phase prior to receiving a formal FedRAMP Certification.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Provider"],
               "updated": [
@@ -3342,7 +3342,7 @@
               "statement": "Providers MUST complete the FedRAMP Certification Application Form at https://fedramp.gov/forms/provider-listing-request/ in full to request an initial assessment by FedRAMP.",
               "reference": "FedRAMP Certification Application Form",
               "reference_url": "https://fedramp.gov/forms",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Provider"],
               "updated": [
@@ -3355,7 +3355,7 @@
             "FRC-APP-FCP": {
               "name": "Fresh FedRAMP Certification Package",
               "statement": "Providers MUST supply a fresh initial FedRAMP Certification Package that shows the current status of the cloud service offering as verified and validated by the provider within the previous 7 days.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Certification Package",
@@ -3374,7 +3374,7 @@
             "FRC-APP-FIA": {
               "name": "Fresh Independent Assessment",
               "statement": "Providers MUST supply a fresh initial independent verification and validation assessment that was completed by a FedRAMP Recognized Independent Assessment Service within the previous 3 months.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "FedRAMP Recognized",
@@ -3394,7 +3394,7 @@
             "FRC-APS-ATO": {
               "name": "Agency Authorization to Operate",
               "statement": "Providers seeking a FedRAMP Rev5 Agency Certification MUST have completed the Authorization to Operate (ATO) process with their agency sponsor for the cloud service offering, concluding with a formal signed ATO letter that the agency has sent over official government channels to FedRAMP.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Agency", "Cloud Service Offering", "Provider"],
               "updated": [
@@ -3419,7 +3419,7 @@
                 "Current implementation status",
                 "Any clarifications or responses to the assessment summary"
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Machine-Based (Information Resources)",
@@ -3436,7 +3436,7 @@
             "FRC-CSX-MAS": {
               "name": "Application within MAS",
               "statement": "Providers SHOULD apply ALL Key Security Indicators to ALL aspects of their cloud service offering that are within the FedRAMP Minimum Assessment Scope.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": ["Cloud Service Offering", "Provider"],
               "updated": [
@@ -3456,7 +3456,7 @@
                 "The effectiveness, completeness, and integrity of the human processes that perform validation of the cloud service offering's security posture",
                 "The coverage of these processes within the cloud service offering, including if all of the consolidated information resources listed are being validated."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "terms": [
                 "Assessor",
@@ -3477,7 +3477,7 @@
             "FRC-IAX-STE": {
               "name": "Static Evidence",
               "statement": "Assessors MUST NOT rely on screenshots, configuration dumps, or other static output as evidence EXCEPT when evaluating the accuracy and reliability of a process that generates such artifacts.",
-              "primary_key_word": "MUST NOT",
+              "force": "MUST NOT",
               "affects": ["Assessors"],
               "terms": ["Artifacts", "Assessor"],
               "updated": [
@@ -3504,7 +3504,7 @@
                 "The mapping must be available in both machine-readable and human-readable formats.",
                 "If a mapping is not clear, the provider should supply new information indicating that the Key Security Indicator has not been independently audited."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Machine-Readable", "Provider"],
               "updated": [
@@ -3522,7 +3522,7 @@
               "name": "Class D Program Certification Exclusion",
               "statement": "Providers seeking a FedRAMP Rev5 Class D Certification MUST use the FedRAMP Agency Certification path.",
               "note": "FedRAMP will not perform FedRAMP Rev5 Class D Program Certifications.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Agency", "Provider"],
               "updated": [
@@ -3536,7 +3536,7 @@
               "name": "FedRAMP Ready Conversion",
               "statement": "Providers with FedRAMP Rev5 Ready status MUST convert to a FedRAMP Certification before the furthest date of the expiration of their most recently yearly assessment or November 17, 2026; the legacy FedRAMP Ready status will be entirely removed on December 31, 2027.",
               "note": "Cloud services that do not wish to convert or do not meet conversion criteria will be renamed Legacy FedRAMP Ready and otherwise retired from FedRAMP Ready.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Provider"],
               "updated": [
@@ -3555,7 +3555,7 @@
                 "The only approved alternative security frameworks based on the SP 800-53 Revision 5 are FedRAMP Ready and GovRAMP.",
                 "An independent assessment is not required for FedRAMP Rev5 Class A Certification."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Provider"],
               "updated": [
@@ -3615,7 +3615,7 @@
               "name": "Verified Emails",
               "statement": "FedRAMP MUST send messages to cloud service providers using an official @fedramp.gov or @gsa.gov email address with properly configured Sender Policy Framework (SPF), DomainKeys Identified Mail (DKIM), and Domain-based Message Authentication Reporting and Conformance (DMARC) email authentication.",
               "note": "Anyone at GSA can send email from @fedramp.gov or @gsa.gov - FedRAMP team members will typically have \"FedRAMP\" or \"Q20B\" in their name but this is not universal or enforceable. The nature of government enterprise IT services makes it difficult for FedRAMP to isolate FedRAMP-specific team members with enforceable identifiers.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["FedRAMP"],
               "terms": ["Provider"],
               "updated": [
@@ -3634,7 +3634,7 @@
                 "**Important:** There is an important issue that FedRAMP requires the cloud service provider to address; important messages will contain reasonable timeframes for reaction and failure to meet these timeframes may result in corrective action."
               ],
               "note": "Messages sent by FedRAMP without one of these designators are considered general communications and do not require an elevated reaction; these may be resolved in the normal course of business by the cloud service provider.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["FedRAMP"],
               "terms": ["FedRAMP Security Inbox", "Incident", "Provider"],
               "updated": [
@@ -3647,7 +3647,7 @@
             "FSI-FRP-UFS": {
               "name": "Use FedRAMP_Security Email in Emergencies",
               "statement": "FedRAMP MUST send Emergency and Emergency Test designated messages from fedramp_security@gsa.gov OR fedramp_security@fedramp.gov.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["FedRAMP"],
               "updated": [
                 {
@@ -3663,7 +3663,7 @@
                 "Public notice may include blog posts, social media posts, announcements during Community Updates, or e-blasts.",
                 "As this process matures, additional confirmed options may become available."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["FedRAMP"],
               "timeframe_type": "bizdays",
               "timeframe_num": 10,
@@ -3685,7 +3685,7 @@
             "FSI-FRP-RQA": {
               "name": "Required Actions",
               "statement": "FedRAMP MUST clearly specify the required actions in the body of messages that require an elevated reaction.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["FedRAMP"],
               "updated": [
                 {
@@ -3704,7 +3704,7 @@
                 "**Class A:** by 3:00 p.m. Eastern Time on the 5th business day"
               ],
               "note": "FedRAMP Class D Certified cloud service providers are expected to address Emergency messages (including tests) from FedRAMP with a reaction time appropriate to operating a service where failure to react rapidly might have a severe or debilitating customer effect on the U.S. Government; some Emergency messages may require faster reaction and all such messages should be addressed as quickly as possible.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["FedRAMP"],
               "terms": [
                 "Debilitating Customer Effect",
@@ -3721,7 +3721,7 @@
             "FSI-FRP-COR": {
               "name": "Explain Corrective Actions",
               "statement": "FedRAMP MUST clearly specify the corrective actions that will result from failure to complete the required actions in the body of messages that require an elevated reaction; such actions may vary from negative ratings in the FedRAMP Marketplace to suspension of FedRAMP Certification depending on the severity of the event.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["FedRAMP"],
               "updated": [
                 {
@@ -3733,7 +3733,7 @@
             "FSI-FRP-RPM": {
               "name": "Reaction Metrics",
               "statement": "FedRAMP MAY track and publicly share the time required by cloud service providers to take the actions specified in messages that require an elevated reaction.",
-              "primary_key_word": "MAY",
+              "force": "MAY",
               "affects": ["FedRAMP"],
               "terms": ["Provider"],
               "updated": [
@@ -3754,7 +3754,7 @@
                 "If a provider establishes a new inbox in reaction to this guidance that is different from the Security Email then they must follow the FSI-CSO-NOC (Notification of Changes) rules to notify FedRAMP."
               ],
               "related": ["FSI-CSO-NOC"],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["FedRAMP Security Inbox", "Provider"],
               "updated": [
@@ -3767,7 +3767,7 @@
             "FSI-CSO-NOC": {
               "name": "Notification of Changes",
               "statement": "Providers MUST immediately notify FedRAMP of any changes in addressing for their FedRAMP Security Inbox by emailing info@fedramp.gov with the name and FedRAMP ID of the cloud service offering and the updated email address.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "notification": [
                 {
@@ -3791,7 +3791,7 @@
             "FSI-CSO-TFG": {
               "name": "Trust @fedramp.gov and @gsa.gov",
               "statement": "Providers MUST treat any email originating from an @fedramp.gov or @gsa.gov email address as if it was sent from FedRAMP by default; if such a message is confirmed to originate from someone other than FedRAMP then the FedRAMP Security Inbox rules no longer apply.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["FedRAMP Security Inbox", "Provider"],
               "updated": [
@@ -3805,7 +3805,7 @@
               "name": "Receive Email Without Disruption",
               "statement": "Providers MUST receive and react to email messages from FedRAMP without disruption and without requiring additional actions from FedRAMP.",
               "note": "This requirement is intended to prevent cloud service providers from requiring FedRAMP to complete a CAPTCHA, log into a customer portal, or otherwise take service-specific actions that might prevent the security team from receiving the message.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Provider"],
               "updated": [
@@ -3819,7 +3819,7 @@
               "name": "Complete Required Actions",
               "statement": "Providers MUST complete the required actions in Emergency or Emergency Test designated messages sent by FedRAMP within the timeframe included in the message.",
               "note": "Timeframes may vary by FedRAMP Certification class.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Provider"],
               "updated": [
@@ -3833,7 +3833,7 @@
               "name": "Emergency Message Routing",
               "statement": "Providers MUST route Emergency designated messages sent by FedRAMP to a senior security official for their awareness.",
               "note": "Senior security officials are determined by the provider.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Provider"],
               "updated": [
@@ -3847,7 +3847,7 @@
               "name": "Important Message Actions",
               "statement": "Providers SHOULD complete the required actions in Important designated messages sent by FedRAMP within the timeframe specified in the message.",
               "note": "Timeframes may vary by FedRAMP Certification class.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": ["Provider"],
               "updated": [
@@ -3860,7 +3860,7 @@
             "FSI-CSO-ACK": {
               "name": "Acknowledge Receipt",
               "statement": "Providers SHOULD promptly and automatically acknowledge the receipt of messages received from FedRAMP in their FedRAMP Security Inbox.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": ["FedRAMP Security Inbox", "Promptly", "Provider"],
               "updated": [
@@ -4204,7 +4204,7 @@
                 "FedRAMP will request a Corrective Action Plan when a provider is unaware of the rules or has failed to implement proper procedures.",
                 "FedRAMP will grant a 3 month grace period to implement proper procedures pending remediation and possible revocation of FedRAMP Certification."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["FedRAMP"],
               "terms": ["Incident", "Provider"],
               "updated": [
@@ -4219,7 +4219,7 @@
             "ICP-CSO-EFR": {
               "name": "Evaluate FedRAMP Reportability",
               "statement": "Providers MUST promptly evaluate incidents to determine if they affect confidentiality or integrity of federal customer data or are likely to affect confidentiality or integrity of federal customer data; such incidents are FedRAMP Reportable Incidents and must be reported following the FedRAMP Incident Communications Procedures.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "FedRAMP Reportable Incident",
@@ -4240,7 +4240,7 @@
               "name": "Default PAIN Rating",
               "statement": "Providers MUST treat FedRAMP Reportable Incidents as if they have a Potential Agency Impact N-rating (PAIN) of 5 UNLESS they promptly estimate the PAIN rating following the rule in ICP-CSO-EFI (Estimate Federal Impact).",
               "related": ["ICP-CSO-EFI"],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Agency",
@@ -4272,7 +4272,7 @@
                     "Estimated recovery plan, milestones, and timelines",
                     "List of likely affected customer agencies"
                   ],
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "pain_timeframes": {
                     "1": {
                       "iir": {
@@ -4323,7 +4323,7 @@
                     "Estimated recovery plan, milestones, and timelines",
                     "List of likely affected customer agencies"
                   ],
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "pain_timeframes": {
                     "1": {
                       "iir": {
@@ -4374,7 +4374,7 @@
                     "Estimated recovery plan, milestones, and timelines",
                     "List of likely affected customer agencies"
                   ],
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "pain_timeframes": {
                     "1": {
                       "iir": {
@@ -4425,7 +4425,7 @@
                     "Estimated recovery plan, milestones, and timelines",
                     "List of likely affected customer agencies"
                   ],
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "pain_timeframes": {
                     "1": {
                       "iir": {
@@ -4511,7 +4511,7 @@
                     "Root cause",
                     "Response and recovery activities"
                   ],
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "pain_timeframes": {
                     "1": {
                       "oir": {
@@ -4559,7 +4559,7 @@
                     "Root cause",
                     "Response and recovery activities"
                   ],
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "pain_timeframes": {
                     "1": {
                       "oir": {
@@ -4607,7 +4607,7 @@
                     "Root cause",
                     "Response and recovery activities"
                   ],
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "pain_timeframes": {
                     "1": {
                       "oir": {
@@ -4655,7 +4655,7 @@
                     "Root cause",
                     "Response and recovery activities"
                   ],
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "pain_timeframes": {
                     "1": {
                       "oir": {
@@ -4733,7 +4733,7 @@
               "varies_by_class": {
                 "a": {
                   "statement": "Providers with Class A Certifications MUST responsibly notify all affected parties by providing a Final Incident Report once the incident has been resolved and recovery is complete, including final updates to all previously reported information.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "pain_timeframes": {
                     "1": {
                       "fir": {
@@ -4774,7 +4774,7 @@
                 },
                 "b": {
                   "statement": "Providers with Class B Certifications MUST responsibly notify all affected parties by providing a Final Incident Report once the incident has been resolved and recovery is complete, including final updates to all previously reported information.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "pain_timeframes": {
                     "1": {
                       "fir": {
@@ -4815,7 +4815,7 @@
                 },
                 "c": {
                   "statement": "Providers with Class C Certifications MUST responsibly notify all affected parties by providing a Final Incident Report once the incident has been resolved and recovery is complete, including final updates to all previously reported information.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "pain_timeframes": {
                     "1": {
                       "fir": {
@@ -4856,7 +4856,7 @@
                 },
                 "d": {
                   "statement": "Providers with Class D Certifications MUST responsibly notify all affected parties by providing a Final Incident Report once the incident has been resolved and recovery is complete, including final updates to all previously reported information.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "pain_timeframes": {
                     "1": {
                       "fir": {
@@ -4940,7 +4940,7 @@
               ],
               "note": "All incidents must be assigned a default PAIN-5 as required by ICP-CSO-DPR (Default PAIN Rating) if this step is not completed.",
               "related": ["ICP-CSO-DPR"],
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": [
                 "Agency",
@@ -4965,7 +4965,7 @@
               "name": "Automated Incident Reporting",
               "statement": "Providers SHOULD use automation to minimize human intervention in the process of reporting FedRAMP Reportable Incidents to all affected parties.",
               "danger": "Modern cloud services should not be reporting incidents by hand-crafting emails!",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": [
                 "All Affected Parties",
@@ -5038,7 +5038,7 @@
                 "Software produced by cloud service providers that is delivered separately for installation on agency systems and not operated in a shared responsibility model (typically including agents, application clients, mobile applications, etc. that are not fully managed by the cloud service provider) is not a cloud computing product or service and is entirely outside the scope of FedRAMP under the FedRAMP Certification Act. All such software is therefore not included in the cloud service offering for FedRAMP. For more, see fedramp.gov/scope.",
                 "All aspects of the cloud service offering are determined and maintained by the cloud service provider in accordance with related FedRAMP Certification rules and documented by the cloud service provider in their FedRAMP Certification Package."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Agency",
@@ -5061,7 +5061,7 @@
               "name": "Information Flows and Security Categories",
               "statement": "Providers MUST clearly identify, document, and explain information flows and security categories for ALL information resources or sets of information resources in the cloud service offering.",
               "note": "Information resources (including third-party information resources) MAY vary by security category as appropriate to the type of information handled by or impacted by the information resource.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
@@ -5088,7 +5088,7 @@
                 "Compensating controls in place to reduce the potential impact to federal customer data"
               ],
               "related": ["MAS-CSO-IIR"],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
@@ -5109,7 +5109,7 @@
               "name": "Metadata Inclusion",
               "statement": "Providers MUST include metadata (including metadata about federal customer data) in the Minimum Assessment Scope ONLY IF MAS-CSO-IIR (Identify Information Resources) APPLIES.",
               "related": ["MAS-CSO-IIR"],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Federal Customer Data",
@@ -5128,7 +5128,7 @@
               "name": "Supplemental Information",
               "statement": "Providers MAY include additional materials about other information resources that are not part of the cloud service offering in a FedRAMP Certification package supplement; these resources will not be FedRAMP Certified and MUST be clearly marked and separated from the cloud service offering.",
               "note": "This is intended to allow inclusion of things like security materials for apps, supplemental marketing collateral, and other information that is not part of the cloud service offering but may be useful to agencies.",
-              "primary_key_word": "MAY",
+              "force": "MAY",
               "affects": ["Providers"],
               "terms": [
                 "Agency",
@@ -5237,7 +5237,7 @@
             "MKT-FRP-DSM": {
               "name": "Decision Summaries",
               "statement": "FedRAMP MUST include a summary with any Marketplace listing decision that explains why the decision was made, including an explanation of deficiencies if applicable.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["FedRAMP"],
               "updated": [
                 {
@@ -5251,7 +5251,7 @@
               "statement": "FedRAMP MUST publish and maintain JSON schemas for required machine-readable Marketplace web information supplied by advisors and assessors.",
               "reference": "FedRAMP JSON Schemas on GitHub",
               "reference_url": "https://github.com/FedRAMP/schemas",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["FedRAMP"],
               "terms": ["Advisor", "Assessor", "Machine-Readable"],
               "updated": [
@@ -5266,7 +5266,7 @@
               "statement": "FedRAMP MUST NOT list cloud service offerings in the Marketplace or perform any FedRAMP Certification activities unless it determines the cloud service offering is within the scope of FedRAMP.",
               "reference": "Scope of FedRAMP",
               "reference_url": "https://fedramp.gov/docs/authority/scope",
-              "primary_key_word": "MUST NOT",
+              "force": "MUST NOT",
               "affects": ["FedRAMP"],
               "terms": ["Cloud Service Offering"],
               "updated": [
@@ -5290,7 +5290,7 @@
                 "Services used by private companies to meet other compliance requirements (such as CMMC) that do not also meet one of the above use cases are outside the scope of FedRAMP."
               ],
               "related": ["MKT-FRP-SOF"],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Agency",
@@ -5311,7 +5311,7 @@
               "statement": "Providers MUST complete the Provider Listing Request Form at https://fedramp.gov/forms/provider-listing-request/ in full to request listing in the FedRAMP Marketplace.",
               "reference": "FedRAMP Marketplace Provider Listing Request Form",
               "reference_url": "https://fedramp.gov/forms",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Provider"],
               "updated": [
@@ -5326,7 +5326,7 @@
             "MKT-IAS-OFR": {
               "name": "Only FedRAMP Recognized Assessors",
               "statement": "Assessors MUST obtain and maintain FedRAMP Recognition to be listed in the FedRAMP Marketplace.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "terms": ["Assessor", "FedRAMP Recognized"],
               "updated": [
@@ -5345,7 +5345,7 @@
                 "Types of independent services offered",
                 "Optional: Positive attestations from customers or customer references"
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "terms": ["Assessor", "Machine-Readable"],
               "updated": [
@@ -5358,7 +5358,7 @@
             "MKT-IAS-LRQ": {
               "name": "Listing Requests for Assessors",
               "statement": "Assessors MUST complete the Assessor Listing Request Form at https://fedramp.gov/forms/assessor-listing-request/ to request listing in the FedRAMP Marketplace.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "terms": ["Assessor"],
               "updated": [
@@ -5379,7 +5379,7 @@
                 "Types of consulting or advisory services offered",
                 "Optional: Positive attestations from customers or customer references"
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Advisors"],
               "terms": ["Advisor", "Machine-Readable"],
               "updated": [
@@ -5392,7 +5392,7 @@
             "MKT-CAS-LRQ": {
               "name": "Listing Requests for Advisors",
               "statement": "Advisors MUST complete the Advisor Listing Request Form at https://fedramp.gov/forms/advisor-listing-request/ to request listing in the FedRAMP Marketplace.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Advisors"],
               "terms": ["Advisor"],
               "updated": [
@@ -5410,7 +5410,7 @@
                 "If an advisor fails to respond to the follow-up email within 5 business days, FedRAMP will remove their listing from the Marketplace.",
                 "Advisors removed from the Marketplace for failure to respond to FedRAMP will not be eligible for listing for at least 6 months unless there are extenuating circumstances."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Advisors"],
               "terms": ["Advisor"],
               "updated": [
@@ -5426,7 +5426,7 @@
               "name": "Preparation Phase Requirements",
               "statement": "Providers MUST implement a minimum set of rules to be listed in the FedRAMP Marketplace during the Preparation Phase, including at least:",
               "following_information": ["CDS: rules", "CCM: rules"],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Provider"],
               "updated": [
@@ -5440,7 +5440,7 @@
               "name": "Demonstrating Continuous Progress",
               "statement": "Providers MUST demonstrate continuous progress towards FedRAMP Certification, documented in their quarterly Ongoing Certification Reports; progress is measured by the provider against documented goals and milestones.",
               "note": "This is an opportunity for a business to showcase its goals and progress, and should be seen as a marketing and customer experience challenge instead of a compliance challenge.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Ongoing Certification", "Provider"],
               "updated": [
@@ -5456,7 +5456,7 @@
               "corrective_actions": [
                 "If a provider fails to schedule an assessment for a FedRAMP Certification Class B, C, or D within 2 years of initial listing in the Preparation Phase, FedRAMP will remove their listing from the Marketplace until they provide evidence of a scheduled assessment."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Provider"],
               "updated": [
@@ -5515,7 +5515,7 @@
             "REC-FRP-FOC": {
               "name": "Foreign Ownership Collection",
               "statement": "FedRAMP MUST maintain a process to collect foreign ownership, control, or influence declarations from FedRAMP Recognized assessors and updates to those declarations.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["FedRAMP"],
               "terms": ["Assessor", "FedRAMP Recognized"],
               "updated": [
@@ -5528,7 +5528,7 @@
             "REC-FRP-RAO": {
               "name": "Recognized Assessors Only",
               "statement": "FedRAMP MUST NOT accept verification, validation, or other attestations from independent assessors who are not FedRAMP Recognized.",
-              "primary_key_word": "MUST NOT",
+              "force": "MUST NOT",
               "affects": ["FedRAMP"],
               "terms": [
                 "Assessor",
@@ -5546,7 +5546,7 @@
             "REC-FRP-DRD": {
               "name": "Double Revocation Disqualification",
               "statement": "FedRAMP MUST NOT restore FedRAMP Recognition for an assessor after FedRAMP has revoked that assessor's FedRAMP Recognition 2 times.",
-              "primary_key_word": "MUST NOT",
+              "force": "MUST NOT",
               "affects": ["FedRAMP"],
               "terms": ["Assessor", "FedRAMP Recognized"],
               "updated": [
@@ -5562,7 +5562,7 @@
               "name": "A2LA Accreditation",
               "statement": "Assessors MUST obtain and maintain accreditation through the American Association for Laboratory Accreditation (A2LA) Cybersecurity Inspection Body Program to qualify for FedRAMP Recognition.",
               "note": "FedRAMP will remove FedRAMP Recognition immediately after the American Association for Laboratory Accreditation notifies FedRAMP that an assessor's accreditation has lapsed.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "terms": ["Assessor", "FedRAMP Recognized"],
               "updated": [
@@ -5585,7 +5585,7 @@
                 "FedRAMP will notify assessors when they are within 6 months of losing FedRAMP Recognition under this rule and request a corrective action plan.",
                 "Assessors whose corrective action plan is not accepted will lose FedRAMP Recognition and must supply an alternative corrective action plan to move toward renewed FedRAMP Recognition."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "timeframe_type": "years",
               "timeframe_num": 2,
@@ -5602,7 +5602,7 @@
               "statement": "Assessors MUST maintain compliance with the latest American Association for Laboratory Accreditation (A2LA) R311 - Specific Requirements - Federal Risk and Authorization Management Program to maintain FedRAMP Recognition.",
               "reference": "A2LA Public Documents",
               "reference_url": "https://portal.a2la.org/documents/",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "terms": ["Assessor", "FedRAMP Recognized"],
               "updated": [
@@ -5618,7 +5618,7 @@
               "corrective_actions": [
                 "Assessors have 75 days to complete corrective actions for nonconformances identified by the American Association for Laboratory Accreditation (A2LA)during a surveillance assessment. If an assessor exceeds the 75 day resolution timeframe, A2LA will supply FedRAMP with a narrative of the assessor's current status, the assessor will be designated as in Remediation in the FedRAMP Marketplace, and the assessor must supply a corrective action plan to FedRAMP."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "timeframe_type": "years",
               "timeframe_num": 1,
@@ -5636,7 +5636,7 @@
               "corrective_actions": [
                 "Assessors have 75 days to complete corrective actions for nonconformances identified by the American Association for Laboratory Accreditation during a reassessment. If an assessor exceeds the 75 day resolution timeframe, the American Association for Laboratory Accreditation will supply FedRAMP with a narrative of the assessor's current status, the assessor will be designated as In Remediation in the FedRAMP Marketplace, and the assessor must supply a corrective action plan to FedRAMP."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "timeframe_type": "years",
               "timeframe_num": 2,
@@ -5652,7 +5652,7 @@
               "name": "Re-entry after Revocation",
               "statement": "Assessors MUST satisfy all American Association for Laboratory Accreditation (A2LA) re-entry conditions before regaining FedRAMP Recognition after revocation.",
               "note": "A revocation may require extended time in revoked status while the assessor demonstrates acceptable performance in the A2LA Cybersecurity Inspection Body Program before seeking FedRAMP Recognition again.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "terms": ["Assessor", "FedRAMP Recognized"],
               "updated": [
@@ -5668,7 +5668,7 @@
               "corrective_actions": [
                 "FedRAMP may require a consultation meeting, corrective action plan, or revocation for failure to comply."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "terms": ["Assessor"],
               "updated": [
@@ -5681,7 +5681,7 @@
             "REC-IAS-AFI": {
               "name": "Annual Foreign Interest Reports",
               "statement": "Assessors MUST report information relating to any foreign interest, foreign influence, or foreign control of the independent assessment service to FedRAMP annually.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "timeframe_type": "years",
               "timeframe_num": 1,
@@ -5704,7 +5704,7 @@
             "REC-IAS-CFI": {
               "name": "Changes in Foreign Interest",
               "statement": "Assessors MUST report updated information relating to any foreign interest, foreign influence, or foreign control of the independent assessment service within 48 hours of any change in foreign ownership or control.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "timeframe_type": "hours",
               "timeframe_num": 48,
@@ -5736,7 +5736,7 @@
                 "Assessment Integrity: Submits independent assessments of provider security implementations that are not influenced by provider demands.",
                 "Chain of Custody: Preserves the integrity and chain of custody of assessor-authored documents and provider-supplied evidence used in FedRAMP assessments."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "terms": [
                 "Agency",
@@ -5754,7 +5754,7 @@
             "REC-IAS-CAP": {
               "name": "Corrective Action Plan",
               "statement": "Assessors MUST supply a corrective action plan when FedRAMP requires one for performance standards deficiencies or organizational risks.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "terms": ["Assessor"],
               "updated": [
@@ -5767,7 +5767,7 @@
             "REC-IAS-INV": {
               "name": "Invalid Deliverables",
               "statement": "Assessors MUST treat deliverables prepared, performed, or submitted by personnel who do not meet required role qualifications as invalid for FedRAMP purposes.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Assessors"],
               "terms": ["Assessor"],
               "updated": [
@@ -5783,7 +5783,7 @@
               "corrective_actions": [
                 "FedRAMP may require a consultation meeting, corrective action plan, or revocation for failure to comply."
               ],
-              "primary_key_word": "MUST NOT",
+              "force": "MUST NOT",
               "affects": ["Assessors"],
               "timeframe_type": "years",
               "timeframe_num": 2,
@@ -5853,7 +5853,7 @@
                 "These rules refer to this guidance as a Secure Configuration Guide but cloud service providers may make this guidance available in various appropriate forms that provide the best customer experience.",
                 "This guidance should explain how top-level administrative accounts are named and referred to in the cloud service offering."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
@@ -5872,7 +5872,7 @@
               "name": "Use Instructions",
               "statement": "Providers MUST include instructions in the FedRAMP Certification package that explain how to obtain and use the Secure Configuration Guide.",
               "note": "These instructions may appear in a variety of ways; it is up to the provider to do so in the most appropriate and effective ways for their specific customer needs.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Certification Package", "Provider"],
               "updated": [
@@ -5885,7 +5885,7 @@
             "SCG-CSO-PUB": {
               "name": "Public Guidance",
               "statement": "Providers SHOULD make the Secure Configuration Guide available publicly.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": ["Provider"],
               "updated": [
@@ -5898,7 +5898,7 @@
             "SCG-CSO-SDF": {
               "name": "Secure Defaults",
               "statement": "Providers SHOULD set all settings to their recommended secure defaults for top-level administrative accounts and privileged accounts when initially provisioned.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": [
                 "Privileged Account",
@@ -5917,7 +5917,7 @@
             "SCG-ENH-CMP": {
               "name": "Comparison Capability",
               "statement": "Providers SHOULD offer the capability to compare all current settings for top-level administrative accounts and privileged accounts to the recommended secure defaults.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": [
                 "Privileged Account",
@@ -5934,7 +5934,7 @@
             "SCG-ENH-EXP": {
               "name": "Export Capability",
               "statement": "Providers SHOULD offer the capability to export all security settings in a machine-readable format.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": ["Machine-Readable", "Provider"],
               "updated": [
@@ -5947,7 +5947,7 @@
             "SCG-ENH-API": {
               "name": "API Capability",
               "statement": "Providers SHOULD offer the capability to view and adjust security settings via an API or similar capability.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": ["Provider"],
               "updated": [
@@ -5960,7 +5960,7 @@
             "SCG-ENH-MRG": {
               "name": "Machine-Readable Guidance",
               "statement": "Providers SHOULD also provide the Secure Configuration Guide in a machine-readable format that can be used by customers or third-party tools to compare against current settings.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": ["Machine-Readable", "Provider"],
               "updated": [
@@ -5973,7 +5973,7 @@
             "SCG-ENH-VRH": {
               "name": "Versioning and Release History",
               "statement": "Providers SHOULD provide versioning and a release history for recommended secure default settings for top-level administrative accounts and privileged accounts as they are adjusted over time.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": [
                 "Privileged Account",
@@ -6081,7 +6081,7 @@
               "name": "Corrective Action Plan Conditions",
               "statement": "FedRAMP MAY require providers to delay significant changes beyond the standard Significant Change Notification period and/or submit significant changes for approval in advance as a condition of a formal FedRAMP Corrective Action Plan or other agreement.",
               "note": "The circumstances and conditions of such a Corrective Action Plan will vary and be documented in the Correcive Action Plan.",
-              "primary_key_word": "MAY",
+              "force": "MAY",
               "affects": ["FedRAMP"],
               "terms": ["Provider", "Significant Change"],
               "updated": [
@@ -6103,7 +6103,7 @@
                 "If it is not, is it a transformative change? --> Follow the Transformative Change rules (SCN-TRF Transformative Changes).",
                 "If it is not, then it is an adaptive change --> Follow the Adaptive Change rules (SCN-ADP Adaptive Changes)."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Adaptive Change",
@@ -6125,7 +6125,7 @@
               "statement": "Providers MUST maintain auditable records of the significant change evaluation activities required by SCN-CSO-EVA (Evaluate Changes) and make them available to FedRAMP.",
               "note": "These audit records must be available to FedRAMP on request; these records do not need to be included in the FedRAMP Certification package by default.",
               "related": ["SCN-CSO-EVA"],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Certification Package",
@@ -6155,7 +6155,7 @@
                 "Name and title of approver"
               ],
               "note": "Structure of the information may vary depending on how the provider tracks this internally.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Assessor",
@@ -6175,7 +6175,7 @@
             "SCN-CSO-HIS": {
               "name": "Historical Notifications",
               "statement": "Providers MUST keep 12 months of historical Significant Change Notifications available with their FedRAMP Certification Data.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Certification Data", "Provider", "Significant Change"],
               "updated": [
@@ -6189,7 +6189,7 @@
               "name": "Human and Machine-Readable",
               "statement": "Providers MUST make ALL Significant Change Notifications and related audit records available in human-readable and machine-readable formats.",
               "note": "During the SCN beta, many cloud service providers met this requirement by using carefully structured and organized csv files to meet human-readable and machine-readable requirements simultaneously.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Machine-Readable", "Provider", "Significant Change"],
               "updated": [
@@ -6203,7 +6203,7 @@
               "name": "Additional Relevant Information",
               "statement": "Providers MAY include additional relevant information in Significant Change Notifications.",
               "note": "This allows providers to convey whatever additional information they think is relevant without worrying about negative consequences from not following an exact template.",
-              "primary_key_word": "MAY",
+              "force": "MAY",
               "affects": ["Providers"],
               "terms": ["Provider", "Significant Change"],
               "updated": [
@@ -6220,7 +6220,7 @@
                 "The sharing mechanism should be designed based on the needs of the provider and their customers and may vary between providers.",
                 "The default sharing mechanism for most providers during the SCN beta was to send an email to agency customers and upload a copy of the notification to the provider's secure sharing location."
               ],
-              "primary_key_word": "MAY",
+              "force": "MAY",
               "affects": ["Providers"],
               "terms": ["Agency", "Certification Package", "Provider"],
               "updated": [
@@ -6234,7 +6234,7 @@
               "name": "Emergency Changes",
               "statement": "Providers MAY execute significant changes (including transformative changes) during an emergency or incident without following the Significant Change Notification rules in advance. In such emergencies, providers MUST follow all relevant procedures, notify all necessary parties, retroactively provide all Significant Change Notification materials, and complete appropriate assessment after the incident.",
               "note": "Procedures for emergency changes should be documented in the FedRAMP Certification package.",
-              "primary_key_word": "MAY",
+              "force": "MAY",
               "affects": ["Providers"],
               "terms": [
                 "All Necessary Parties",
@@ -6263,7 +6263,7 @@
                 "Activities that match the adaptive significant change type are a frequent and normal part of iteratively improving a service by deploying new functionality or modifying existing functionality in a way that is typically transparent to customers and does not introduce significant new security risks.",
                 "In general, most changes that do not happen regularly will be adaptive changes. This change type deliberately covers a wide range of activities in a way that requires assessment and consideration."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "examples": [
                 {
@@ -6316,7 +6316,7 @@
                 "These changes leverage mature processes and capabilities to identify, mitigate, and remediate risks as part of the change. They are often entirely automated and may occur without human intervention, even though they have an impact on security of the service.",
                 "If the activity does not occur regularly and routinely then it cannot be a significant change of this type (e.g., replacing all physical firewalls to remediate a vulnerability is obviously not regular or routine)."
               ],
-              "primary_key_word": "SHOULD NOT",
+              "force": "SHOULD NOT",
               "affects": ["Providers"],
               "examples": [
                 {
@@ -6368,7 +6368,7 @@
             "SCN-TRF-NIP": {
               "name": "Notification of Initial Plans",
               "statement": "Providers MUST notify all necessary parties of initial plans for transformative changes at least 30 business days before starting transformative changes, including a summary of any likely security impacts or changes in risk.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "timeframe_type": "bizdays",
               "timeframe_num": 30,
@@ -6395,7 +6395,7 @@
             "SCN-TRF-NFP": {
               "name": "Notification of Final Plans",
               "statement": "Providers MUST notify all necessary parties of final plans for transformative changes at least 10 business days before starting transformative changes, including updates to all previously sent information.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "timeframe_type": "bizdays",
               "timeframe_num": 10,
@@ -6421,7 +6421,7 @@
             "SCN-TRF-NAF": {
               "name": "Notification After Finishing",
               "statement": "Providers MUST notify all necessary parties within 5 business days after finishing transformative changes, including updates to all previously sent information.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "timeframe_type": "bizdays",
               "timeframe_num": 5,
@@ -6452,7 +6452,7 @@
                 "Summary of any new risks identified and/or vulnerabilities resulting from the change (if applicable)",
                 "Copy of the security assessment report (if applicable)"
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "timeframe_type": "bizdays",
               "timeframe_num": 5,
@@ -6482,7 +6482,7 @@
               "name": "Update Documentation",
               "statement": "Providers MUST publish updated service documentation and other materials to reflect transformative changes within 30 business days after finishing transformative changes.",
               "note": "This requirement is focused on service documentation like user guides, information listed in the marketplace, and other such materials; it does not require updating the system security plan or FedRAMP Certification package.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "timeframe_type": "bizdays",
               "timeframe_num": 30,
@@ -6502,7 +6502,7 @@
               "name": "Third-Party Review",
               "statement": "Providers SHOULD engage a third-party assessor to review the scope and impact of the planned change before starting transformative changes if human validation is necessary; such reviews SHOULD be limited to security decisions that require human validation.",
               "note": "Activities that match the transformative significant change type are rare for a cloud service offering, adjusted for the size, scale, and complexity of the service. Small cloud service offerings may go years without transformative changes, while hyperscale providers may release multiple transformative changes per year.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "examples": [
                 {
@@ -6661,7 +6661,7 @@
             "UCM-CSO-CMD": {
               "name": "Cryptographic Module Documentation",
               "statement": "Providers MUST document the cryptographic modules used in each service (or groups of services that use the same modules) where cryptographic services are used to protect federal customer data, including whether these modules are validated under the NIST Cryptographic Module Validation Program or are update streams of such modules.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Federal Customer Data", "Provider", "Validation"],
               "updated": [
@@ -6676,19 +6676,19 @@
               "varies_by_class": {
                 "a": {
                   "statement": "Providers with Class A Certifications MAY use cryptographic modules or update streams of cryptographic modules with active validations under the NIST Cryptographic Module Validation Program when using cryptographic services to protect federal customer data.",
-                  "primary_key_word": "MAY"
+                  "force": "MAY"
                 },
                 "b": {
                   "statement": "Providers with Class B Certifications MAY use cryptographic modules or update streams of cryptographic modules with active validations under the NIST Cryptographic Module Validation Program when using cryptographic services to protect federal customer data.",
-                  "primary_key_word": "MAY"
+                  "force": "MAY"
                 },
                 "c": {
                   "statement": "Providers with Class C Certifications SHOULD use cryptographic modules or update streams of cryptographic modules with active validations under the NIST Cryptographic Module Validation Program when using cryptographic services to protect federal customer data.",
-                  "primary_key_word": "SHOULD"
+                  "force": "SHOULD"
                 },
                 "d": {
                   "statement": "Providers with Class D Certifications MUST use cryptographic modules or update streams of cryptographic modules with active validations under the NIST Cryptographic Module Validation Program when using cryptographic services to protect federal customer data.",
-                  "primary_key_word": "MUST"
+                  "force": "MUST"
                 }
               },
               "affects": ["Providers"],
@@ -6703,7 +6703,7 @@
             "UCM-CSO-CAT": {
               "name": "Configuration of Agency Tenants",
               "statement": "Providers SHOULD configure agency tenants by default to use cryptographic services that use cryptographic modules or update streams of cryptographic modules with active validations under the NIST Cryptographic Module Validation Program when such modules are available.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": ["Agency", "Provider", "Validation"],
               "updated": [
@@ -6826,7 +6826,7 @@
             "VDR-FRP-ARP": {
               "name": "Additional Requirements",
               "statement": "FedRAMP MAY require providers to share additional vulnerability information, alternative reports, or to report at an alternative frequency as a condition of a FedRAMP Corrective Action Plan or other agreements with federal agencies.",
-              "primary_key_word": "MAY",
+              "force": "MAY",
               "affects": ["FedRAMP"],
               "terms": ["Agency", "Provider", "Vulnerability"],
               "updated": [
@@ -6839,7 +6839,7 @@
             "VDR-FRP-ADV": {
               "name": "Sensitive Details",
               "statement": "FedRAMP MAY require providers to share additional information or details about vulnerabilities, including sensitive information that would likely lead to exploitation, as part of review, response or investigation by necessary parties.",
-              "primary_key_word": "MAY",
+              "force": "MAY",
               "affects": ["FedRAMP"],
               "terms": [
                 "Likely",
@@ -6864,7 +6864,7 @@
                 "FedRAMP's vulnerability detection (and response) rules are intended to set modern expectations for maintaining the security of a cloud service. Historical FedRAMP guidance on vulnerability scanning or continuous monitoring generally focused only on CVE-type vulnerabilities while leaving other types of vulnerabilities and exposures unaddressed.",
                 "Providers are encouraged to leverage their existing holistic security review, architecture review, and similar processes to meet these requirements. FedRAMP strongly discourages providers from implementing separate vulnerability detection and response processes for FedRAMP reporting that are operated by independent compliance branches unless these processes are consuming data directly from the areas of the cloud service that actively maintain it."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
@@ -6892,7 +6892,7 @@
                 "FedRAMP does not use the terms \"mitigation\" and \"remediation\" interchangeably. Mitigation is the process of reducing the risk and impact of a vulnerability through partial mitigation and even full mitigation; remediation is the process of entirely eliminating the vulnerability. A fully mitigated vulnerability will still exist (with negligible risk) until it has been remediated. This separation is based on the plain language definitions of these words.",
                 "Please refer to FedRAMP Definitions for strict interpretation in the FedRAMP context."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
@@ -6916,7 +6916,7 @@
             "VDR-CSO-FAV": {
               "name": "Failures Are Vulnerabilities",
               "statement": "Providers MUST treat problems or failures with their vulnerability detection and response processes as vulnerabilities.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Provider",
@@ -6937,7 +6937,7 @@
               "name": "Notify FedRAMP",
               "statement": "Agencies MUST notify FedRAMP after requesting any additional vulnerability information or materials from a cloud service provider beyond those FedRAMP requires by sending a notification to [info@fedramp.gov](mailto:info@fedramp.gov).",
               "note": "This is an OMB policy; agencies are required to notify FedRAMP in OMB Memorandum M-24-15 section IV (a).",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Agencies"],
               "notification": [
                 {
@@ -6958,7 +6958,7 @@
               "name": "Review Vulnerability Reports",
               "statement": "Agencies SHOULD review the information provided in vulnerability reports at appropriate and reasonable intervals commensurate with the expectations and risk posture indicated by their Authorization to Operate, and SHOULD use automated processing and filtering of machine readable information from cloud service providers.",
               "note": "FedRAMP recommends that agencies only review overdue and accepted vulnerabilities Potential Agency Impact N-rating > 2 unless the cloud service provider recommends mitigations or the service is included in a higher risk federal information system. Furthermore, accepted vulnerabilities generally only need to be reviewed when they are added or during an updated risk assessment due to changes in the agency's use or authorization.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Agencies"],
               "terms": [
                 "Accepted Vulnerability",
@@ -6977,7 +6977,7 @@
             "VDR-AGM-MAP": {
               "name": "Maintain Agency Plans of Action and Milestones",
               "statement": "Agencies SHOULD use vulnerability information reported by the Provider to maintain Plans of Action and Milestones for agency security programs when relevant according to agency security policies (such as if the agency takes action to mitigate the risk of exploitation or authorized the continued use of a cloud service with accepted vulnerabilities that put agency information systems at risk).",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Agencies"],
               "terms": [
                 "Accepted Vulnerability",
@@ -6997,7 +6997,7 @@
               "name": "Do Not Request Extra Info",
               "statement": "Agencies SHOULD NOT request additional information from cloud service providers that is not required by the FedRAMP Vulnerability Detection and Response rules UNLESS the head of the agency or an authorized delegate makes a determination that there is a demonstrable need for such.",
               "note": "This is related to the Presumption of Adequacy directed by 44 USC § 3613 (e).",
-              "primary_key_word": "SHOULD NOT",
+              "force": "SHOULD NOT",
               "affects": ["Agencies"],
               "terms": [
                 "Agency",
@@ -7019,7 +7019,7 @@
             "VDR-BST-DFR": {
               "name": "Design For Resilience",
               "statement": "Providers SHOULD make design and architecture decisions for their cloud service offering that mitigate the risk of vulnerabilities by default AND decrease the risk and complexity of vulnerability detection and response.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
@@ -7038,7 +7038,7 @@
             "VDR-BST-ADT": {
               "name": "Automate Detection",
               "statement": "Providers SHOULD use automated services to improve and streamline vulnerability detection and response.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": [
                 "Provider",
@@ -7056,7 +7056,7 @@
             "VDR-BST-DAC": {
               "name": "Detect After Changes",
               "statement": "Providers SHOULD automatically perform vulnerability detection on representative samples of new or significantly changed information resources.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": [
                 "Information Resource",
@@ -7074,7 +7074,7 @@
             "VDR-BST-MSP": {
               "name": "Maintain Security",
               "statement": "Providers SHOULD NOT weaken the security of information resources to facilitate vulnerability scanning, detection, or assessment activities.",
-              "primary_key_word": "SHOULD NOT",
+              "force": "SHOULD NOT",
               "affects": ["Providers"],
               "terms": [
                 "Information Resource",
@@ -7092,7 +7092,7 @@
             "VDR-BST-AKE": {
               "name": "Avoid KEVs",
               "statement": "Providers SHOULD NOT deploy or otherwise activate new machine-based information resources with Known Exploited Vulnerabilities.",
-              "primary_key_word": "SHOULD NOT",
+              "force": "SHOULD NOT",
               "affects": ["Providers"],
               "terms": [
                 "Information Resource",
@@ -7111,7 +7111,7 @@
             "VDR-BST-SIR": {
               "name": "Sampling",
               "statement": "Providers MAY sample effectively identical information resources, especially machine-based information resources, when performing vulnerability detection UNLESS doing so would decrease the efficiency or effectiveness of vulnerability detection.",
-              "primary_key_word": "MAY",
+              "force": "MAY",
               "affects": ["Providers"],
               "terms": [
                 "Information Resource",
@@ -7136,7 +7136,7 @@
                 "The simple reality is that most traditional vulnerabilities discovered by scanners or during assessment are not likely to be exploitable; exploitation typically requires an unrealistic set of circumstances that will not occur during normal operation. The likelihood of exploitation will vary depending on so many factors that FedRAMP will not recommend a specific framework for approaching this beyond these rules.",
                 "The proof, ultimately, is in the pudding - providers who regularly evaluate vulnerabilities as not likely exploitable without careful consideration are more likely to suffer from an adverse impact where the root cause was an exploited vulnerability that was improperly evaluated. If done recklessly or deliberately, such actions will have a negative impact on a provider's FedRAMP Certification."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
@@ -7163,7 +7163,7 @@
                 "A classic example of an internet-reachable vulnerability on systems that are not typically internet-accessible is [SQL injection](https://en.wikipedia.org/wiki/SQL_injection), where an application stack behind a load balancer and firewall with no ability to route traffic to or from the internet can receive a payload indirectly from the internet that triggers the manipulation or compromise of data in a database that can only be accessed by an authorized connection from the application server on a private network.",
                 "Another simple example is the infamous Log4Shell (https://en.wikipedia.org/wiki/Log4Shell) vulnerability from 2021, where exploitation was possible via vulnerable internet-reachable resources deep in the application stack that were often not internet-accessible themselves."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
@@ -7190,7 +7190,7 @@
                 "**N4**: Exploitation could be expected to have a debilitating customer effect on one agency that uses the cloud service offering OR a disruptive customer effect on more than one federal agency that uses the cloud service offering.",
                 "**N5**: Exploitation could be expected to have a debilitating customer effect on more than one agency that uses the cloud service offering."
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Agency",
@@ -7214,7 +7214,7 @@
             "VDR-EVA-GRV": {
               "name": "Group Vulnerabilities",
               "statement": "Providers SHOULD evaluate detected vulnerabilities, considering the context of the cloud service offering, to identify logical groupings of affected information resources that may improve the efficiency and effectiveness of vulnerability response by consolidating further activity; FedRAMP Vulnerability Detection and Response rules are then applied to these consolidated groupings of vulnerabilities instead of each individual detected instance.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
@@ -7234,7 +7234,7 @@
             "VDR-EVA-EFP": {
               "name": "Evaluate False Positives",
               "statement": "Providers SHOULD evaluate detected vulnerabilities, considering the context of the cloud service offering, to determine if they are false positive vulnerabilities.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
@@ -7263,7 +7263,7 @@
                 "**Proximate Vulnerabilities**: How does this vulnerability interact with previously detected vulnerabilities, especially partially or fully mitigated vulnerabilities?",
                 "**Known Threats**: How might already known threats leverage the vulnerability and how likely is that?"
               ],
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
@@ -7285,7 +7285,7 @@
             "VDR-RPT-PER": {
               "name": "Persistent Reporting",
               "statement": "Providers MUST report vulnerability detection and response activity (including persistent verification and validation) to all necessary parties persistently, summarizing ALL activity since the previous report; these reports are FedRAMP Certification Data and are subject to FedRAMP Certification Data Sharing rules.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "All Necessary Parties",
@@ -7321,7 +7321,7 @@
                 "Any supplementary information the provider responsibly determines will help federal agencies assess or mitigate the risk to their federal customer data within the cloud service offering resulting from the vulnerability",
                 "Final disposition of the vulnerability"
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Accepted Vulnerability",
@@ -7359,7 +7359,7 @@
                 "Explanation of why this is an accepted vulnerability",
                 "Any supplementary information the provider determines will responsibly help federal agencies assess or mitigate the risk to their federal customer data within the cloud service offering resulting from the accepted vulnerability"
               ],
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Accepted Vulnerability",
@@ -7387,7 +7387,7 @@
               "name": "Responsible Disclosure",
               "statement": "Providers MUST NOT irresponsibly disclose specific sensitive information about vulnerabilities that would likely lead to exploitation, but MUST disclose sufficient information for informed risk-based decision-making to all necessary parties.",
               "note": "This requirement will be superseded in the event of formal action related to an investigation or corrective action plan.",
-              "primary_key_word": "MUST NOT",
+              "force": "MUST NOT",
               "affects": ["Providers"],
               "terms": [
                 "All Necessary Parties",
@@ -7405,7 +7405,7 @@
             "VDR-RPT-HLO": {
               "name": "High-Level Overviews",
               "statement": "Providers SHOULD include high-level overviews of ALL vulnerability detection and response activities conducted during this period for the cloud service offering; this includes vulnerability disclosure programs, bug bounty programs, penetration testing, assessments, etc.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
@@ -7424,7 +7424,7 @@
             "VDR-RPT-RPD": {
               "name": "Responsible Public Disclosure",
               "statement": "Providers MAY responsibly disclose vulnerabilities publicly or with other parties if the provider determines doing so will NOT likely lead to exploitation.",
-              "primary_key_word": "MAY",
+              "force": "MAY",
               "affects": ["Providers"],
               "terms": ["Likely", "Provider", "Responsibly", "Vulnerability"],
               "updated": [
@@ -7439,7 +7439,7 @@
             "VDR-TFR-MHR": {
               "name": "Monthly Activity Report",
               "statement": "Providers MUST report vulnerability detection and response activity to all necessary parties in a consistent format that is human readable at least monthly.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "timeframe_type": "month",
               "timeframe_num": 1,
@@ -7460,7 +7460,7 @@
             "VDR-TFR-MAV": {
               "name": "Mark Accepted Vulnerabilities",
               "statement": "Providers MUST categorize any vulnerability that is not or will not be fully mitigated or remediated within 192 days of evaluation as an accepted vulnerability.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "timeframe_type": "days",
               "timeframe_num": 192,
@@ -7475,7 +7475,7 @@
             "VDR-TFR-NMV": {
               "name": "Non-Machine Verification and Validation",
               "statement": "Providers MUST verify and validate the status of non-machine-based information resources at least once every 3 months.",
-              "primary_key_word": "MUST",
+              "force": "MUST",
               "affects": ["Providers"],
               "terms": [
                 "Information Resource",
@@ -7496,7 +7496,7 @@
               "statement": "Providers SHOULD remediate Known Exploited Vulnerabilities according to the due dates in the CISA Known Exploited Vulnerabilities Catalog (even if the vulnerability has been fully mitigated) as required by CISA Binding Operational Directive (BOD) 22-01 or any successor guidance from CISA.",
               "reference": "CISA BOD 22-01",
               "reference_url": "https://www.cisa.gov/news-events/directives/bod-22-01-reducing-significant-risk-known-exploited-vulnerabilities",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": [
                 "Known Exploited Vulnerability (KEV)",
@@ -7515,25 +7515,25 @@
               "varies_by_class": {
                 "a": {
                   "statement": "Providers with Class A Certifications MAY make all recent historical vulnerability detection and response activity available in a machine-readable format for automated retrieval by all necessary parties (e.g. using an API service or similar); this information MAY be updated persistently, at least once every month.",
-                  "primary_key_word": "MAY",
+                  "force": "MAY",
                   "timeframe_type": "month",
                   "timeframe_num": 1
                 },
                 "b": {
                   "statement": "Providers with Class B Certifications SHOULD make all recent historical vulnerability detection and response activity available in a machine-readable format for automated retrieval by all necessary parties (e.g. using an API service or similar); this information SHOULD be updated persistently, at least once every month.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "month",
                   "timeframe_num": 1
                 },
                 "c": {
                   "statement": "Providers with Class C Certifications SHOULD make all recent historical vulnerability detection and response activity available in a machine-readable format for automated retrieval by all necessary parties (e.g. using an API service or similar); this information SHOULD be updated persistently, at least once every 14 days.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 14
                 },
                 "d": {
                   "statement": "Providers with Class D Certifications SHOULD make all recent historical vulnerability detection and response activity available in a machine-readable format for automated retrieval by all necessary parties (e.g. using an API service or similar); this information SHOULD be updated persistently, at least once every 7 days.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 7
                 }
@@ -7560,25 +7560,25 @@
               "varies_by_class": {
                 "a": {
                   "statement": "Providers with Class A Certifications SHOULD persistently perform vulnerability detection on representative samples of similar machine-based information resources, at least once every 14 days.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 14
                 },
                 "b": {
                   "statement": "Providers with Class B Certifications SHOULD persistently perform vulnerability detection on representative samples of similar machine-based information resources, at least once every 7 days.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 7
                 },
                 "c": {
                   "statement": "Providers with Class C Certifications SHOULD persistently perform vulnerability detection on representative samples of similar machine-based information resources, at least once every 3 days.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 3
                 },
                 "d": {
                   "statement": "Providers with Class D Certifications SHOULD persistently perform vulnerability detection on representative samples of similar machine-based information resources, at least once per day.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 1
                 }
@@ -7604,25 +7604,25 @@
               "varies_by_class": {
                 "a": {
                   "statement": "Providers with Class A Certifications SHOULD persistently perform vulnerability detection on all information resources that are likely to drift, at least once every 3 months.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "month",
                   "timeframe_num": 3
                 },
                 "b": {
                   "statement": "Providers with Class B Certifications SHOULD persistently perform vulnerability detection on all information resources that are likely to drift, at least once every month.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "month",
                   "timeframe_num": 1
                 },
                 "c": {
                   "statement": "Providers with Class C Certifications SHOULD persistently perform vulnerability detection on all information resources that are likely to drift, at least once every 14 days.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 14
                 },
                 "d": {
                   "statement": "Providers with Class D Certifications SHOULD persistently perform vulnerability detection on all information resources that are likely to drift, at least once every 7 days.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 7
                 }
@@ -7649,25 +7649,25 @@
               "varies_by_class": {
                 "a": {
                   "statement": "Providers with Class A Certifications SHOULD persistently perform vulnerability detection on all information resources that are NOT likely to drift, at least once every 6 months.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "month",
                   "timeframe_num": 6
                 },
                 "b": {
                   "statement": "Providers with Class B Certifications SHOULD persistently perform vulnerability detection on all information resources that are NOT likely to drift, at least once every 6 months.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "month",
                   "timeframe_num": 6
                 },
                 "c": {
                   "statement": "Providers with Class C Certifications SHOULD persistently perform vulnerability detection on all information resources that are NOT likely to drift, at least once every month.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "month",
                   "timeframe_num": 1
                 },
                 "d": {
                   "statement": "Providers with Class D Certifications SHOULD persistently perform vulnerability detection on all information resources that are NOT likely to drift, at least once every month.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "month",
                   "timeframe_num": 1
                 }
@@ -7694,25 +7694,25 @@
               "varies_by_class": {
                 "a": {
                   "statement": "Providers with Class A Certifications SHOULD evaluate ALL vulnerabilities as required by VDR-EVA (Evaluation) within 14 days of detection.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 14
                 },
                 "b": {
                   "statement": "Providers with Class B Certifications SHOULD evaluate ALL vulnerabilities as required by VDR-EVA (Evaluation) within 7 days of detection.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 7
                 },
                 "c": {
                   "statement": "Providers with Class C Certifications SHOULD evaluate ALL vulnerabilities as required by VDR-EVA (Evaluation) within 5 days of detection.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 5
                 },
                 "d": {
                   "statement": "Providers with Class D Certifications SHOULD evaluate ALL vulnerabilities as required by VDR-EVA (Evaluation) within 2 days of detection.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "days",
                   "timeframe_num": 2
                 }
@@ -7731,7 +7731,7 @@
               "varies_by_class": {
                 "a": {
                   "statement": "Providers with Class A Certifications SHOULD partially mitigate vulnerabilities, fully mitigate vulnerabilities, or remediate vulnerabilities to a lower potential adverse impact within the timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "pain_timeframes": {
                     "1": {},
                     "2": {
@@ -7806,7 +7806,7 @@
                 },
                 "b": {
                   "statement": "Providers with Class B Certifications SHOULD partially mitigate vulnerabilities, fully mitigate vulnerabilities, or remediate vulnerabilities to a lower potential adverse impact within the timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "pain_timeframes": {
                     "1": {},
                     "2": {
@@ -7881,7 +7881,7 @@
                 },
                 "c": {
                   "statement": "Providers with Class C Certifications SHOULD partially mitigate vulnerabilities, fully mitigate vulnerabilities, or remediate vulnerabilities to a lower Potential Agency Impact N-rating within the timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "pain_timeframes": {
                     "1": {},
                     "2": {
@@ -7956,7 +7956,7 @@
                 },
                 "d": {
                   "statement": "Providers with Class D Certifications SHOULD partially mitigate vulnerabilities, fully mitigate vulnerabilities, or remediate vulnerabilities to a lower Potential Agency Impact N-rating within the maximum timeframes from evaluation shown below, factoring for the current Potential Agency Impact N-rating, internet reachability, and likely exploitability:",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "pain_timeframes": {
                     "1": {},
                     "2": {
@@ -8051,7 +8051,7 @@
             "VDR-TFR-RMN": {
               "name": "Remaining Vulnerabilities",
               "statement": "Providers SHOULD mitigate or remediate remaining vulnerabilities during routine operations as determined necessary by the provider.",
-              "primary_key_word": "SHOULD",
+              "force": "SHOULD",
               "affects": ["Providers"],
               "terms": ["Provider", "Vulnerability"],
               "updated": [
@@ -8066,19 +8066,19 @@
               "varies_by_class": {
                 "a": {
                   "statement": "Providers with Class A Certifications MAY treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated vulnerabilities at N3 or below.",
-                  "primary_key_word": "MAY"
+                  "force": "MAY"
                 },
                 "b": {
                   "statement": "Providers with Class B Certifications MAY treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated vulnerabilities at N3 or below.",
-                  "primary_key_word": "MAY"
+                  "force": "MAY"
                 },
                 "c": {
                   "statement": "Providers with Class C Certifications SHOULD treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated vulnerabilities at N3 or below.",
-                  "primary_key_word": "SHOULD"
+                  "force": "SHOULD"
                 },
                 "d": {
                   "statement": "Providers with Class D Certifications SHOULD treat internet-reachable likely exploitable vulnerabilities where Potential Agency Impact N-rating > 3 as a FedRAMP Reportable Incident until they are partially mitigated vulnerabilities at N3 or below.",
-                  "primary_key_word": "SHOULD"
+                  "force": "SHOULD"
                 }
               },
               "affects": ["Providers"],
@@ -8105,19 +8105,19 @@
               "varies_by_class": {
                 "a": {
                   "statement": "Providers with Class A Certifications MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated vulnerabilities at N4 or below.",
-                  "primary_key_word": "MAY"
+                  "force": "MAY"
                 },
                 "b": {
                   "statement": "Providers with Class B Certifications MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated vulnerabilities at N4 or below.",
-                  "primary_key_word": "MAY"
+                  "force": "MAY"
                 },
                 "c": {
                   "statement": "Providers with Class C Certifications MAY treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated vulnerabilities at N4 or below.",
-                  "primary_key_word": "MAY"
+                  "force": "MAY"
                 },
                 "d": {
                   "statement": "Providers with Class D Certifications SHOULD treat likely exploitable vulnerabilities that are NOT internet-reachable where Potential Agency Impact N-rating = 5 as a FedRAMP Reportable Incident until they are partially mitigated vulnerabilities at N4 or below.",
-                  "primary_key_word": "SHOULD"
+                  "force": "SHOULD"
                 }
               },
               "affects": ["Providers"],
@@ -8148,19 +8148,19 @@
               "varies_by_class": {
                 "a": {
                   "statement": "Providers of FedRAMP 20x Class A offerings SHOULD verify and validate the status of machine-based information resources at least once every month.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "months",
                   "timeframe_num": 1
                 },
                 "b": {
                   "statement": "Providers of FedRAMP 20x Class B offerings MUST verify and validate the status of machine-based information resources at least once every 7 days.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "timeframe_type": "days",
                   "timeframe_num": 7
                 },
                 "c": {
                   "statement": "Providers of FedRAMP 20x Class C offerings MUST verify and validate the status of machine-based information resources at least once every 3 days.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "timeframe_type": "days",
                   "timeframe_num": 3
                 }
@@ -8189,25 +8189,25 @@
               "varies_by_class": {
                 "a": {
                   "statement": "Providers of FedRAMP Rev5 Class A offerings SHOULD verify and validate the status of machine-based information resources at least once every month.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "months",
                   "timeframe_num": 1
                 },
                 "b": {
                   "statement": "Providers of FedRAMP Rev5 Class B offerings SHOULD verify and validate the status of machine-based information resources at least once every month.",
-                  "primary_key_word": "SHOULD",
+                  "force": "SHOULD",
                   "timeframe_type": "months",
                   "timeframe_num": 1
                 },
                 "c": {
                   "statement": "Providers of FedRAMP Rev5 Class C offerings MUST verify and validate the status of machine-based information resources at least once every month.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "timeframe_type": "months",
                   "timeframe_num": 1
                 },
                 "d": {
                   "statement": "Providers of FedRAMP Rev5 Class D offerings MUST verify and validate the status of machine-based information resources at least once every month.",
-                  "primary_key_word": "MUST",
+                  "force": "MUST",
                   "timeframe_type": "months",
                   "timeframe_num": 1
                 }

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -4880,6 +4880,48 @@
                 }
               ]
             },
+            "VDR-CSO-PVV": {
+              "name": "Persistent Verification and Validation",
+              "statement": "Providers MUST persistently verify and validate that their information resources are operating as intended; this process is called Persistent Verification and Validation (PVV) and is part of vulnerability detection.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": [
+                "Information Resource",
+                "Persistently",
+                "Provider",
+                "Validation",
+                "Verification",
+                "Vulnerability",
+                "Vulnerability Detection"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "VDR-CSO-FAV": {
+              "name": "Failures Are Vulnerabilities",
+              "statement": "Providers MUST treat problems detected during persistent verification and validation as vulnerabilities, including failures of the verification and validation process it; FedRAMP Vulnerability Detection and Response rules MUST be followed for such findings.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": [
+                "Persistently",
+                "Provider",
+                "Validation",
+                "Verification",
+                "Vulnerability",
+                "Vulnerability Detection",
+                "Vulnerability Response"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
             "VDR-CSO-RES": {
               "name": "Vulnerability Response",
               "statement": "Providers MUST systematically, persistently, and promptly track, evaluate, monitor, mitigate, remediate, assess exploitation of, report, and otherwise manage all detected vulnerabilities within their cloud service offering; this process is called vulnerability response.",
@@ -5436,6 +5478,25 @@
               "timeframe_type": "days",
               "timeframe_num": 192,
               "terms": ["Accepted Vulnerability", "Provider", "Vulnerability"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "VDR-TFR-NMV": {
+              "name": "Non-Machine Verification and Validation",
+              "statement": "Providers MUST verify and validate the status of non-machine-based information resources at least once every 3 months.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": [
+                "Information Resource",
+                "Machine-Based (Information Resources)",
+                "Provider",
+                "Validation",
+                "Verification"
+              ],
               "updated": [
                 {
                   "date": "2026-05-04",
@@ -6087,6 +6148,94 @@
               ]
             }
           }
+        },
+        "20x": {
+          "TFR": {
+            "VDR-TFR-PMV": {
+              "name": "Persistent Machine Verification and Validation",
+              "varies_by_class": {
+                "a": {
+                  "statement": "Providers of FedRAMP 20x Class A offerings SHOULD verify and validate the status of machine-based information resources at least once every month.",
+                  "primary_key_word": "SHOULD",
+                  "timeframe_type": "months",
+                  "timeframe_num": 1
+                },
+                "b": {
+                  "statement": "Providers of FedRAMP 20x Class B offerings MUST verify and validate the status of machine-based information resources at least once every 7 days.",
+                  "primary_key_word": "MUST",
+                  "timeframe_type": "days",
+                  "timeframe_num": 7
+                },
+                "c": {
+                  "statement": "Providers of FedRAMP 20x Class C offerings MUST verify and validate the status of machine-based information resources at least once every 3 days.",
+                  "primary_key_word": "MUST",
+                  "timeframe_type": "days",
+                  "timeframe_num": 3
+                }
+              },
+              "affects": ["Providers"],
+              "terms": [
+                "Information Resource",
+                "Machine-Based (Information Resources)",
+                "Provider",
+                "Validation",
+                "Verification"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          }
+        },
+        "rev5": {
+          "TFR": {
+            "VDR-TFR-PMV": {
+              "name": "Persistent Machine Verification and Validation",
+              "varies_by_class": {
+                "a": {
+                  "statement": "Providers of FedRAMP Rev5 Class A offerings SHOULD verify and validate the status of machine-based information resources at least once every month.",
+                  "primary_key_word": "SHOULD",
+                  "timeframe_type": "months",
+                  "timeframe_num": 1
+                },
+                "b": {
+                  "statement": "Providers of FedRAMP Rev5 Class B offerings SHOULD verify and validate the status of machine-based information resources at least once every month.",
+                  "primary_key_word": "SHOULD",
+                  "timeframe_type": "months",
+                  "timeframe_num": 1
+                },
+                "c": {
+                  "statement": "Providers of FedRAMP Rev5 Class C offerings MUST verify and validate the status of machine-based information resources at least once every month.",
+                  "primary_key_word": "MUST",
+                  "timeframe_type": "months",
+                  "timeframe_num": 1
+                },
+                "d": {
+                  "statement": "Providers of FedRAMP Rev5 Class D offerings MUST verify and validate the status of machine-based information resources at least once every month.",
+                  "primary_key_word": "MUST",
+                  "timeframe_type": "months",
+                  "timeframe_num": 1
+                }
+              },
+              "affects": ["Providers"],
+              "terms": [
+                "Information Resource",
+                "Machine-Based (Information Resources)",
+                "Provider",
+                "Validation",
+                "Verification"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          }
         }
       }
     },
@@ -6515,67 +6664,6 @@
               "primary_key_word": "MUST NOT",
               "affects": ["Providers"],
               "terms": ["Agency", "Cloud Service Offering", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-PVV": {
-              "name": "Persistent Verification and Validation",
-              "statement": "Providers MUST persistently verify and validate that their information resources are operating as intended; this process is called Persistent Verification and Validation (PVV) and is part of vulnerability detection.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "Information Resource",
-                "Persistently",
-                "Provider",
-                "Validation",
-                "Verification",
-                "Vulnerability",
-                "Vulnerability Detection"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-FAV": {
-              "name": "Failures Are Vulnerabilities",
-              "statement": "Providers MUST treat problems detected during persistent verification and validation as vulnerabilities, including failures of the verification and validation process it; FedRAMP Vulnerability Detection and Response rules MUST be followed for such findings.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "Persistently",
-                "Provider",
-                "Validation",
-                "Verification",
-                "Vulnerability",
-                "Vulnerability Detection",
-                "Vulnerability Response"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-NMV": {
-              "name": "Non-Machine Verification and Validation",
-              "statement": "Providers MUST verify and validate the status of non-machine-based information resources at least once every 3 months.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "Information Resource",
-                "Machine-Based (Information Resources)",
-                "Provider",
-                "Validation",
-                "Verification"
-              ],
               "updated": [
                 {
                   "date": "2026-05-04",
@@ -7036,43 +7124,6 @@
                   "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
                 }
               ]
-            },
-            "FRC-CSX-PMV": {
-              "name": "Persistent Machine Verification and Validation",
-              "varies_by_class": {
-                "a": {
-                  "statement": "Providers of FedRAMP 20x Class A offerings SHOULD verify and validate the status of machine-based information resources at least once every month.",
-                  "primary_key_word": "SHOULD",
-                  "timeframe_type": "months",
-                  "timeframe_num": 1
-                },
-                "b": {
-                  "statement": "Providers of FedRAMP 20x Class B offerings MUST verify and validate the status of machine-based information resources at least once every 7 days.",
-                  "primary_key_word": "MUST",
-                  "timeframe_type": "days",
-                  "timeframe_num": 7
-                },
-                "c": {
-                  "statement": "Providers of FedRAMP 20x Class C offerings MUST verify and validate the status of machine-based information resources at least once every 3 days.",
-                  "primary_key_word": "MUST",
-                  "timeframe_type": "days",
-                  "timeframe_num": 3
-                }
-              },
-              "affects": ["Providers"],
-              "terms": [
-                "Information Resource",
-                "Machine-Based (Information Resources)",
-                "Provider",
-                "Validation",
-                "Verification"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
             }
           },
           "IAX": {
@@ -7153,49 +7204,6 @@
               "primary_key_word": "MUST",
               "affects": ["Providers"],
               "terms": ["Agency", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSF-PMV": {
-              "name": "Persistent Machine Verification and Validation",
-              "varies_by_class": {
-                "a": {
-                  "statement": "Providers of FedRAMP Rev5 Class A offerings SHOULD verify and validate the status of machine-based information resources at least once every month.",
-                  "primary_key_word": "SHOULD",
-                  "timeframe_type": "months",
-                  "timeframe_num": 1
-                },
-                "b": {
-                  "statement": "Providers of FedRAMP Rev5 Class B offerings SHOULD verify and validate the status of machine-based information resources at least once every month.",
-                  "primary_key_word": "SHOULD",
-                  "timeframe_type": "months",
-                  "timeframe_num": 1
-                },
-                "c": {
-                  "statement": "Providers of FedRAMP Rev5 Class C offerings MUST verify and validate the status of machine-based information resources at least once every month.",
-                  "primary_key_word": "MUST",
-                  "timeframe_type": "months",
-                  "timeframe_num": 1
-                },
-                "d": {
-                  "statement": "Providers of FedRAMP Rev5 Class D offerings MUST verify and validate the status of machine-based information resources at least once every month.",
-                  "primary_key_word": "MUST",
-                  "timeframe_type": "months",
-                  "timeframe_num": 1
-                }
-              },
-              "affects": ["Providers"],
-              "terms": [
-                "Information Resource",
-                "Machine-Based (Information Resources)",
-                "Provider",
-                "Validation",
-                "Verification"
-              ],
               "updated": [
                 {
                   "date": "2026-05-04",

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -2,8 +2,8 @@
   "info": {
     "title": "FedRAMP Consolidated Rules for 2026 Public Preview",
     "description": "This datafile contains the Consolidated Rules for FedRAMP in structured machine-readable text. It includes definitions, requirements, recommendations, and key security indicators.",
-    "version": "2026.05.25.01-preview",
-    "last_updated": "2026-05-25",
+    "version": "2026.05.28.01-preview",
+    "last_updated": "2026-05-28",
     "default_artifacts": {
       "FRR": [
         "Explanation of how the rule is followed, or an explanation of the reason and resulting risk to customers for not following the rule.",
@@ -995,15 +995,33 @@
         "subsets": {
           "CSO": {
             "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Certifications of any type."
+            "description": "These rules apply to providers for FedRAMP Certifications of any type.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           },
           "TRC": {
             "name": "FedRAMP-Compatible Trust Centers",
-            "description": "These rules apply to trust centers that are FedRAMP-compatible."
+            "description": "These rules apply to trust centers that are FedRAMP-compatible.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           },
           "UTC": {
             "name": "Using a Trust Center",
-            "description": "These rules apply to providers that are using a FedRAMP-compatible trust center instead of USDA Connect; they DO NOT apply to providers using USDA Connect."
+            "description": "These rules apply to providers that are using a FedRAMP-compatible trust center instead of USDA Connect; they DO NOT apply to providers using USDA Connect.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           }
         },
         "20x": {
@@ -1019,7 +1037,13 @@
           "subsets": {
             "CSX": {
               "name": "20x-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP 20x Certifications."
+              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
             }
           }
         },
@@ -1037,7 +1061,13 @@
           "subsets": {
             "CSF": {
               "name": "Rev5-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP Rev5 Certifications."
+              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
             }
           }
         }
@@ -1603,15 +1633,33 @@
         "subsets": {
           "AGM": {
             "name": "Agency Guidance",
-            "description": "These rules for agencies apply to all agencies using a FedRAMP Certification."
+            "description": "These rules for agencies apply to all agencies using a FedRAMP Certification.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Agencies"]
+            }
           },
           "OCR": {
             "name": "Ongoing Certification Reports",
-            "description": "These rules for Ongoing Certification Reports apply to providers with any type of FedRAMP Certification."
+            "description": "These rules for Ongoing Certification Reports apply to providers with any type of FedRAMP Certification.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           },
           "QTR": {
             "name": "Quarterly Reviews",
-            "description": "These rules for Quarterly Reviews apply to providers with any type of FedRAMP Certification."
+            "description": "These rules for Quarterly Reviews apply to providers with any type of FedRAMP Certification.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           }
         },
         "20x": {
@@ -2152,11 +2200,23 @@
         "subsets": {
           "FRP": {
             "name": "FedRAMP Responsibilities",
-            "description": "These rules apply to FedRAMP when communicating with cloud service providers."
+            "description": "These rules apply to FedRAMP when communicating with cloud service providers.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["FedRAMP"]
+            }
           },
           "CSO": {
             "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers with any type of FedRAMP Certification."
+            "description": "These rules apply to providers with any type of FedRAMP Certification.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           }
         }
       },
@@ -2436,11 +2496,23 @@
         "subsets": {
           "FRP": {
             "name": "FedRAMP Responsibilities",
-            "description": "These rules apply to FedRAMP."
+            "description": "These rules apply to FedRAMP.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["FedRAMP"]
+            }
           },
           "CSO": {
             "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers with FedRAMP Certifications of any type."
+            "description": "These rules apply to providers with FedRAMP Certifications of any type.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           }
         },
         "flows": [
@@ -3323,12 +3395,18 @@
         "name": "Minimum Assessment Scope",
         "short_name": "MAS",
         "web_name": "minimum-assessment-scope",
-        "purpose": "The Minimum Assessment Scope rules help providers define assessment boundaries narrowly enough to avoid unnecessary review of components that do not affect the offering’s security. These rules still ensure the assessment includes the resources and connections needed to understand the offering’s confidentiality, integrity, and availability.",
+        "purpose": "The Minimum Assessment Scope rules help providers define assessment boundaries narrowly enough to avoid unnecessary review of components that do not affect the offering's security. These rules still ensure the assessment includes the resources and connections needed to understand the offering's confidentiality, integrity, and availability.",
         "status": "stable",
         "subsets": {
           "CSO": {
             "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers for any type of FedRAMP Certification."
+            "description": "These rules apply to providers for any type of FedRAMP Certification.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           }
         },
         "20x": {
@@ -3487,23 +3565,53 @@
         "subsets": {
           "FRP": {
             "name": "FedRAMP Responsibilities",
-            "description": "These rules apply to FedRAMP activities related to the FedRAMP Marketplace."
+            "description": "These rules apply to FedRAMP activities related to the FedRAMP Marketplace.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["FedRAMP"]
+            }
           },
           "CSO": {
             "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers seeking a listing in the FedRAMP Marketplace."
+            "description": "These rules apply to providers seeking a listing in the FedRAMP Marketplace.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           },
           "IAS": {
             "name": "General Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services seeking a listing in the FedRAMP Marketplace."
+            "description": "These rules apply to independent assessment services seeking a listing in the FedRAMP Marketplace.",
+            "applicability": {
+              "types": [],
+              "paths": [],
+              "classes": [],
+              "affects": ["Assessors"]
+            }
           },
           "CAS": {
             "name": "General Advisor Responsibilities",
-            "description": "These rules apply to consulting and advisory services seeking a listing in the FedRAMP Marketplace."
+            "description": "These rules apply to consulting and advisory services seeking a listing in the FedRAMP Marketplace.",
+            "applicability": {
+              "types": [],
+              "paths": [],
+              "classes": [],
+              "affects": ["Advisors"]
+            }
           },
           "PRE": {
             "name": "Provider Responsibilities for Preparation Phase Listings",
-            "description": "These rules apply to providers seeking a Preparation Phase listing in the FedRAMP Marketplace."
+            "description": "These rules apply to providers seeking a Preparation Phase listing in the FedRAMP Marketplace.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": [],
+              "affects": ["Providers"]
+            }
           }
         },
         "20x": {
@@ -3787,11 +3895,23 @@
         "subsets": {
           "CSO": {
             "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers with FedRAMP Certifications of any type."
+            "description": "These rules apply to providers with FedRAMP Certifications of any type.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           },
           "ENH": {
             "name": "Enhanced Capabilities",
-            "description": "These recommendations apply to providers with FedRAMP Certifications of any type."
+            "description": "These recommendations apply to providers with FedRAMP Certifications of any type.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           }
         }
       },
@@ -3958,23 +4078,53 @@
         "subsets": {
           "FRP": {
             "name": "FedRAMP Responsibilities",
-            "description": "These rules apply to FedRAMP."
+            "description": "These rules apply to FedRAMP.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["FedRAMP"]
+            }
           },
           "CSO": {
             "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers with FedRAMP Certifications of any type."
+            "description": "These rules apply to providers with FedRAMP Certifications of any type.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           },
           "ADP": {
             "name": "Adaptive Changes",
-            "description": "These rules apply to all adaptive significant changes."
+            "description": "These rules apply to all adaptive significant changes.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           },
           "RTR": {
             "name": "Routine Recurring Changes",
-            "description": "These rules apply to all routine recurring significant changes."
+            "description": "These rules apply to all routine recurring significant changes.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           },
           "TRF": {
             "name": "Transformative Changes",
-            "description": "These rules apply to all transformative significant changes."
+            "description": "These rules apply to all transformative significant changes.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           }
         },
         "20x": {
@@ -4477,7 +4627,13 @@
         "subsets": {
           "CSO": {
             "name": "Cloud Service Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Certifications."
+            "description": "These rules apply to providers for FedRAMP Certifications.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           }
         },
         "20x": {
@@ -4575,31 +4731,73 @@
         "subsets": {
           "FRP": {
             "name": "FedRAMP Responsibilities",
-            "description": "These rules apply to FedRAMP when setting expectations for specific cloud service providers."
+            "description": "These rules apply to FedRAMP when setting expectations for specific cloud service providers.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["FedRAMP"]
+            }
           },
           "CSO": {
             "name": "General Provider Responsibilities",
-            "description": "These rules apply to all providers with FedRAMP Certifications of any type."
+            "description": "These rules apply to all providers with FedRAMP Certifications of any type.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           },
           "AGM": {
             "name": "Agency Guidance",
-            "description": "These rules for agencies apply to all agencies using a FedRAMP Certification."
+            "description": "These rules for agencies apply to all agencies using a FedRAMP Certification.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Agencies"]
+            }
           },
           "BST": {
             "name": "Best Practices",
-            "description": "These recommendations for best practices apply to all cloud service providers."
+            "description": "These recommendations for best practices apply to all cloud service providers.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           },
           "EVA": {
             "name": "Evaluation",
-            "description": "These rules apply to the evaluation of vulnerabilities."
+            "description": "These rules apply to the evaluation of vulnerabilities.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           },
           "RPT": {
             "name": "Reporting",
-            "description": "These rules apply to reporting related to vulnerability detection and response."
+            "description": "These rules apply to reporting related to vulnerability detection and response.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           },
           "TFR": {
             "name": "Timeframes",
-            "description": "These rules apply to timeframes for vulnerability detection and response."
+            "description": "These rules apply to timeframes for vulnerability detection and response.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           }
         },
         "20x": {
@@ -5902,27 +6100,63 @@
         "subsets": {
           "FRP": {
             "name": "FedRAMP Responsibilities",
-            "description": "These rules apply to FedRAMP."
+            "description": "These rules apply to FedRAMP.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["FedRAMP"]
+            }
           },
           "CSO": {
             "name": "General Provider Responsibilities",
-            "description": "These rules apply to cloud service providers obtaining and maintaining any FedRAMP Certification."
+            "description": "These rules apply to cloud service providers obtaining and maintaining any FedRAMP Certification.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           },
           "IAS": {
             "name": "General Independent Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types."
+            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Assessors"]
+            }
           },
           "CLA": {
             "name": "FedRAMP Class A Certification Rules",
-            "description": "These rules apply to providers seeking FedRAMP Class A Certifications."
+            "description": "These rules apply to providers seeking FedRAMP Class A Certifications.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A"],
+              "affects": ["Providers"]
+            }
           },
           "APP": {
             "name": "Applying for FedRAMP Certification",
-            "description": "These rules apply to cloud service providers who have met all other relevant rules and are ready to apply for any FedRAMP Certification."
+            "description": "These rules apply to cloud service providers who have met all other relevant rules and are ready to apply for any FedRAMP Certification.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           },
           "APS": {
             "name": "Applying for FedRAMP Certification with an Agency Sponsor",
-            "description": "These rules apply to cloud service providers with an Agency Sponsor who have met all other relevant rules and are ready to apply for any FedRAMP Certification."
+            "description": "These rules apply to cloud service providers with an Agency Sponsor who have met all other relevant rules and are ready to apply for any FedRAMP Certification.",
+            "applicability": {
+              "types": ["Rev5"],
+              "paths": ["Agency"],
+              "classes": ["B", "C", "D"],
+              "affects": ["Providers"]
+            }
           }
         },
         "20x": {
@@ -5938,11 +6172,23 @@
           "subsets": {
             "CSX": {
               "name": "20x-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP 20x Certifications."
+              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
             },
             "IAX": {
               "name": "20x-Specific Independent Assessor Responsibilities",
-              "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications."
+              "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Assessors"]
+              }
             }
           }
         },
@@ -5959,11 +6205,23 @@
           "subsets": {
             "CSF": {
               "name": "Rev5-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP Rev5 Certifications."
+              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
             },
             "IAF": {
               "name": "Rev5-Specific Independent Assessor Responsibilities",
-              "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications."
+              "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Assessors"]
+              }
             }
           }
         }
@@ -6992,7 +7250,13 @@
         "subsets": {
           "CSO": {
             "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Certifications of any type."
+            "description": "These rules apply to providers for FedRAMP Certifications of any type.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           }
         },
         "20x": {
@@ -7008,7 +7272,13 @@
           "subsets": {
             "CSX": {
               "name": "20x-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP 20x Certifications."
+              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
             }
           }
         },
@@ -7026,7 +7296,13 @@
           "subsets": {
             "CSF": {
               "name": "Rev5-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP Rev5 Certifications."
+              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
             }
           }
         }
@@ -7047,11 +7323,23 @@
         "subsets": {
           "CSO": {
             "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Certifications of any type."
+            "description": "These rules apply to providers for FedRAMP Certifications of any type.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           },
           "IAS": {
             "name": "General Independent Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types."
+            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["B", "C", "D"],
+              "affects": ["Assessors"]
+            }
           }
         },
         "20x": {
@@ -7067,11 +7355,23 @@
           "subsets": {
             "CSX": {
               "name": "20x-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP 20x Certifications."
+              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
             },
             "IAX": {
               "name": "20x-Specific Independent Assessor Responsibilities",
-              "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications."
+              "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["B", "C", "D"],
+                "affects": ["Assessors"]
+              }
             }
           }
         },
@@ -7089,11 +7389,23 @@
           "subsets": {
             "CSF": {
               "name": "Rev5-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP Rev5 Certifications."
+              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
             },
             "IAF": {
               "name": "Rev5-Specific Independent Assessor Responsibilities",
-              "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications."
+              "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Assessors"]
+              }
             }
           }
         }
@@ -7114,11 +7426,23 @@
         "subsets": {
           "CSO": {
             "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Certifications of any type."
+            "description": "These rules apply to providers for FedRAMP Certifications of any type.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
           },
           "IAS": {
             "name": "General Independent Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types."
+            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["B", "C", "D"],
+              "affects": ["Assessors"]
+            }
           }
         },
         "20x": {
@@ -7134,11 +7458,23 @@
           "subsets": {
             "CSX": {
               "name": "20x-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP 20x Certifications."
+              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
             },
             "IAX": {
               "name": "20x-Specific Independent Assessor Responsibilities",
-              "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications."
+              "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["B", "C", "D"],
+                "affects": ["Assessors"]
+              }
             }
           }
         },
@@ -7156,11 +7492,23 @@
           "subsets": {
             "CSF": {
               "name": "Rev5-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP Rev5 Certifications."
+              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
             },
             "IAF": {
               "name": "Rev5-Specific Independent Assessor Responsibilities",
-              "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications."
+              "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["B", "C", "D"],
+                "affects": ["Assessors"]
+              }
             }
           }
         }
@@ -7190,15 +7538,33 @@
         "subsets": {
           "AGC": {
             "name": "General Agency Responsibilities",
-            "description": "These rules apply to agencies based on the FedRAMP Authorization Act, OMB M-24-15, and related FedRAMP policies."
+            "description": "These rules apply to agencies based on the FedRAMP Authorization Act, OMB M-24-15, and related FedRAMP policies.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Agencies"]
+            }
           },
           "USE": {
             "name": "Use of FedRAMP Certifications",
-            "description": "These rules apply when agencies use FedRAMP Certifications to make agency authorization decisions."
+            "description": "These rules apply when agencies use FedRAMP Certifications to make agency authorization decisions.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Agencies"]
+            }
           },
           "SPN": {
             "name": "Agency Sponsored Certifications",
-            "description": "These rules apply when an agency sponsors a FedRAMP Rev5 Certification after completing an agency authorization."
+            "description": "These rules apply when an agency sponsors a FedRAMP Rev5 Certification after completing an agency authorization.",
+            "applicability": {
+              "types": ["Rev5"],
+              "paths": ["Agency"],
+              "classes": ["B", "C", "D"],
+              "affects": ["Agencies"]
+            }
           }
         }
       },
@@ -7545,11 +7911,23 @@
         "subsets": {
           "FRP": {
             "name": "FedRAMP Responsibilities",
-            "description": "These rules apply to FedRAMP when evaluating independent assessment services for initial or ongoing FedRAMP Recognition."
+            "description": "These rules apply to FedRAMP when evaluating independent assessment services for initial or ongoing FedRAMP Recognition.",
+            "applicability": {
+              "types": [],
+              "paths": [],
+              "classes": [],
+              "affects": ["FedRAMP"]
+            }
           },
           "IAS": {
             "name": "General Independent Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services seeking to obtain or maintain FedRAMP Recognition."
+            "description": "These rules apply to independent assessment services seeking to obtain or maintain FedRAMP Recognition.",
+            "applicability": {
+              "types": [],
+              "paths": [],
+              "classes": [],
+              "affects": ["Assessors"]
+            }
           }
         }
       },

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -985,132 +985,129 @@
     }
   },
   "FRR": {
-    "CDS": {
+    "AGU": {
       "info": {
-        "name": "Certification Data Sharing",
-        "short_name": "CDS",
-        "web_name": "certification-data-sharing",
-        "purpose": "The Certification Data Sharing rules allow providers to store and share FedRAMP certification information through the platform they choose as long as it follows FedRAMP rules for access, accuracy, and transparency. This helps customers and the public review consistent, current security and compliance information while recognizing that the information usually remains the provider's intellectual property and is not federal information.",
-        "status": "stable",
+        "name": "Agency Use of FedRAMP Certified Cloud Services (Needs Review)",
+        "short_name": "AGU",
+        "web_name": "agency-use",
+        "purpose": "The Agency Use rules summarize the many demands made on agencies by the FedRAMP Authorization Act and OMB Memorandum M-24-15 in a simple, clear, easy-to-follow set of FedRAMP-style rules. These rules align agency policies, authorization letters, machine-readable tools, secure configuration review, continuous monitoring, and communication with FedRAMP so certifications can be reused consistently across government.",
+        "status": "placeholder",
+        "effective": {
+          "is": "required",
+          "current_status": "Consolidated Rules for 2026",
+          "date": {
+            "obtain": "2026-07-04",
+            "maintain": "2026-07-04",
+            "grace_ends": "2026-07-04"
+          }
+        },
         "subsets": {
-          "CSO": {
-            "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Certifications of any type.",
+          "AGC": {
+            "name": "General Agency Responsibilities",
+            "description": "These rules apply to agencies based on the FedRAMP Authorization Act, OMB M-24-15, and related FedRAMP policies.",
             "applicability": {
               "types": ["20x", "Rev5"],
               "paths": ["Program", "Agency"],
               "classes": ["A", "B", "C", "D"],
-              "affects": ["Providers"]
+              "affects": ["Agencies"]
             }
           },
-          "TRC": {
-            "name": "FedRAMP-Compatible Trust Centers",
-            "description": "These rules apply to trust centers that are FedRAMP-compatible.",
+          "USE": {
+            "name": "Use of FedRAMP Certifications",
+            "description": "These rules apply when agencies use FedRAMP Certifications to make agency authorization decisions.",
             "applicability": {
               "types": ["20x", "Rev5"],
               "paths": ["Program", "Agency"],
               "classes": ["A", "B", "C", "D"],
-              "affects": ["Providers"]
+              "affects": ["Agencies"]
             }
           },
-          "UTC": {
-            "name": "Using a Trust Center",
-            "description": "These rules apply to providers that are using a FedRAMP-compatible trust center instead of USDA Connect; they DO NOT apply to providers using USDA Connect.",
+          "SPN": {
+            "name": "Agency Sponsored Certifications",
+            "description": "These rules apply when an agency sponsors a FedRAMP Rev5 Certification after completing an agency authorization.",
             "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["A", "B", "C", "D"],
-              "affects": ["Providers"]
-            }
-          }
-        },
-        "20x": {
-          "effective": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-07-04",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-05-04"
-            }
-          },
-          "subsets": {
-            "CSX": {
-              "name": "20x-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
-              "applicability": {
-                "types": ["20x"],
-                "paths": ["Program"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Providers"]
-              }
-            }
-          }
-        },
-        "rev5": {
-          "effective": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2027-01-01",
-              "maintain": "2027-08-01",
-              "grace_ends": "2028-02-01"
-            },
-            "signup_url": "ADDME"
-          },
-          "subsets": {
-            "CSF": {
-              "name": "Rev5-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
-              "applicability": {
-                "types": ["Rev5"],
-                "paths": ["Program", "Agency"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Providers"]
-              }
+              "types": ["Rev5"],
+              "paths": ["Agency"],
+              "classes": ["B", "C", "D"],
+              "affects": ["Agencies"]
             }
           }
         }
       },
       "data": {
         "all": {
-          "CSO": {
-            "CDS-CSO-PUB": {
-              "name": "Public Information",
-              "statement": "Providers MUST publicly share up-to-date information about the cloud service offering in both human-readable and machine-readable formats, including at least:",
+          "AGC": {
+            "AGU-AGC-AIP": {
+              "name": "Agency Internal Policies",
+              "statement": "Agencies MUST maintain agency-wide policy that aligns with the requirements in OMB Memorandum M-24-15.",
+              "primary_key_word": "MUST",
+              "affects": ["Agencies"],
+              "terms": ["Agency"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "AGU-AGC-NAL": {
+              "name": "Notify FedRAMP After Authorization",
+              "statement": "Agencies MUST supply FedRAMP the following information upon authorizing the use of a cloud service within the scope of FedRAMP:",
               "following_information": [
-                "Direct link to the FedRAMP Marketplace for the offering",
-                "Service Model",
-                "Deployment Model",
-                "Business Category",
-                "UEI Number",
-                "Contact Information",
-                "Overall Service Description",
-                "Detailed list of specific services and their security categories (see CDS-CSO-SVC (Service List))",
-                "Summary of customer responsibilities and secure configuration guidance (if applicable, see the FedRAMP Secure Configuration Guide process)",
-                "Process for accessing information in the trust center (if applicable)",
-                "Availability status and recent disruptions for the trust center (if applicable)",
-                "Customer support information for the trust center (if applicable)",
-                "Next Ongoing Certification Report date (see CCM-OCR-NRD (Next Report Date))"
+                "A copy of the Authorization to Operate letter",
+                "All other supplementary information outlined at https://help.fedramp.gov/ato"
               ],
-              "note": "Generally, this information should be available on a public webpage.",
-              "related": ["CDS-CSO-SVC", "CCM-OCR-NRD"],
               "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "artifacts": {
-                "all": [
-                  "URL to the human-readable data.",
-                  "URL to the machine-readable data."
-                ]
-              },
+              "affects": ["Agencies"],
+              "notification": [
+                {
+                  "party": "FedRAMP",
+                  "method": "email",
+                  "target": "ato-letter@fedramp.gov"
+                }
+              ],
+              "terms": ["Agency"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "AGU-AGC-GRC": {
+              "name": "Governance, Risk, and Compliance Tools",
+              "statement": "Agencies MUST ensure that internal governance, risk, compliance, and inventory tools can produce and ingest machine-readable artifacts using formats identified by FedRAMP, including at least:",
+              "following_information": [
+                "Open Security Controls Assessment Language (OSCAL)",
+                "JSON"
+              ],
+              "primary_key_word": "MUST",
+              "affects": ["Agencies"],
+              "terms": ["Agency", "Artifacts", "Machine-Readable"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "AGU-AGC-NAI": {
+              "name": "Notify Additional Information Requests",
+              "statement": "Agencies MUST notify FedRAMP after requesting any additional information or materials from a FedRAMP Certified cloud service offering beyond those FedRAMP requires.",
+              "note": "Agencies are expected to notify FedRAMP under OMB Memorandum M-24-15 section IV (a).",
+              "primary_key_word": "MUST",
+              "affects": ["Agencies"],
+              "notification": [
+                {
+                  "party": "FedRAMP",
+                  "method": "email",
+                  "target": "info@fedramp.gov"
+                }
+              ],
               "terms": [
+                "Agency",
                 "Cloud Service Offering",
-                "Machine-Readable",
-                "Ongoing Certification",
-                "Ongoing Certification Report (OCR)",
-                "Provider",
-                "Security Category",
-                "Trust Center"
+                "FedRAMP Certified"
               ],
               "updated": [
                 {
@@ -1119,22 +1116,17 @@
                 }
               ]
             },
-            "CDS-CSO-SVC": {
-              "name": "Service List",
-              "statement": "Providers MUST publicly share a detailed list of specific services and their security categories that are included in the cloud service offering using clear feature or service names that align with standard public marketing materials; this list MUST be complete enough for a potential customer to determine which services are and are not included in the FedRAMP Minimum Assessment Scope without requesting access to underlying FedRAMP Certification Data.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "artifacts": {
-                "all": [
-                  "URL to the human-readable data.",
-                  "URL to the machine-readable data (if applicable)."
-                ]
-              },
+            "AGU-AGC-NAR": {
+              "name": "No Additional Security Requirements",
+              "statement": "Agencies MUST NOT require additional information or materials from FedRAMP Certified cloud service offerings beyond those required by FedRAMP UNLESS the head of the agency or an authorized delegate determines there is a demonstrable need; this does not apply to seeking clarification or asking general questions about FedRAMP Certification Data.",
+              "note": "This is related to the Presumption of Adequacy for a FedRAMP Certification.",
+              "primary_key_word": "MUST NOT",
+              "affects": ["Agencies"],
               "terms": [
+                "Agency",
                 "Certification Data",
                 "Cloud Service Offering",
-                "Provider",
-                "Security Category"
+                "FedRAMP Certified"
               ],
               "updated": [
                 {
@@ -1143,37 +1135,62 @@
                 }
               ]
             },
-            "CDS-CSO-PAR": {
-              "name": "Public Availability Reporting",
-              "varies_by_class": {
-                "a": {
-                  "statement": "Providers with Class A Certifications SHOULD maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service SHOULD be available even if the primary cloud service offering is unavailable.",
-                  "primary_key_word": "SHOULD",
-                  "note": "This service may be separate from the trust center."
-                },
-                "b": {
-                  "statement": "Providers with Class B Certifications MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service MUST be available even if the primary cloud service offering is unavailable.",
-                  "primary_key_word": "MUST",
-                  "note": "This service may be separate from the trust center."
-                },
-                "c": {
-                  "statement": "Providers with Class C Certifications MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service MUST be available even if the primary cloud service offering is unavailable.",
-                  "primary_key_word": "MUST",
-                  "note": "This service may be separate from the trust center."
-                },
-                "d": {
-                  "statement": "Providers with Class D Certifications MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service MUST be available even if the primary cloud service offering is unavailable.",
-                  "primary_key_word": "MUST",
-                  "note": "This service may be separate from the trust center."
+            "AGU-AGC-WKG": {
+              "name": "FedRAMP Working Groups",
+              "statement": "Agencies SHOULD participate in FedRAMP working groups, communities of practice, and stakeholder engagements to supply feedback and align practices across government.",
+              "primary_key_word": "SHOULD",
+              "affects": ["Agencies"],
+              "terms": ["Agency"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
                 }
-              },
-              "affects": ["Providers"],
+              ]
+            },
+            "AGU-AGC-LIA": {
+              "name": "Agency Liaison Program",
+              "statement": "Agencies SHOULD assign at least 1 federal employee to be an active participant in the FedRAMP Agency Liaison program.",
+              "reference": "Agency Liaison Program",
+              "reference_url": "https://www.fedramp.gov/preview/2026/agencies/support/liaisons",
+              "primary_key_word": "SHOULD",
+              "affects": ["Agencies"],
+              "terms": ["Agency"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "AGU-AGC-SIN": {
+              "name": "Shared FedRAMP Inbox",
+              "statement": "Agencies SHOULD establish and maintain a dedicated shared FedRAMP agency inbox to serve as the official point of contact for communications between FedRAMP and the agency.",
+              "note": "A shared FedRAMP agency inbox may follow an agency-specific format such as agency-fedramp@agency.gov.",
+              "primary_key_word": "SHOULD",
+              "affects": ["Agencies"],
+              "terms": ["Agency"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "USE": {
+            "AGU-USE-ABU": {
+              "name": "Authorization Before Use",
+              "statement": "Agencies MUST complete the Authorization to Operate process for federal information systems that use FedRAMP Certified cloud service offerings.",
+              "note": "FedRAMP provides technical assistance to help agencies navigate this process.",
+              "reference": "Using a FedRAMP Certified Cloud Service Offering",
+              "reference_url": "https://fedramp.gov/preview/2026/agencies/use",
+              "primary_key_word": "MUST",
+              "affects": ["Agencies"],
               "terms": [
-                "All Necessary Parties",
+                "Agency",
                 "Cloud Service Offering",
-                "Incident",
-                "Machine-Readable",
-                "Provider"
+                "FedRAMP Certified"
               ],
               "updated": [
                 {
@@ -1182,17 +1199,41 @@
                 }
               ]
             },
-            "CDS-CSO-UTC": {
-              "name": "Use Trust Centers",
-              "statement": "Providers MUST use a FedRAMP-compatible trust center to store and share FedRAMP Certification Data with all necessary parties.",
-              "note": "Rules for FedRAMP-Compatible Trust Centers are explained in the Certification Data Sharing Rules under the FedRAMP-Compatible Trust Centers section (id: CDS-TRC).",
+            "AGU-USE-RCF": {
+              "name": "Resolve Certification Package Conflicts",
+              "statement": "Agencies MUST collaborate with FedRAMP when discrepancies or conflicts arise between agency-specific security determinations and the baseline FedRAMP Certification package.",
               "primary_key_word": "MUST",
-              "affects": ["Providers"],
+              "affects": ["Agencies"],
+              "terms": ["Agency", "Certification Package"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "AGU-USE-RSG": {
+              "name": "Review Secure Configuration Guides",
+              "statement": "Agencies MUST review the Secure Configuration Guides supplied by Providers and configure relevant security settings.",
+              "primary_key_word": "MUST",
+              "affects": ["Agencies"],
+              "terms": ["Agency", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "AGU-USE-AFR": {
+              "name": "Accept FedRAMP Rules",
+              "statement": "Agencies MUST allow FedRAMP Certified cloud service offerings to follow FedRAMP rules.",
+              "primary_key_word": "MUST",
+              "affects": ["Agencies"],
               "terms": [
-                "All Necessary Parties",
-                "Certification Data",
-                "Provider",
-                "Trust Center"
+                "Agency",
+                "Cloud Service Offering",
+                "FedRAMP Certified"
               ],
               "updated": [
                 {
@@ -1201,49 +1242,24 @@
                 }
               ]
             },
-            "CDS-CSO-CBF": {
-              "name": "Consistency Between Formats",
-              "statement": "Providers MUST use automation to ensure information remains consistent between human-readable and machine-readable formats when FedRAMP Certification Data is provided in both formats.",
+            "AGU-USE-NFC": {
+              "name": "Notify FedRAMP of Concerns",
+              "statement": "Agencies MUST notify FedRAMP if information presented in an Ongoing Authorization Report, Quarterly Review, or other FedRAMP Certification Data causes significant concerns for the authorizing official that would likely result in rescission of their Authorization to Operate.",
+              "note": "Agencies are expected to notify FedRAMP under OMB Memorandum M-24-15 section IV (a).",
               "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Certification Data", "Machine-Readable", "Provider"],
-              "updated": [
+              "affects": ["Agencies"],
+              "notification": [
                 {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "CDS-CSO-RIS": {
-              "name": "Responsible Information Sharing",
-              "statement": "Providers MUST provide sufficient information in FedRAMP Certification Data to support agency authorization decisions but SHOULD NOT include sensitive information that would likely enable a threat actor to gain unauthorized access, cause harm, disrupt operations, or otherwise have a negative adverse impact on the cloud service offering.",
-              "note": "This is not a license to exclude accurate risk information, but specifics that would likely lead to compromise should be abstracted. A breach of confidentiality with FedRAMP Certification Data should be anticipated by a secure cloud service provider.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "examples": [
-                {
-                  "id": "Tips on sensitive information in FedRAMP Certification Data",
-                  "key_tests": [
-                    "Passwords, API keys, access credentials, etc.",
-                    "Excessive detail about methodology that exposes weaknesses",
-                    "Personally identifiable information about employees"
-                  ],
-                  "examples": [
-                    "DON'T: \"In an emergency, an administrator with physical access to a system can log in using \"secretadmin\" with the password \"pleasewutno\"\"",
-                    "DO: \"In an emergency, administrators with physical access can log in directly.\"",
-                    "DON'T: \"All backup MFA credentials are stored in a SuperSafe Series 9000 safe in the CEOs office.\"",
-                    "DO: \"All backup MFA credentials are stored in a UL Class 350 safe in a secure location with limited access.\"",
-                    "DON'T: \"During an incident, the incident response team lead by Jim Smith (555-0505) will open a channel at the conference line (555-0101 #97808 passcode 99731)...\"",
-                    "DO: \"During an incident, the incident response team will coordinate over secure channels.\""
-                  ]
+                  "party": "FedRAMP",
+                  "method": "email",
+                  "target": "info@fedramp.gov"
                 }
               ],
               "terms": [
                 "Agency",
                 "Certification Data",
-                "Cloud Service Offering",
                 "Likely",
-                "Provider"
+                "Quarterly Review"
               ],
               "updated": [
                 {
@@ -1252,23 +1268,49 @@
                 }
               ]
             },
-            "CDS-CSO-HAD": {
-              "name": "Historical FedRAMP Certification Data",
-              "statement": "Providers MUST make historical versions of FedRAMP Certification Data available for three years to all necessary parties UNLESS otherwise specified by applicable FedRAMP rules; deltas between versions MAY be consolidated quarterly.",
-              "note": "Consolidating changes quarterly means that the historical status at the end of each quarter or at the time of the Ongoing Authorization Report or Quarterly Review is sufficient, instead of maintaining separate versions with every single change that took place throughout the quarter.",
-              "effective_date": {
-                "obtain": "2027-05-04",
-                "maintain": "2027-05-04",
-                "grace_by_assessment_months": 2
-              },
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "artifacts": {
-                "all": ["Explanation of how to access this information."]
-              },
+            "AGU-USE-ROR": {
+              "name": "Review Ongoing Authorization Reports",
+              "statement": "Agencies SHOULD review each Ongoing Authorization Report to understand how changes to the cloud service offering may impact the risk tolerance documented in the agency Authorization to Operate for the federal information system that includes the cloud service offering in its boundary.",
+              "note": "This agency review supports agency responsibilities under 44 USC § 35, OMB Circular A-130, FIPS-200, and OMB Memorandum M-24-15.",
+              "primary_key_word": "SHOULD",
+              "affects": ["Agencies"],
+              "terms": ["Agency", "Cloud Service Offering"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "AGU-USE-DSO": {
+              "name": "Designate Senior Official",
+              "statement": "Agencies SHOULD designate a federal senior information security official to review Ongoing Authorization Reports and represent the agency at Quarterly Reviews for cloud service offerings included in agency information systems.",
+              "primary_key_word": "SHOULD",
+              "affects": ["Agencies"],
+              "terms": ["Agency", "Cloud Service Offering", "Quarterly Review"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "AGU-USE-NPC": {
+              "name": "Notify Provider of Concerns",
+              "statement": "Agencies SHOULD formally notify the Provider if information presented in an Ongoing Authorization Report, Quarterly Review, or other FedRAMP Certification Data causes significant concerns for the authorizing official that would likely result in rescission of their Authorization to Operate.",
+              "primary_key_word": "SHOULD",
+              "affects": ["Agencies"],
+              "notification": [
+                {
+                  "party": "Provider",
+                  "method": "email",
+                  "target": "Provider security contact"
+                }
+              ],
               "terms": [
-                "All Necessary Parties",
+                "Agency",
                 "Certification Data",
+                "Likely",
                 "Provider",
                 "Quarterly Review"
               ],
@@ -1279,80 +1321,16 @@
                 }
               ]
             },
-            "CDS-CSO-PSM": {
-              "name": "Per-Service Certification Materials",
-              "varies_by_class": {
-                "a": {
-                  "statement": "Providers with Class A Certifications MAY supply per-service FedRAMP Certification materials.",
-                  "primary_key_word": "MAY",
-                  "artifacts": {
-                    "all": [
-                      "Explanation of the supplied materials, including how to access and use them."
-                    ]
-                  }
-                },
-                "b": {
-                  "statement": "Providers with Class B Certifications MAY supply per-service FedRAMP Certification materials.",
-                  "primary_key_word": "MAY",
-                  "artifacts": {
-                    "all": [
-                      "Explanation of the supplied materials, including how to access and use them."
-                    ]
-                  }
-                },
-                "c": {
-                  "statement": "Providers with Class C Certifications MAY supply per-service FedRAMP Certification materials.",
-                  "primary_key_word": "MAY",
-                  "artifacts": {
-                    "all": [
-                      "Explanation of the supplied materials, including how to access and use them."
-                    ]
-                  }
-                },
-                "d": {
-                  "statement": "Providers with Class D Certifications MUST supply per-service FedRAMP Certification materials.",
-                  "primary_key_word": "MUST",
-                  "effective_date": {
-                    "obtain": "2027-05-04",
-                    "maintain": "2027-05-04",
-                    "grace_by_assessment_months": 2
-                  },
-                  "artifacts": {
-                    "all": [
-                      "Explanation of the supplied materials, including how to access and use them."
-                    ]
-                  }
-                }
-              },
-              "notes": [
-                "Providers determine what they consider to be separate services, based on maximizing the customer experience for agencies who may only adopt some services and not others.",
-                "Providers are encouraged to provide a single comprehensive set of materials for all shared aspects of the service offering and only provide separate materials for unique aspects of each service to minimize the burden on providers and agencies."
-              ],
-              "affects": ["Providers"],
-              "terms": ["Agency", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "CDS-CSO-RPS": {
-              "name": "Responsible Public Sharing",
-              "statement": "Providers MAY responsibly share some or all of the information in a FedRAMP Certification Package publicly or with other parties if the provider determines doing so will NOT likely have an adverse effect on the cloud service offering.",
-              "primary_key_word": "MAY",
-              "affects": ["Providers"],
-              "artifacts": {
-                "all": [
-                  "Explanation of if and how this information is shared with other parties."
-                ]
-              },
+            "AGU-USE-RIR": {
+              "name": "Review All Information Resources",
+              "statement": "Agencies SHOULD consider third-party information resources used by the cloud service offering during initial and ongoing authorization activities.",
+              "primary_key_word": "SHOULD",
+              "affects": ["Agencies"],
               "terms": [
-                "Certification Package",
+                "Agency",
                 "Cloud Service Offering",
-                "Likely",
-                "Provider",
-                "Responsibly"
+                "Information Resource",
+                "Third-Party Information Resource"
               ],
               "updated": [
                 {
@@ -1362,256 +1340,13 @@
               ]
             }
           },
-          "TRC": {
-            "CDS-TRC-USH": {
-              "name": "Uninterrupted Sharing",
-              "statement": "Trust centers MUST share FedRAMP Certification Data with all necessary parties without interruption.",
-              "note": "\"Without interruption\" means that parties should not have to request manual approval each time they need to access FedRAMP Certification Data or go through a complicated process. The preferred way of ensuring access without interruption is to use on-demand just-in-time access provisioning.",
+          "SPN": {
+            "AGU-SPN-MRC": {
+              "name": "Most Recent Consolidated Rules",
+              "statement": "Agencies MUST follow the most recent FedRAMP Consolidated Rules when initiating agency-sponsored FedRAMP Certification.",
               "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "All Necessary Parties",
-                "Certification Data",
-                "Trust Center"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "CDS-TRC-PAC": {
-              "name": "Programmatic Access",
-              "statement": "Trust centers MUST provide documented programmatic access to all FedRAMP Certification Data, including programmatic access to human-readable materials.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "artifacts": {
-                "all": ["URL to the documentation for programmatic access."]
-              },
-              "terms": ["Certification Data", "Trust Center"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "CDS-TRC-AAI": {
-              "name": "Agency Access Inventory",
-              "statement": "Trust centers MUST maintain an inventory and history of federal agency users or systems with access to FedRAMP Certification Data and MUST make this information available to FedRAMP upon request.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "artifacts": {
-                "all": [
-                  "Explanation of how FedRAMP can obtain this information."
-                ]
-              },
-              "terms": ["Agency", "Certification Data", "Trust Center"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "CDS-TRC-ACL": {
-              "name": "Access Logging",
-              "statement": "Trust centers MUST log access to FedRAMP Certification Data and store summaries of access for at least six months; such information, as it pertains to specific parties, SHOULD be made available upon request by those parties.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "artifacts": {
-                "all": [
-                  "Explanation of how the appropriate parties can obtain this log information."
-                ]
-              },
-              "terms": ["Certification Data", "Trust Center"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "CDS-TRC-HMR": {
-              "name": "Human and Machine-Readable",
-              "statement": "Trust centers SHOULD make FedRAMP Certification Data available to view and download in both human-readable and machine-readable formats.",
-              "primary_key_word": "SHOULD",
-              "affects": ["Providers"],
-              "terms": [
-                "Certification Data",
-                "Machine-Readable",
-                "Trust Center"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "CDS-TRC-SSM": {
-              "name": "Self-Service Access Management",
-              "statement": "Trust centers SHOULD include features that encourage all necessary parties to provision and manage access to FedRAMP Certification Data for their users and services directly.",
-              "primary_key_word": "SHOULD",
-              "affects": ["Providers"],
-              "artifacts": {
-                "all": [
-                  "URL or explanation how to access documentation of these features and capabilities."
-                ]
-              },
-              "terms": [
-                "All Necessary Parties",
-                "Certification Data",
-                "Trust Center"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
-          "UTC": {
-            "CDS-UTC-PGD": {
-              "name": "Public Guidance",
-              "statement": "Providers MUST publicly provide plain-language policies and guidance for all necessary parties that explains how they can obtain and manage access to FedRAMP Certification Data stored in the trust center.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "artifacts": {
-                "all": [
-                  "URL or explanation of the supplied materials, including how to access and use them."
-                ]
-              },
-              "terms": [
-                "All Necessary Parties",
-                "Certification Data",
-                "Provider",
-                "Trust Center"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "CDS-UTC-AGA": {
-              "name": "Agency Access",
-              "statement": "Providers SHOULD share the FedRAMP Certification package with agencies upon request.",
-              "primary_key_word": "SHOULD",
-              "affects": ["Providers"],
-              "artifacts": {
-                "all": [
-                  "URL or explanation of how to request these materials.",
-                  "Explanation of how the provider decides whether or not to share these materials or other related policies."
-                ]
-              },
-              "terms": ["Agency", "Certification Package", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "CDS-UTC-AAD": {
-              "name": "Agency Access Denial",
-              "statement": "Providers MUST notify FedRAMP by email to info@fedramp.gov within 5 business days of denying an agency access request for FedRAMP Certification Data.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "timeframe_type": "bizdays",
-              "timeframe_num": 5,
-              "notification": [
-                {
-                  "party": "FedRAMP",
-                  "method": "email",
-                  "target": "info@fedramp.gov"
-                }
-              ],
-              "terms": ["Agency", "Certification Data", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          }
-        },
-        "20x": {
-          "CSX": {}
-        },
-        "rev5": {
-          "CSF": {
-            "CDS-CSF-TCM": {
-              "name": "Trust Center Migration",
-              "statement": "Providers MUST notify all necessary parties when migrating to a trust center and MUST provide information in their existing USDA Connect Community Portal secure folders explaining how to use the trust center to obtain FedRAMP Certification Data.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "notification": [
-                {
-                  "party": "All Necessary Parties",
-                  "method": "update",
-                  "target": "FedRAMP Certification Data"
-                }
-              ],
-              "terms": [
-                "All Necessary Parties",
-                "Certification Data",
-                "Provider",
-                "Trust Center"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "CDS-CSF-SCD": {
-              "name": "Structured Certification Data",
-              "varies_by_class": {
-                "a": {
-                  "statement": "Providers with Class A Certifications MUST supply semi-structured text-based FedRAMP Certification Data.",
-                  "primary_key_word": "MUST",
-                  "effective_date": {
-                    "obtain": "2027-01-01",
-                    "maintain": "2027-05-04",
-                    "grace_by_assessment_months": 2
-                  }
-                },
-                "b": {
-                  "statement": "Providers with Class B Certifications MUST supply semi-structured text-based FedRAMP Certification Data.",
-                  "primary_key_word": "MUST",
-                  "effective_date": {
-                    "obtain": "2027-01-01",
-                    "maintain": "2027-05-04",
-                    "grace_by_assessment_months": 2
-                  }
-                },
-                "c": {
-                  "statement": "Providers with Class C Certifications MUST supply semi-structured text-based FedRAMP Certification Data.",
-                  "primary_key_word": "MUST",
-                  "effective_date": {
-                    "obtain": "2027-01-01",
-                    "maintain": "2027-05-04",
-                    "grace_by_assessment_months": 2
-                  }
-                },
-                "d": {
-                  "statement": "Providers with Class D Certifications MUST supply comprehensive machine-readable FedRAMP Certification Data.",
-                  "primary_key_word": "MUST",
-                  "effective_date": {
-                    "obtain": "2027-05-04",
-                    "maintain": "2027-05-04",
-                    "grace_by_assessment_months": 2
-                  }
-                }
-              },
-              "affects": ["Providers"],
-              "terms": ["Certification Data", "Machine-Readable", "Provider"],
+              "affects": ["Agencies"],
+              "terms": ["Agency"],
               "updated": [
                 {
                   "date": "2026-05-04",
@@ -2181,6 +1916,1653 @@
         }
       }
     },
+    "CDS": {
+      "info": {
+        "name": "Certification Data Sharing",
+        "short_name": "CDS",
+        "web_name": "certification-data-sharing",
+        "purpose": "The Certification Data Sharing rules allow providers to store and share FedRAMP certification information through the platform they choose as long as it follows FedRAMP rules for access, accuracy, and transparency. This helps customers and the public review consistent, current security and compliance information while recognizing that the information usually remains the provider's intellectual property and is not federal information.",
+        "status": "stable",
+        "subsets": {
+          "CSO": {
+            "name": "General Provider Responsibilities",
+            "description": "These rules apply to providers for FedRAMP Certifications of any type.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
+          },
+          "TRC": {
+            "name": "FedRAMP-Compatible Trust Centers",
+            "description": "These rules apply to trust centers that are FedRAMP-compatible.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
+          },
+          "UTC": {
+            "name": "Using a Trust Center",
+            "description": "These rules apply to providers that are using a FedRAMP-compatible trust center instead of USDA Connect; they DO NOT apply to providers using USDA Connect.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
+          }
+        },
+        "20x": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2026-07-04",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-05-04"
+            }
+          },
+          "subsets": {
+            "CSX": {
+              "name": "20x-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
+            }
+          }
+        },
+        "rev5": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2027-01-01",
+              "maintain": "2027-08-01",
+              "grace_ends": "2028-02-01"
+            },
+            "signup_url": "ADDME"
+          },
+          "subsets": {
+            "CSF": {
+              "name": "Rev5-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
+            }
+          }
+        }
+      },
+      "data": {
+        "all": {
+          "CSO": {
+            "CDS-CSO-PUB": {
+              "name": "Public Information",
+              "statement": "Providers MUST publicly share up-to-date information about the cloud service offering in both human-readable and machine-readable formats, including at least:",
+              "following_information": [
+                "Direct link to the FedRAMP Marketplace for the offering",
+                "Service Model",
+                "Deployment Model",
+                "Business Category",
+                "UEI Number",
+                "Contact Information",
+                "Overall Service Description",
+                "Detailed list of specific services and their security categories (see CDS-CSO-SVC (Service List))",
+                "Summary of customer responsibilities and secure configuration guidance (if applicable, see the FedRAMP Secure Configuration Guide process)",
+                "Process for accessing information in the trust center (if applicable)",
+                "Availability status and recent disruptions for the trust center (if applicable)",
+                "Customer support information for the trust center (if applicable)",
+                "Next Ongoing Certification Report date (see CCM-OCR-NRD (Next Report Date))"
+              ],
+              "note": "Generally, this information should be available on a public webpage.",
+              "related": ["CDS-CSO-SVC", "CCM-OCR-NRD"],
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "artifacts": {
+                "all": [
+                  "URL to the human-readable data.",
+                  "URL to the machine-readable data."
+                ]
+              },
+              "terms": [
+                "Cloud Service Offering",
+                "Machine-Readable",
+                "Ongoing Certification",
+                "Ongoing Certification Report (OCR)",
+                "Provider",
+                "Security Category",
+                "Trust Center"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "CDS-CSO-SVC": {
+              "name": "Service List",
+              "statement": "Providers MUST publicly share a detailed list of specific services and their security categories that are included in the cloud service offering using clear feature or service names that align with standard public marketing materials; this list MUST be complete enough for a potential customer to determine which services are and are not included in the FedRAMP Minimum Assessment Scope without requesting access to underlying FedRAMP Certification Data.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "artifacts": {
+                "all": [
+                  "URL to the human-readable data.",
+                  "URL to the machine-readable data (if applicable)."
+                ]
+              },
+              "terms": [
+                "Certification Data",
+                "Cloud Service Offering",
+                "Provider",
+                "Security Category"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "CDS-CSO-PAR": {
+              "name": "Public Availability Reporting",
+              "varies_by_class": {
+                "a": {
+                  "statement": "Providers with Class A Certifications SHOULD maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service SHOULD be available even if the primary cloud service offering is unavailable.",
+                  "primary_key_word": "SHOULD",
+                  "note": "This service may be separate from the trust center."
+                },
+                "b": {
+                  "statement": "Providers with Class B Certifications MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service MUST be available even if the primary cloud service offering is unavailable.",
+                  "primary_key_word": "MUST",
+                  "note": "This service may be separate from the trust center."
+                },
+                "c": {
+                  "statement": "Providers with Class C Certifications MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service MUST be available even if the primary cloud service offering is unavailable.",
+                  "primary_key_word": "MUST",
+                  "note": "This service may be separate from the trust center."
+                },
+                "d": {
+                  "statement": "Providers with Class D Certifications MUST maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service MUST be available even if the primary cloud service offering is unavailable.",
+                  "primary_key_word": "MUST",
+                  "note": "This service may be separate from the trust center."
+                }
+              },
+              "affects": ["Providers"],
+              "terms": [
+                "All Necessary Parties",
+                "Cloud Service Offering",
+                "Incident",
+                "Machine-Readable",
+                "Provider"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "CDS-CSO-UTC": {
+              "name": "Use Trust Centers",
+              "statement": "Providers MUST use a FedRAMP-compatible trust center to store and share FedRAMP Certification Data with all necessary parties.",
+              "note": "Rules for FedRAMP-Compatible Trust Centers are explained in the Certification Data Sharing Rules under the FedRAMP-Compatible Trust Centers section (id: CDS-TRC).",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": [
+                "All Necessary Parties",
+                "Certification Data",
+                "Provider",
+                "Trust Center"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "CDS-CSO-CBF": {
+              "name": "Consistency Between Formats",
+              "statement": "Providers MUST use automation to ensure information remains consistent between human-readable and machine-readable formats when FedRAMP Certification Data is provided in both formats.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Certification Data", "Machine-Readable", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "CDS-CSO-RIS": {
+              "name": "Responsible Information Sharing",
+              "statement": "Providers MUST provide sufficient information in FedRAMP Certification Data to support agency authorization decisions but SHOULD NOT include sensitive information that would likely enable a threat actor to gain unauthorized access, cause harm, disrupt operations, or otherwise have a negative adverse impact on the cloud service offering.",
+              "note": "This is not a license to exclude accurate risk information, but specifics that would likely lead to compromise should be abstracted. A breach of confidentiality with FedRAMP Certification Data should be anticipated by a secure cloud service provider.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "examples": [
+                {
+                  "id": "Tips on sensitive information in FedRAMP Certification Data",
+                  "key_tests": [
+                    "Passwords, API keys, access credentials, etc.",
+                    "Excessive detail about methodology that exposes weaknesses",
+                    "Personally identifiable information about employees"
+                  ],
+                  "examples": [
+                    "DON'T: \"In an emergency, an administrator with physical access to a system can log in using \"secretadmin\" with the password \"pleasewutno\"\"",
+                    "DO: \"In an emergency, administrators with physical access can log in directly.\"",
+                    "DON'T: \"All backup MFA credentials are stored in a SuperSafe Series 9000 safe in the CEOs office.\"",
+                    "DO: \"All backup MFA credentials are stored in a UL Class 350 safe in a secure location with limited access.\"",
+                    "DON'T: \"During an incident, the incident response team lead by Jim Smith (555-0505) will open a channel at the conference line (555-0101 #97808 passcode 99731)...\"",
+                    "DO: \"During an incident, the incident response team will coordinate over secure channels.\""
+                  ]
+                }
+              ],
+              "terms": [
+                "Agency",
+                "Certification Data",
+                "Cloud Service Offering",
+                "Likely",
+                "Provider"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "CDS-CSO-HAD": {
+              "name": "Historical FedRAMP Certification Data",
+              "statement": "Providers MUST make historical versions of FedRAMP Certification Data available for three years to all necessary parties UNLESS otherwise specified by applicable FedRAMP rules; deltas between versions MAY be consolidated quarterly.",
+              "note": "Consolidating changes quarterly means that the historical status at the end of each quarter or at the time of the Ongoing Authorization Report or Quarterly Review is sufficient, instead of maintaining separate versions with every single change that took place throughout the quarter.",
+              "effective_date": {
+                "obtain": "2027-05-04",
+                "maintain": "2027-05-04",
+                "grace_by_assessment_months": 2
+              },
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "artifacts": {
+                "all": ["Explanation of how to access this information."]
+              },
+              "terms": [
+                "All Necessary Parties",
+                "Certification Data",
+                "Provider",
+                "Quarterly Review"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "CDS-CSO-PSM": {
+              "name": "Per-Service Certification Materials",
+              "varies_by_class": {
+                "a": {
+                  "statement": "Providers with Class A Certifications MAY supply per-service FedRAMP Certification materials.",
+                  "primary_key_word": "MAY",
+                  "artifacts": {
+                    "all": [
+                      "Explanation of the supplied materials, including how to access and use them."
+                    ]
+                  }
+                },
+                "b": {
+                  "statement": "Providers with Class B Certifications MAY supply per-service FedRAMP Certification materials.",
+                  "primary_key_word": "MAY",
+                  "artifacts": {
+                    "all": [
+                      "Explanation of the supplied materials, including how to access and use them."
+                    ]
+                  }
+                },
+                "c": {
+                  "statement": "Providers with Class C Certifications MAY supply per-service FedRAMP Certification materials.",
+                  "primary_key_word": "MAY",
+                  "artifacts": {
+                    "all": [
+                      "Explanation of the supplied materials, including how to access and use them."
+                    ]
+                  }
+                },
+                "d": {
+                  "statement": "Providers with Class D Certifications MUST supply per-service FedRAMP Certification materials.",
+                  "primary_key_word": "MUST",
+                  "effective_date": {
+                    "obtain": "2027-05-04",
+                    "maintain": "2027-05-04",
+                    "grace_by_assessment_months": 2
+                  },
+                  "artifacts": {
+                    "all": [
+                      "Explanation of the supplied materials, including how to access and use them."
+                    ]
+                  }
+                }
+              },
+              "notes": [
+                "Providers determine what they consider to be separate services, based on maximizing the customer experience for agencies who may only adopt some services and not others.",
+                "Providers are encouraged to provide a single comprehensive set of materials for all shared aspects of the service offering and only provide separate materials for unique aspects of each service to minimize the burden on providers and agencies."
+              ],
+              "affects": ["Providers"],
+              "terms": ["Agency", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "CDS-CSO-RPS": {
+              "name": "Responsible Public Sharing",
+              "statement": "Providers MAY responsibly share some or all of the information in a FedRAMP Certification Package publicly or with other parties if the provider determines doing so will NOT likely have an adverse effect on the cloud service offering.",
+              "primary_key_word": "MAY",
+              "affects": ["Providers"],
+              "artifacts": {
+                "all": [
+                  "Explanation of if and how this information is shared with other parties."
+                ]
+              },
+              "terms": [
+                "Certification Package",
+                "Cloud Service Offering",
+                "Likely",
+                "Provider",
+                "Responsibly"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "TRC": {
+            "CDS-TRC-USH": {
+              "name": "Uninterrupted Sharing",
+              "statement": "Trust centers MUST share FedRAMP Certification Data with all necessary parties without interruption.",
+              "note": "\"Without interruption\" means that parties should not have to request manual approval each time they need to access FedRAMP Certification Data or go through a complicated process. The preferred way of ensuring access without interruption is to use on-demand just-in-time access provisioning.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": [
+                "All Necessary Parties",
+                "Certification Data",
+                "Trust Center"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "CDS-TRC-PAC": {
+              "name": "Programmatic Access",
+              "statement": "Trust centers MUST provide documented programmatic access to all FedRAMP Certification Data, including programmatic access to human-readable materials.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "artifacts": {
+                "all": ["URL to the documentation for programmatic access."]
+              },
+              "terms": ["Certification Data", "Trust Center"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "CDS-TRC-AAI": {
+              "name": "Agency Access Inventory",
+              "statement": "Trust centers MUST maintain an inventory and history of federal agency users or systems with access to FedRAMP Certification Data and MUST make this information available to FedRAMP upon request.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "artifacts": {
+                "all": [
+                  "Explanation of how FedRAMP can obtain this information."
+                ]
+              },
+              "terms": ["Agency", "Certification Data", "Trust Center"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "CDS-TRC-ACL": {
+              "name": "Access Logging",
+              "statement": "Trust centers MUST log access to FedRAMP Certification Data and store summaries of access for at least six months; such information, as it pertains to specific parties, SHOULD be made available upon request by those parties.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "artifacts": {
+                "all": [
+                  "Explanation of how the appropriate parties can obtain this log information."
+                ]
+              },
+              "terms": ["Certification Data", "Trust Center"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "CDS-TRC-HMR": {
+              "name": "Human and Machine-Readable",
+              "statement": "Trust centers SHOULD make FedRAMP Certification Data available to view and download in both human-readable and machine-readable formats.",
+              "primary_key_word": "SHOULD",
+              "affects": ["Providers"],
+              "terms": [
+                "Certification Data",
+                "Machine-Readable",
+                "Trust Center"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "CDS-TRC-SSM": {
+              "name": "Self-Service Access Management",
+              "statement": "Trust centers SHOULD include features that encourage all necessary parties to provision and manage access to FedRAMP Certification Data for their users and services directly.",
+              "primary_key_word": "SHOULD",
+              "affects": ["Providers"],
+              "artifacts": {
+                "all": [
+                  "URL or explanation how to access documentation of these features and capabilities."
+                ]
+              },
+              "terms": [
+                "All Necessary Parties",
+                "Certification Data",
+                "Trust Center"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "UTC": {
+            "CDS-UTC-PGD": {
+              "name": "Public Guidance",
+              "statement": "Providers MUST publicly provide plain-language policies and guidance for all necessary parties that explains how they can obtain and manage access to FedRAMP Certification Data stored in the trust center.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "artifacts": {
+                "all": [
+                  "URL or explanation of the supplied materials, including how to access and use them."
+                ]
+              },
+              "terms": [
+                "All Necessary Parties",
+                "Certification Data",
+                "Provider",
+                "Trust Center"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "CDS-UTC-AAD": {
+              "name": "Agency Access Denial",
+              "statement": "Providers MUST notify FedRAMP by email to info@fedramp.gov within 5 business days of denying an agency access request for FedRAMP Certification Data.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "timeframe_type": "bizdays",
+              "timeframe_num": 5,
+              "notification": [
+                {
+                  "party": "FedRAMP",
+                  "method": "email",
+                  "target": "info@fedramp.gov"
+                }
+              ],
+              "terms": ["Agency", "Certification Data", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "CDS-UTC-AGA": {
+              "name": "Agency Access",
+              "statement": "Providers SHOULD share the FedRAMP Certification package with agencies upon request.",
+              "primary_key_word": "SHOULD",
+              "affects": ["Providers"],
+              "artifacts": {
+                "all": [
+                  "URL or explanation of how to request these materials.",
+                  "Explanation of how the provider decides whether or not to share these materials or other related policies."
+                ]
+              },
+              "terms": ["Agency", "Certification Package", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          }
+        },
+        "20x": {
+          "CSX": {}
+        },
+        "rev5": {
+          "CSF": {
+            "CDS-CSF-TCM": {
+              "name": "Trust Center Migration",
+              "statement": "Providers MUST notify all necessary parties when migrating to a trust center and MUST provide information in their existing USDA Connect Community Portal secure folders explaining how to use the trust center to obtain FedRAMP Certification Data.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "notification": [
+                {
+                  "party": "All Necessary Parties",
+                  "method": "update",
+                  "target": "FedRAMP Certification Data"
+                }
+              ],
+              "terms": [
+                "All Necessary Parties",
+                "Certification Data",
+                "Provider",
+                "Trust Center"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "CDS-CSF-SCD": {
+              "name": "Structured Certification Data",
+              "varies_by_class": {
+                "a": {
+                  "statement": "Providers with Class A Certifications MUST supply semi-structured text-based FedRAMP Certification Data.",
+                  "primary_key_word": "MUST",
+                  "effective_date": {
+                    "obtain": "2027-01-01",
+                    "maintain": "2027-05-04",
+                    "grace_by_assessment_months": 2
+                  }
+                },
+                "b": {
+                  "statement": "Providers with Class B Certifications MUST supply semi-structured text-based FedRAMP Certification Data.",
+                  "primary_key_word": "MUST",
+                  "effective_date": {
+                    "obtain": "2027-01-01",
+                    "maintain": "2027-05-04",
+                    "grace_by_assessment_months": 2
+                  }
+                },
+                "c": {
+                  "statement": "Providers with Class C Certifications MUST supply semi-structured text-based FedRAMP Certification Data.",
+                  "primary_key_word": "MUST",
+                  "effective_date": {
+                    "obtain": "2027-01-01",
+                    "maintain": "2027-05-04",
+                    "grace_by_assessment_months": 2
+                  }
+                },
+                "d": {
+                  "statement": "Providers with Class D Certifications MUST supply comprehensive machine-readable FedRAMP Certification Data.",
+                  "primary_key_word": "MUST",
+                  "effective_date": {
+                    "obtain": "2027-05-04",
+                    "maintain": "2027-05-04",
+                    "grace_by_assessment_months": 2
+                  }
+                }
+              },
+              "affects": ["Providers"],
+              "terms": ["Certification Data", "Machine-Readable", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "FRC": {
+      "info": {
+        "name": "FedRAMP Certification",
+        "short_name": "FRC",
+        "web_name": "fedramp-certification",
+        "purpose": "The FedRAMP Certification rules define how cloud service offerings obtain and maintain FedRAMP Certification across certification classes and paths. They give providers, assessors, agencies, and FedRAMP a common set of expectations for required rule sets, current evidence, independent verification and validation, and ongoing certification decisions.",
+        "status": "placeholder",
+        "subsets": {
+          "FRP": {
+            "name": "FedRAMP Responsibilities",
+            "description": "These rules apply to FedRAMP.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["FedRAMP"]
+            }
+          },
+          "CSO": {
+            "name": "General Provider Responsibilities",
+            "description": "These rules apply to cloud service providers obtaining and maintaining any FedRAMP Certification.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
+          },
+          "IAS": {
+            "name": "General Independent Assessor Responsibilities",
+            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Assessors"]
+            }
+          },
+          "CLA": {
+            "name": "FedRAMP Class A Certification Rules",
+            "description": "These rules apply to providers seeking FedRAMP Class A Certifications.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A"],
+              "affects": ["Providers"]
+            }
+          },
+          "APP": {
+            "name": "Applying for FedRAMP Certification",
+            "description": "These rules apply to cloud service providers who have met all other relevant rules and are ready to apply for any FedRAMP Certification.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
+          },
+          "APS": {
+            "name": "Applying for FedRAMP Certification with an Agency Sponsor",
+            "description": "These rules apply to cloud service providers with an Agency Sponsor who have met all other relevant rules and are ready to apply for any FedRAMP Certification.",
+            "applicability": {
+              "types": ["Rev5"],
+              "paths": ["Agency"],
+              "classes": ["B", "C", "D"],
+              "affects": ["Providers"]
+            }
+          }
+        },
+        "20x": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2026-07-04",
+              "maintain": "2027-05-04",
+              "grace_ends": "2027-05-04"
+            }
+          },
+          "subsets": {
+            "CSX": {
+              "name": "20x-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
+            },
+            "IAX": {
+              "name": "20x-Specific Independent Assessor Responsibilities",
+              "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Assessors"]
+              }
+            }
+          }
+        },
+        "rev5": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2027-01-01",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-01-01"
+            }
+          },
+          "subsets": {
+            "CSF": {
+              "name": "Rev5-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
+            },
+            "IAF": {
+              "name": "Rev5-Specific Independent Assessor Responsibilities",
+              "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Assessors"]
+              }
+            }
+          }
+        }
+      },
+      "data": {
+        "all": {
+          "FRP": {
+            "FRC-FRP-MCM": {
+              "name": "Minimum Continuous Monitoring",
+              "statement": "FedRAMP MUST perform a minimum level of continuous monitoring for cloud service offerings with FedRAMP Program Certification, including at least reviewing Ongoing Certification Reports.",
+              "primary_key_word": "MUST",
+              "affects": ["FedRAMP"],
+              "terms": ["Cloud Service Offering", "Ongoing Certification"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-FRP-ECR": {
+              "name": "Exemptions from Certification Rules",
+              "statement": "FedRAMP MAY approve exemptions from some FedRAMP Certification rules in rare circumstances by supplying an explicit waiver, based on a prioritization and risk assessment completed by FedRAMP.",
+              "notes": [
+                "FedRAMP will determine when such exemptions are appropriate.",
+                "Exemptions will typically be part of a public prioritization process and criteria will be published publicly.",
+                "Do not ask FedRAMP for an exemption unless the publicly published criteria is met."
+              ],
+              "primary_key_word": "MAY",
+              "affects": ["FedRAMP"],
+              "terms": [],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "CSO": {
+            "FRC-CSO-CDS": {
+              "name": "FedRAMP Certification Data Sharing",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Certification Data Sharing (CDS) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "FedRAMP Certification Data Sharing",
+              "reference_url_web_name": "certification-data-sharing",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "controls": [
+                "ac-3",
+                "ac-4",
+                "au-2",
+                "au-3",
+                "au-6",
+                "ca-2",
+                "ir-4",
+                "ra-5",
+                "sc-8"
+              ],
+              "terms": ["Certification Data", "Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-CSO-CCM": {
+              "name": "Collaborative Continuous Monitoring",
+              "statement": "Providers MUST follow and persistently address the Collaborative Continuous Monitoring (CCM) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Collaborative Continuous Monitoring",
+              "reference_url_web_name": "collaborative-continuous-monitoring",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-CSO-FSI": {
+              "name": "FedRAMP Security Inbox",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Security Inbox (FSI) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "FedRAMP Security Inbox",
+              "reference_url_web_name": "fedramp-security-inbox",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": ["FedRAMP Security Inbox", "Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-CSO-ICP": {
+              "name": "Incident Communications Procedures",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Incident Communications Procedures (ICP) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Incident Communications Procedures",
+              "reference_url_web_name": "incident-communications-procedures",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Incident", "Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-CSO-MAS": {
+              "name": "Minimum Assessment Scope",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Minimum Assessment Scope (MAS) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Minimum Assessment Scope",
+              "reference_url_web_name": "minimum-assessment-scope",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "controls": [
+                "ac-1",
+                "ac-21",
+                "at-1",
+                "au-1",
+                "ca-1",
+                "cm-1",
+                "cp-1",
+                "cp-2.1",
+                "cp-2.8",
+                "cp-4.1",
+                "ia-1",
+                "ir-1",
+                "ma-1",
+                "mp-1",
+                "pe-1",
+                "pl-1",
+                "pl-2",
+                "pl-4",
+                "pl-4.1",
+                "ps-1",
+                "ra-1",
+                "ra-9",
+                "sa-1",
+                "sc-1",
+                "si-1",
+                "sr-1",
+                "sr-2",
+                "sr-3",
+                "sr-11"
+              ],
+              "terms": ["Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-CSO-SCG": {
+              "name": "Secure Configuration Guide",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Secure Configuration Guide (SCG) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Secure Configuration Guide",
+              "reference_url_web_name": "secure-configuration-guide",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-CSO-SCN": {
+              "name": "Significant Change Notifications",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Significant Change Notifications (SCN) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Significant Change Notifications",
+              "reference_url_web_name": "significant-change-notifications",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "controls": [
+                "ca-7.4",
+                "cm-3.4",
+                "cm-4",
+                "cm-7.1",
+                "au-5",
+                "ca-5",
+                "ca-7",
+                "ra-5",
+                "ra-5.2",
+                "sa-22",
+                "si-2",
+                "si-2.2",
+                "si-3",
+                "si-5",
+                "si-7.7",
+                "si-10",
+                "si-11"
+              ],
+              "terms": ["Persistently", "Provider", "Significant Change"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-CSO-UCM": {
+              "name": "Using Cryptographic Modules",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Using Cryptographic Modules (UCM) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Using Cryptographic Modules",
+              "reference_url_web_name": "using-cryptographic-modules",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-CSO-VDR": {
+              "name": "Vulnerability Detection and Response",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Vulnerability Detection and Response (VDR) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Vulnerability Detection and Response",
+              "reference_url_web_name": "vulnerability-detection-and-response",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "controls": [
+                "ca-2",
+                "ca-7",
+                "ca-7.6",
+                "ir-1",
+                "ir-4",
+                "ir-4.1",
+                "ir-5",
+                "ir-5.1",
+                "ir-6",
+                "ir-6.1",
+                "ir-6.2",
+                "pm-3",
+                "pm-5",
+                "pm-31",
+                "ra-2",
+                "ra-2.1",
+                "ra-3",
+                "ra-3.3",
+                "ra-5",
+                "ra-5.2",
+                "ra-5.3",
+                "ra-5.4",
+                "ra-5.5",
+                "ra-5.6",
+                "ra-5.7",
+                "ra-5.11",
+                "ra-9",
+                "ra-10",
+                "si-2",
+                "si-2.1",
+                "si-2.2",
+                "si-2.4",
+                "si-2.5",
+                "si-3",
+                "si-3.1",
+                "si-3.2",
+                "si-4",
+                "si-4.2",
+                "si-4.3",
+                "si-4.7",
+                "ca-7.4",
+                "ra-7"
+              ],
+              "terms": [
+                "Persistently",
+                "Provider",
+                "Vulnerability",
+                "Vulnerability Detection",
+                "Vulnerability Response"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-CSO-IVV": {
+              "name": "Independent Verification and Validation",
+              "varies_by_class": {
+                "a": {
+                  "statement": "Providers with Class A Certifications MAY persistently complete an independent verification and validation assessment at least once per year; these assessments MAY be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MAY be included in their FedRAMP Certification Data without inappropriate modification.",
+                  "primary_key_word": "MAY",
+                  "timeframe_type": "years",
+                  "timeframe_num": 1
+                },
+                "b": {
+                  "statement": "Providers with Class B Certifications MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
+                  "primary_key_word": "MUST",
+                  "timeframe_type": "years",
+                  "timeframe_num": 1
+                },
+                "c": {
+                  "statement": "Providers with Class C Certifications MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
+                  "primary_key_word": "MUST",
+                  "timeframe_type": "years",
+                  "timeframe_num": 1
+                },
+                "d": {
+                  "statement": "Providers with Class D Certifications MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
+                  "primary_key_word": "MUST",
+                  "timeframe_type": "years",
+                  "timeframe_num": 1
+                }
+              },
+              "notes": [
+                "The first such completed assessment is typically called an \"initial assessment\" while following assessments are called \"annual assessments.\"",
+                "The specific requirements for independent verification and validation assessments are documented by the FedRAMP Certification Class and Type.",
+                "The option for assessment by FedRAMP directly is limited to cloud services that are explicitly prioritized by FedRAMP, in consultation with the FedRAMP Board and the federal Chief Information Officers Council.",
+                "FedRAMP Recognized independent assessors are listed on the FedRAMP Marketplace."
+              ],
+              "affects": ["Providers"],
+              "terms": [
+                "Assessor",
+                "Certification Data",
+                "FedRAMP Recognized",
+                "Persistently",
+                "Provider",
+                "Validation",
+                "Verification"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-CSO-POP": {
+              "name": "Pick One Program Certification Type",
+              "statement": "Providers MUST NOT seek both FedRAMP Rev5 Program Certification and FedRAMP 20x Program Certification for the same cloud service offering; pick one type.",
+              "note": "This rule does not prevent a provider from seeking and maintaining a FedRAMP Rev5 Agency Certification and a FedRAMP 20x Program Certification for the same cloud service offering, however, doing so is strongly discouraged due to the increased complexity and risk of confusion for all parties.",
+              "primary_key_word": "MUST NOT",
+              "affects": ["Providers"],
+              "terms": ["Agency", "Cloud Service Offering", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-CSO-STE": {
+              "name": "Supply Technical Evidence",
+              "statement": "Providers SHOULD supply all necessary accessors with technical explanations, demonstrations, and other relevant supporting information about the technical capabilities they employ to address FedRAMP rules; this SHOULD be supplied as necessary to ensure the assessor can effectively complete verification and validation.",
+              "primary_key_word": "SHOULD",
+              "affects": ["Providers"],
+              "terms": ["Assessor", "Provider", "Validation", "Verification"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-CSO-RAA": {
+              "name": "Receiving Assessor Advice",
+              "statement": "Providers MAY ask for and accept advice from their assessor during assessment regarding techniques and procedures that will improve their security posture or the effectiveness, clarity, and accuracy of their verification, validation and reporting procedures, UNLESS doing so is likely to compromise the objectivity and integrity of the assessment.",
+              "primary_key_word": "MAY",
+              "affects": ["Providers"],
+              "terms": [
+                "Assessor",
+                "Likely",
+                "Provider",
+                "Validation",
+                "Verification"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "IAS": {
+            "FRC-IAS-VVP": {
+              "name": "Verify and Validate Processes",
+              "statement": "Assessors MUST verify and validate the implementation of processes derived from FedRAMP requirements, including rules, controls and Key Security Indicators, to determine whether or not the provider has accurately documented their process and security goals for the cloud service offering.",
+              "primary_key_word": "MUST",
+              "affects": ["Assessors"],
+              "terms": [
+                "Assessor",
+                "Cloud Service Offering",
+                "Provider",
+                "Validation",
+                "Verification"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-IAS-OUC": {
+              "name": "Outcome Consistency",
+              "statement": "Assessors MUST verify and validate whether or not the underlying processes are consistently creating the desired security outcome documented by the provider.",
+              "primary_key_word": "MUST",
+              "affects": ["Assessors"],
+              "terms": ["Assessor", "Provider", "Validation", "Verification"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-IAS-PAD": {
+              "name": "Procedure Adherence",
+              "statement": "Assessors MUST assess whether or not procedures are consistently followed, including evaluating the processes in place to ensure this occurs, without relying solely on the existence of procedure documents.",
+              "note": "This includes evaluating tests or plans for activities that may occur in the future but have not yet occurred.",
+              "primary_key_word": "MUST",
+              "affects": ["Assessors"],
+              "terms": ["Assessor"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-IAS-MME": {
+              "name": "Mixed Methods Evaluation",
+              "statement": "Assessors MUST perform verification and validation using a combination of quantitative and expert qualitative assessment as appropriate AND document which is applied to which aspect of the assessment.",
+              "primary_key_word": "MUST",
+              "affects": ["Assessors"],
+              "terms": ["Assessor", "Validation", "Verification"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-IAS-SUM": {
+              "name": "Assessment Summary",
+              "statement": "Assessors MUST deliver a high-level summary of their assessment process and findings for each FedRAMP requirement, including rules, controls, and Key Security Indicators; this summary will be included in the FedRAMP Certification Data for the cloud service offering.",
+              "primary_key_word": "MUST",
+              "affects": ["Assessors"],
+              "terms": [
+                "Assessor",
+                "Certification Data",
+                "Cloud Service Offering"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-IAS-OSA": {
+              "name": "Overall Summary of Assessment",
+              "statement": "Assessors MUST supply an overall summary of the verification and validation assessment results, including any resulting failures or areas of dispute, to the provider and all necessary assessors.",
+              "note": "FedRAMP will make the final FedRAMP Certification decision based on the assessor's findings and other relevant information.",
+              "primary_key_word": "MUST",
+              "affects": ["Assessors"],
+              "terms": [
+                "All Necessary Assessors",
+                "Assessor",
+                "Provider",
+                "Validation",
+                "Verification"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-IAS-EPX": {
+              "name": "Engage Provider Experts",
+              "statement": "Assessors SHOULD engage provider experts in discussion to understand the decisions made by the provider and inform expert qualitative assessment, and SHOULD perform independent research to test such information as part of the expert qualitative assessment process.",
+              "primary_key_word": "SHOULD",
+              "affects": ["Assessors"],
+              "terms": ["Assessor", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-IAS-SHA": {
+              "name": "Sharing Advice",
+              "statement": "Assessors MAY share advice with providers they are assessing about techniques and procedures that will improve the provider's security posture or the effectiveness, clarity, and accuracy of their verification, validation and reporting procedures, UNLESS doing so is likely to compromise the objectivity and integrity of the assessment.",
+              "primary_key_word": "MAY",
+              "affects": ["Assessors"],
+              "terms": [
+                "Assessor",
+                "Likely",
+                "Provider",
+                "Validation",
+                "Verification"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "CLA": {
+            "FRC-CLA-ASF": {
+              "name": "Approved Alternative Security Frameworks",
+              "statement": "Providers seeking a FedRAMP Class A Certification MUST have completed a certification or equivalent process, including an independent assessment, from one of the following alternative security frameworks:",
+              "following_information": [
+                "FedRAMP Ready",
+                "SOC 2 Type II",
+                "GovRAMP"
+              ],
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-CLA-EAM": {
+              "name": "External Assessment Materials",
+              "statement": "Providers seeking a FedRAMP Class A Certification MUST supply the full materials from the alternative security assessment to all necessary parties as part of the FedRAMP Certification Package.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": [
+                "All Necessary Parties",
+                "Certification Package",
+                "Provider"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-CLA-AFR": {
+              "name": "Address FedRAMP Rules",
+              "statement": "Providers seeking a Class A FedRAMP Certification MUST address the following FedRAMP rules and supply the appropriate artifacts or information mapping in the FedRAMP Certification Package:",
+              "following_information": [
+                "FedRAMP Certification: FRC-CSO-POP (Pick One Program Certification Type)",
+                "Minimum Assessment Scope: MAS-CSO-IIR (Identify Information Resources)",
+                "Certification Data Sharing: CDS-CSO-PUB (Public Information)",
+                "Certification Data Sharing: CDS-CSO-UTC (Use Trust Centers)",
+                "Certification Data Sharing: CDS-UTC-PGD (Public Guidance)",
+                "Certification Data Sharing: CDS-UTC-AAD (Agency Access Denial)",
+                "FedRAMP Security Inbox: FSI-CSO-INB (Maintain a FedRAMP Security Inbox)",
+                "FedRAMP Security Inbox: FSI-CSO-RCV (Receive Email Without Disruption)",
+                "FedRAMP Security Inbox: FSI-CSO-CRA (Complete Required Actions)",
+                "Incident Communications Procedures: ICP-CSO-EFR (Evaluate FedRAMP Reportability)",
+                "Vulnerability Detection and Response: VDR-CSO-DET (Vulnerability Detection)",
+                "Continuous Collaborative Monitoring: CCM-OCR-AVL (Report Availability)",
+                "Continuous Collaborative Monitoring: CCM-OCR-NRD (Next Report Date)"
+              ],
+              "note": "If the alternative security framework has existing rules that align with these FedRAMP rules then a mapping to the alternative security framework content may be supplied instead of generating new artifacts.",
+              "related": [
+                "FRC-CSO-POP",
+                "MAS-CSO-IIR",
+                "CDS-CSO-PUB",
+                "CDS-CSO-UTC",
+                "CDS-UTC-PGD",
+                "CDS-UTC-AAD",
+                "FSI-CSO-INB",
+                "FSI-CSO-RCV",
+                "FSI-CSO-CRA",
+                "ICP-CSO-EFR",
+                "VDR-CSO-DET",
+                "CCM-OCR-AVL",
+                "CCM-OCR-NRD"
+              ],
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": [
+                "Agency",
+                "Artifacts",
+                "Certification Data",
+                "Certification Package",
+                "FedRAMP Security Inbox",
+                "Incident",
+                "Information Resource",
+                "Initial Incident Report (IIR)",
+                "Ongoing Certification Report (OCR)",
+                "Provider",
+                "Trust Center",
+                "Vulnerability",
+                "Vulnerability Detection",
+                "Vulnerability Response"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-CLA-IVV": {
+              "name": "Optional Independent Verification and Validation",
+              "statement": "Providers seeking a FedRAMP Class A Certification MAY have the FedRAMP Certification Package independently verified and validated by a FedRAMP Recognized assessor before submission to FedRAMP.",
+              "primary_key_word": "MAY",
+              "affects": ["Providers"],
+              "terms": [
+                "Assessor",
+                "Certification Package",
+                "FedRAMP Recognized",
+                "Provider",
+                "Validation",
+                "Verification"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "APP": {
+            "FRC-APP-MLF": {
+              "name": "Marketplace Listing First",
+              "statement": "Providers MUST be listed in the FedRAMP Marketplace before applying for FedRAMP Certification.",
+              "note": "See FedRAMP's Marketplace Listing rules for information about being listed in the Marketplace in the Preparation Phase prior to receiving a formal FedRAMP Certification.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-APP-AFC": {
+              "name": "Applying for FedRAMP Certification",
+              "statement": "Providers MUST complete the FedRAMP Certification Application Form at https://fedramp.gov/forms/provider-listing-request/ in full to request an initial assessment by FedRAMP.",
+              "reference": "FedRAMP Certification Application Form",
+              "reference_url": "https://fedramp.gov/forms",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-APP-FCP": {
+              "name": "Fresh FedRAMP Certification Package",
+              "statement": "Providers MUST supply a fresh initial FedRAMP Certification Package that shows the current status of the cloud service offering as verified and validated by the provider within the previous 7 days.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": [
+                "Certification Package",
+                "Cloud Service Offering",
+                "Provider",
+                "Validation",
+                "Verification"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-APP-FIA": {
+              "name": "Fresh Independent Assessment",
+              "statement": "Providers MUST supply a fresh initial independent verification and validation assessment that was completed by a FedRAMP Recognized Independent Assessment Service within the previous 3 months.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": [
+                "FedRAMP Recognized",
+                "Provider",
+                "Validation",
+                "Verification"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "APS": {
+            "FRC-APS-ATO": {
+              "name": "Agency Authorization to Operate",
+              "statement": "Providers seeking a FedRAMP Rev5 Agency Certification MUST have completed the Authorization to Operate (ATO) process with their agency sponsor for the cloud service offering, concluding with a formal signed ATO letter that the agency has sent over official government channels to FedRAMP.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Agency", "Cloud Service Offering", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          }
+        },
+        "20x": {
+          "CSX": {
+            "FRC-CSX-SUM": {
+              "name": "Implementation Summaries",
+              "statement": "Providers MUST maintain simple high-level summaries of at least the following for each Key Security Indicator:",
+              "following_information": [
+                "Goals for how it will be implemented and validated, including clear pass/fail criteria and traceability",
+                "The consolidated _information resources_ that will be validated (this should include consolidated summaries such as \"all employees with privileged access that are members of the Admin group\")",
+                "The machine-based processes for _validation_ and the _persistent_ cycle on which they will be performed (or an explanation of why this doesn't apply)",
+                "The non-machine-based processes for _validation_ and the _persistent_ cycle on which they will be performed (or an explanation of why this doesn't apply)",
+                "Current implementation status",
+                "Any clarifications or responses to the assessment summary"
+              ],
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": [
+                "Machine-Based (Information Resources)",
+                "Provider",
+                "Validation"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-CSX-MAS": {
+              "name": "Application within MAS",
+              "statement": "Providers SHOULD apply ALL Key Security Indicators to ALL aspects of their cloud service offering that are within the FedRAMP Minimum Assessment Scope.",
+              "primary_key_word": "SHOULD",
+              "affects": ["Providers"],
+              "terms": ["Cloud Service Offering", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "IAX": {
+            "FRC-IAX-UNP": {
+              "name": "Underlying Processes",
+              "statement": "Assessors MUST verify and validate the underlying processes (both machine-based and non-machine-based) that providers use to validate Key Security Indicators; this should include at least:",
+              "following_information": [
+                "The effectiveness, completeness, and integrity of the automated processes that perform validation of the cloud service offering's security posture.",
+                "The effectiveness, completeness, and integrity of the human processes that perform validation of the cloud service offering's security posture",
+                "The coverage of these processes within the cloud service offering, including if all of the consolidated information resources listed are being validated."
+              ],
+              "primary_key_word": "MUST",
+              "affects": ["Assessors"],
+              "terms": [
+                "Assessor",
+                "Cloud Service Offering",
+                "Information Resource",
+                "Machine-Based (Information Resources)",
+                "Provider",
+                "Validation",
+                "Verification"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-IAX-STE": {
+              "name": "Static Evidence",
+              "statement": "Assessors MUST NOT rely on screenshots, configuration dumps, or other static output as evidence EXCEPT when evaluating the accuracy and reliability of a process that generates such artifacts.",
+              "primary_key_word": "MUST NOT",
+              "affects": ["Assessors"],
+              "terms": ["Artifacts", "Assessor"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "CLA": {
+            "FRC-CLA-KSM": {
+              "name": "Key Security Indicator Mapping",
+              "statement": "Providers seeking a FedRAMP 20x Certification Class A by leveraging an alternative security framework MUST supply a temporary mapping from the alternative security assessment to the following FedRAMP Key Security Indicators:",
+              "following_information": [
+                "KSI-CMT-LMC",
+                "KSI-CNA-RNT",
+                "KSI-CED-RAT",
+                "KSI-IAM-AAM",
+                "KSI-INR-RIR",
+                "KSI-SVC-SNT"
+              ],
+              "notes": [
+                "The mapping must be available in both machine-readable and human-readable formats.",
+                "If a mapping is not clear, the provider should supply new information indicating that the Key Security Indicator has not been independently audited."
+              ],
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Machine-Readable", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          }
+        },
+        "rev5": {
+          "CSF": {
+            "FRC-CSF-CDE": {
+              "name": "Class D Program Certification Exclusion",
+              "statement": "Providers seeking a FedRAMP Rev5 Class D Certification MUST use the FedRAMP Agency Certification path.",
+              "note": "FedRAMP will not perform FedRAMP Rev5 Class D Program Certifications.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Agency", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-CSF-RDY": {
+              "name": "FedRAMP Ready Conversion",
+              "statement": "Providers with FedRAMP Rev5 Ready status MUST convert to a FedRAMP Certification before the furthest date of the expiration of their most recently yearly assessment or November 17, 2026; the legacy FedRAMP Ready status will be entirely removed on December 31, 2027.",
+              "note": "Cloud services that do not wish to convert or do not meet conversion criteria will be renamed Legacy FedRAMP Ready and otherwise retired from FedRAMP Ready.",
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "CLA": {
+            "FRC-CLA-CAC": {
+              "name": "Rev5 Class A Certification",
+              "statement": "Providers seeking a FedRAMP Rev5 Class A Certification by leveraging an alternative security framework that is based on the SP 800-53 Revision 5 MUST supply all Security Decision Record materials required for FedRAMP Rev5 Class B Certification.",
+              "notes": [
+                "The only approved alternative security frameworks based on the SP 800-53 Revision 5 are FedRAMP Ready and GovRAMP.",
+                "An independent assessment is not required for FedRAMP Rev5 Class A Certification."
+              ],
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
     "FSI": {
       "info": {
         "name": "FedRAMP Security Inbox",
@@ -2484,6 +3866,212 @@
             }
           }
         }
+      }
+    },
+    "IAP": {
+      "info": {
+        "name": "Independent Assessment Plan",
+        "short_name": "IAP",
+        "web_name": "independent-assessment-plan",
+        "purpose": "The Independent Assessment Plan rules explain how independent assessment services should approach the verification, validation, and attestation of a cloud service provider's own Security Decision Record on behalf of FedRAMP.",
+        "status": "empty",
+        "subsets": {
+          "CSO": {
+            "name": "General Provider Responsibilities",
+            "description": "These rules apply to providers for FedRAMP Certifications of any type.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
+          },
+          "IAS": {
+            "name": "General Independent Assessor Responsibilities",
+            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["B", "C", "D"],
+              "affects": ["Assessors"]
+            }
+          }
+        },
+        "20x": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2026-07-04",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-05-04"
+            }
+          },
+          "subsets": {
+            "CSX": {
+              "name": "20x-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
+            },
+            "IAX": {
+              "name": "20x-Specific Independent Assessor Responsibilities",
+              "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["B", "C", "D"],
+                "affects": ["Assessors"]
+              }
+            }
+          }
+        },
+        "rev5": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2027-01-01",
+              "maintain": "2027-08-01",
+              "grace_ends": "2028-02-01"
+            },
+            "signup_url": "ADDME"
+          },
+          "subsets": {
+            "CSF": {
+              "name": "Rev5-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
+            },
+            "IAF": {
+              "name": "Rev5-Specific Independent Assessor Responsibilities",
+              "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Assessors"]
+              }
+            }
+          }
+        }
+      },
+      "data": {
+        "all": {},
+        "20x": {},
+        "rev5": {}
+      }
+    },
+    "IAR": {
+      "info": {
+        "name": "Independent Assessment Report",
+        "short_name": "IAR",
+        "web_name": "independent-assessment-report",
+        "purpose": "The Independent Assessment Report rules explain the minimum expectations for independent assessor attestations after the completion of an independent assessment for FedRAMP Certification.",
+        "status": "empty",
+        "subsets": {
+          "CSO": {
+            "name": "General Provider Responsibilities",
+            "description": "These rules apply to providers for FedRAMP Certifications of any type.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
+          },
+          "IAS": {
+            "name": "General Independent Assessor Responsibilities",
+            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["B", "C", "D"],
+              "affects": ["Assessors"]
+            }
+          }
+        },
+        "20x": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2026-07-04",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-05-04"
+            }
+          },
+          "subsets": {
+            "CSX": {
+              "name": "20x-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
+            },
+            "IAX": {
+              "name": "20x-Specific Independent Assessor Responsibilities",
+              "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["B", "C", "D"],
+                "affects": ["Assessors"]
+              }
+            }
+          }
+        },
+        "rev5": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2027-01-01",
+              "maintain": "2027-08-01",
+              "grace_ends": "2028-02-01"
+            },
+            "signup_url": "ADDME"
+          },
+          "subsets": {
+            "CSF": {
+              "name": "Rev5-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
+            },
+            "IAF": {
+              "name": "Rev5-Specific Independent Assessor Responsibilities",
+              "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["B", "C", "D"],
+                "affects": ["Assessors"]
+              }
+            }
+          }
+        }
+      },
+      "data": {
+        "all": {},
+        "20x": {},
+        "rev5": {}
       }
     },
     "ICP": {
@@ -3652,21 +5240,6 @@
                 }
               ]
             },
-            "MKT-FRP-SOF": {
-              "name": "Scope of FedRAMP",
-              "statement": "FedRAMP MUST NOT list cloud service offerings in the Marketplace or perform any FedRAMP Certification activities unless it determines the cloud service offering is within the scope of FedRAMP.",
-              "reference": "Scope of FedRAMP",
-              "reference_url": "https://fedramp.gov/docs/authority/scope",
-              "primary_key_word": "MUST NOT",
-              "affects": ["FedRAMP"],
-              "terms": ["Cloud Service Offering"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
             "MKT-FRP-MJS": {
               "name": "Marketplace JSON Schemas",
               "statement": "FedRAMP MUST publish and maintain JSON schemas for required machine-readable Marketplace web information supplied by advisors and assessors.",
@@ -3675,6 +5248,21 @@
               "primary_key_word": "MUST",
               "affects": ["FedRAMP"],
               "terms": ["Advisor", "Assessor", "Machine-Readable"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "MKT-FRP-SOF": {
+              "name": "Scope of FedRAMP",
+              "statement": "FedRAMP MUST NOT list cloud service offerings in the Marketplace or perform any FedRAMP Certification activities unless it determines the cloud service offering is within the scope of FedRAMP.",
+              "reference": "Scope of FedRAMP",
+              "reference_url": "https://fedramp.gov/docs/authority/scope",
+              "primary_key_word": "MUST NOT",
+              "affects": ["FedRAMP"],
+              "terms": ["Cloud Service Offering"],
               "updated": [
                 {
                   "date": "2026-05-04",
@@ -3865,6 +5453,335 @@
               "primary_key_word": "MUST",
               "affects": ["Providers"],
               "terms": ["Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "REC": {
+      "info": {
+        "name": "FedRAMP Recognition of Independent Assessment Services",
+        "short_name": "REC",
+        "web_name": "fedramp-recognition",
+        "purpose": "The FedRAMP Recognition of Independent Assessment Services rules explain the requirements for assessors to obtain and maintain FedRAMP Recognition in order to support the FedRAMP Certification process.",
+        "status": "placeholder",
+        "effective": {
+          "is": "required",
+          "current_status": "Consolidated Rules for 2026",
+          "date": {
+            "obtain": "2026-07-04",
+            "maintain": "2026-07-04",
+            "grace_ends": "2026-07-04"
+          }
+        },
+        "subsets": {
+          "FRP": {
+            "name": "FedRAMP Responsibilities",
+            "description": "These rules apply to FedRAMP when evaluating independent assessment services for initial or ongoing FedRAMP Recognition.",
+            "applicability": {
+              "types": [],
+              "paths": [],
+              "classes": [],
+              "affects": ["FedRAMP"]
+            }
+          },
+          "IAS": {
+            "name": "General Independent Assessor Responsibilities",
+            "description": "These rules apply to independent assessment services seeking to obtain or maintain FedRAMP Recognition.",
+            "applicability": {
+              "types": [],
+              "paths": [],
+              "classes": [],
+              "affects": ["Assessors"]
+            }
+          }
+        }
+      },
+      "data": {
+        "all": {
+          "FRP": {
+            "REC-FRP-FOC": {
+              "name": "Foreign Ownership Collection",
+              "statement": "FedRAMP MUST maintain a process to collect foreign ownership, control, or influence declarations from FedRAMP Recognized assessors and updates to those declarations.",
+              "primary_key_word": "MUST",
+              "affects": ["FedRAMP"],
+              "terms": ["Assessor", "FedRAMP Recognized"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "REC-FRP-RAO": {
+              "name": "Recognized Assessors Only",
+              "statement": "FedRAMP MUST NOT accept verification, validation, or other attestations from independent assessors who are not FedRAMP Recognized.",
+              "primary_key_word": "MUST NOT",
+              "affects": ["FedRAMP"],
+              "terms": [
+                "Assessor",
+                "FedRAMP Recognized",
+                "Validation",
+                "Verification"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "REC-FRP-DRD": {
+              "name": "Double Revocation Disqualification",
+              "statement": "FedRAMP MUST NOT restore FedRAMP Recognition for an assessor after FedRAMP has revoked that assessor's FedRAMP Recognition 2 times.",
+              "primary_key_word": "MUST NOT",
+              "affects": ["FedRAMP"],
+              "terms": ["Assessor", "FedRAMP Recognized"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "IAS": {
+            "REC-IAS-ACC": {
+              "name": "A2LA Accreditation",
+              "statement": "Assessors MUST obtain and maintain accreditation through the American Association for Laboratory Accreditation (A2LA) Cybersecurity Inspection Body Program to qualify for FedRAMP Recognition.",
+              "note": "FedRAMP will remove FedRAMP Recognition immediately after the American Association for Laboratory Accreditation notifies FedRAMP that an assessor's accreditation has lapsed.",
+              "primary_key_word": "MUST",
+              "affects": ["Assessors"],
+              "terms": ["Assessor", "FedRAMP Recognized"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "REC-IAS-ADA": {
+              "name": "Actually Do Assessments",
+              "statement": "Assessors MUST complete at least 2 initial or ongoing assessments for Class B, C, or D FedRAMP Certifications every 2 years to maintain FedRAMP Recognition.",
+              "note": "For a newly FedRAMP Recognized Assessor, this rule applies beginning on the initial date of FedRAMP Recognition if that date is later than 2026-06-01.",
+              "effective_date": {
+                "obtain": "2026-06-01",
+                "maintain": "2026-06-01",
+                "grace_ends": "2026-06-01"
+              },
+              "corrective_actions": [
+                "FedRAMP will notify assessors when they are within 6 months of losing FedRAMP Recognition under this rule and request a corrective action plan.",
+                "Assessors whose corrective action plan is not accepted will lose FedRAMP Recognition and must supply an alternative corrective action plan to move toward renewed FedRAMP Recognition."
+              ],
+              "primary_key_word": "MUST",
+              "affects": ["Assessors"],
+              "timeframe_type": "years",
+              "timeframe_num": 2,
+              "terms": ["Assessor", "FedRAMP Recognized"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "REC-IAS-PSC": {
+              "name": "Policy and Standards Compliance",
+              "statement": "Assessors MUST maintain compliance with the latest American Association for Laboratory Accreditation (A2LA) R311 - Specific Requirements - Federal Risk and Authorization Management Program to maintain FedRAMP Recognition.",
+              "reference": "A2LA Public Documents",
+              "reference_url": "https://portal.a2la.org/documents/",
+              "primary_key_word": "MUST",
+              "affects": ["Assessors"],
+              "terms": ["Assessor", "FedRAMP Recognized"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "REC-IAS-ANR": {
+              "name": "Annual Surveillance Assessment",
+              "statement": "Assessors MUST achieve a favorable annual surveillance assessment by the American Association for Laboratory Accreditation (A2LA) to maintain FedRAMP Recognition.",
+              "corrective_actions": [
+                "Assessors have 75 days to complete corrective actions for nonconformances identified by the American Association for Laboratory Accreditation (A2LA)during a surveillance assessment. If an assessor exceeds the 75 day resolution timeframe, A2LA will supply FedRAMP with a narrative of the assessor's current status, the assessor will be designated as in Remediation in the FedRAMP Marketplace, and the assessor must supply a corrective action plan to FedRAMP."
+              ],
+              "primary_key_word": "MUST",
+              "affects": ["Assessors"],
+              "timeframe_type": "years",
+              "timeframe_num": 1,
+              "terms": ["Assessor", "FedRAMP Recognized"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "REC-IAS-RAS": {
+              "name": "Full A2LA Reassessment",
+              "statement": "Assessors MUST achieve a favorable full reassessment by the American Association for Laboratory Accreditation (A2LA) at least once every 2 years to maintain FedRAMP Recognition.",
+              "corrective_actions": [
+                "Assessors have 75 days to complete corrective actions for nonconformances identified by the American Association for Laboratory Accreditation during a reassessment. If an assessor exceeds the 75 day resolution timeframe, the American Association for Laboratory Accreditation will supply FedRAMP with a narrative of the assessor's current status, the assessor will be designated as In Remediation in the FedRAMP Marketplace, and the assessor must supply a corrective action plan to FedRAMP."
+              ],
+              "primary_key_word": "MUST",
+              "affects": ["Assessors"],
+              "timeframe_type": "years",
+              "timeframe_num": 2,
+              "terms": ["Assessor", "FedRAMP Recognized"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "REC-IAS-RAR": {
+              "name": "Re-entry after Revocation",
+              "statement": "Assessors MUST satisfy all American Association for Laboratory Accreditation (A2LA) re-entry conditions before regaining FedRAMP Recognition after revocation.",
+              "note": "A revocation may require extended time in revoked status while the assessor demonstrates acceptable performance in the A2LA Cybersecurity Inspection Body Program before seeking FedRAMP Recognition again.",
+              "primary_key_word": "MUST",
+              "affects": ["Assessors"],
+              "terms": ["Assessor", "FedRAMP Recognized"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "REC-IAS-RQU": {
+              "name": "Roles and Qualifications",
+              "statement": "Assessors MUST staff FedRAMP assessments with all roles required by the American Association for Laboratory Accreditation (A2LA) R311, including personnel who meet the qualifications for each role, unless FedRAMP publishes a specific exception for a limited pilot or other explicitly scoped process.",
+              "corrective_actions": [
+                "FedRAMP may require a consultation meeting, corrective action plan, or revocation for failure to comply."
+              ],
+              "primary_key_word": "MUST",
+              "affects": ["Assessors"],
+              "terms": ["Assessor"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "REC-IAS-AFI": {
+              "name": "Annual Foreign Interest Reports",
+              "statement": "Assessors MUST report information relating to any foreign interest, foreign influence, or foreign control of the independent assessment service to FedRAMP annually.",
+              "primary_key_word": "MUST",
+              "affects": ["Assessors"],
+              "timeframe_type": "years",
+              "timeframe_num": 1,
+              "notification": [
+                {
+                  "party": "FedRAMP",
+                  "method": "web",
+                  "target": "FedRAMP Foreign Ownership, Control, or Influence Declaration Form",
+                  "url": "https://help.fedramp.gov/forms/assessors/foci-declaration"
+                }
+              ],
+              "terms": ["Assessor"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "REC-IAS-CFI": {
+              "name": "Changes in Foreign Interest",
+              "statement": "Assessors MUST report updated information relating to any foreign interest, foreign influence, or foreign control of the independent assessment service within 48 hours of any change in foreign ownership or control.",
+              "primary_key_word": "MUST",
+              "affects": ["Assessors"],
+              "timeframe_type": "hours",
+              "timeframe_num": 48,
+              "notification": [
+                {
+                  "party": "FedRAMP",
+                  "method": "web",
+                  "target": "FedRAMP Foreign Ownership, Control, or Influence Declaration Form",
+                  "url": "https://help.fedramp.gov/forms/assessors/foci-declaration"
+                }
+              ],
+              "terms": ["Assessor"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "REC-IAS-PST": {
+              "name": "Performance Standards",
+              "statement": "Assessors MUST meet FedRAMP performance standards for assessor deliverables to support independent, risk-based reviews by FedRAMP and federal agencies, including at least:",
+              "following_information": [
+                "Complete Assessment Packages: Supplies complete and thoroughly prepared documents on the first submission.",
+                "Deliverable Quality: Ensures documentation content is clear, complete, concise, and consistent.",
+                "Deliverable Format: Uses current FedRAMP templates, procedures, and required formats for assessor-authored deliverables unless FedRAMP publishes an alternate format for a specific path, pilot, or process, and does not alter or delete required template content.",
+                "Timeliness and Responsiveness: Delivers documents on time according to the schedule agreed to by the federal government, provider, and assessor.",
+                "Testing Accuracy and Completeness: Ensures accurate and complete testing of a cloud service offering in accordance with ISO 17020 and FedRAMP security rules.",
+                "Assessment Integrity: Submits independent assessments of provider security implementations that are not influenced by provider demands.",
+                "Chain of Custody: Preserves the integrity and chain of custody of assessor-authored documents and provider-supplied evidence used in FedRAMP assessments."
+              ],
+              "primary_key_word": "MUST",
+              "affects": ["Assessors"],
+              "terms": [
+                "Agency",
+                "Assessor",
+                "Cloud Service Offering",
+                "Provider"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "REC-IAS-CAP": {
+              "name": "Corrective Action Plan",
+              "statement": "Assessors MUST supply a corrective action plan when FedRAMP requires one for performance standards deficiencies or organizational risks.",
+              "primary_key_word": "MUST",
+              "affects": ["Assessors"],
+              "terms": ["Assessor"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "REC-IAS-INV": {
+              "name": "Invalid Deliverables",
+              "statement": "Assessors MUST treat deliverables prepared, performed, or submitted by personnel who do not meet required role qualifications as invalid for FedRAMP purposes.",
+              "primary_key_word": "MUST",
+              "affects": ["Assessors"],
+              "terms": ["Assessor"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "REC-IAS-SEP": {
+              "name": "Advisory Separation",
+              "statement": "Assessors MUST NOT perform an independent assessment of the same cloud service offering within 2 years after supplying advisory or consulting services for that offering, unless FedRAMP publishes a specific exception for a limited pilot or other explicitly scoped process.",
+              "corrective_actions": [
+                "FedRAMP may require a consultation meeting, corrective action plan, or revocation for failure to comply."
+              ],
+              "primary_key_word": "MUST NOT",
+              "affects": ["Assessors"],
+              "timeframe_type": "years",
+              "timeframe_num": 2,
+              "terms": ["Assessor", "Cloud Service Offering"],
               "updated": [
                 {
                   "date": "2026-05-04",
@@ -4170,6 +6087,33 @@
             }
           },
           "CSO": {
+            "SCN-CSO-EVA": {
+              "name": "Evaluate Changes",
+              "statement": "Providers MUST evaluate all potential significant changes to determine the type of significant change and follow the appropriate Significant Change Notification rules.",
+              "following_information": [
+                "Is it a significant change? --> Continue evaluation and follow the Significant Change Notification rules.",
+                "If it is, is it an FedRAMP Certification class change?  --> This requires a new assessment and cannot be done under the Significant Change Notification rules.",
+                "If it is not, is it a routine recurring change? --> Follow the Routine Recurring Change rules (SCN-RTR Routine Recurring Changes).",
+                "If it is not, is it a transformative change? --> Follow the Transformative Change rules (SCN-TRF Transformative Changes).",
+                "If it is not, then it is an adaptive change --> Follow the Adaptive Change rules (SCN-ADP Adaptive Changes)."
+              ],
+              "primary_key_word": "MUST",
+              "affects": ["Providers"],
+              "terms": [
+                "Adaptive Change",
+                "Certification Class Change",
+                "Provider",
+                "Routine Recurring Change",
+                "Significant Change",
+                "Transformative Change"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
             "SCN-CSO-MAR": {
               "name": "Maintain Audit Records",
               "statement": "Providers MUST maintain auditable records of the significant change evaluation activities required by SCN-CSO-EVA (Evaluate Changes) and make them available to FedRAMP.",
@@ -4291,33 +6235,6 @@
                 "Certification Package",
                 "Incident",
                 "Provider",
-                "Significant Change",
-                "Transformative Change"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "SCN-CSO-EVA": {
-              "name": "Evaluate Changes",
-              "statement": "Providers MUST evaluate all potential significant changes to determine the type of significant change and follow the appropriate Significant Change Notification rules.",
-              "following_information": [
-                "Is it a significant change? --> Continue evaluation and follow the Significant Change Notification rules.",
-                "If it is, is it an FedRAMP Certification class change?  --> This requires a new assessment and cannot be done under the Significant Change Notification rules.",
-                "If it is not, is it a routine recurring change? --> Follow the Routine Recurring Change rules (SCN-RTR Routine Recurring Changes).",
-                "If it is not, is it a transformative change? --> Follow the Transformative Change rules (SCN-TRF Transformative Changes).",
-                "If it is not, then it is an adaptive change --> Follow the Adaptive Change rules (SCN-ADP Adaptive Changes)."
-              ],
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "Adaptive Change",
-                "Certification Class Change",
-                "Provider",
-                "Routine Recurring Change",
                 "Significant Change",
                 "Transformative Change"
               ],
@@ -4615,6 +6532,79 @@
             }
           }
         }
+      }
+    },
+    "SDR": {
+      "info": {
+        "name": "Security Decision Record",
+        "short_name": "SDR",
+        "web_name": "security-decision-record",
+        "purpose": "The Security Decision Record replaced a traditional System Security Plan with a persistently maintained, verified, and validated record of the security decisions made by the cloud service provider over the lifecycle of their cloud service offering.",
+        "status": "empty",
+        "subsets": {
+          "CSO": {
+            "name": "General Provider Responsibilities",
+            "description": "These rules apply to providers for FedRAMP Certifications of any type.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
+          }
+        },
+        "20x": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2026-07-04",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-05-04"
+            }
+          },
+          "subsets": {
+            "CSX": {
+              "name": "20x-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
+            }
+          }
+        },
+        "rev5": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2027-01-01",
+              "maintain": "2027-08-01",
+              "grace_ends": "2028-02-01"
+            },
+            "signup_url": "ADDME"
+          },
+          "subsets": {
+            "CSF": {
+              "name": "Rev5-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
+            }
+          }
+        }
+      },
+      "data": {
+        "all": {},
+        "20x": {},
+        "rev5": {}
       }
     },
     "UCM": {
@@ -4946,6 +6936,27 @@
             }
           },
           "AGM": {
+            "VDR-AGM-NFR": {
+              "name": "Notify FedRAMP",
+              "statement": "Agencies MUST notify FedRAMP after requesting any additional vulnerability information or materials from a cloud service provider beyond those FedRAMP requires by sending a notification to [info@fedramp.gov](mailto:info@fedramp.gov).",
+              "note": "This is an OMB policy; agencies are required to notify FedRAMP in OMB Memorandum M-24-15 section IV (a).",
+              "primary_key_word": "MUST",
+              "affects": ["Agencies"],
+              "notification": [
+                {
+                  "party": "FedRAMP",
+                  "method": "email",
+                  "target": "info@fedramp.gov"
+                }
+              ],
+              "terms": ["Agency", "Provider", "Vulnerability"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
             "VDR-AGM-RVR": {
               "name": "Review Vulnerability Reports",
               "statement": "Agencies SHOULD review the information provided in vulnerability reports at appropriate and reasonable intervals commensurate with the expectations and risk posture indicated by their Authorization to Operate, and SHOULD use automated processing and filtering of machine readable information from cloud service providers.",
@@ -4999,27 +7010,6 @@
                 "Vulnerability Detection",
                 "Vulnerability Response"
               ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "VDR-AGM-NFR": {
-              "name": "Notify FedRAMP",
-              "statement": "Agencies MUST notify FedRAMP after requesting any additional vulnerability information or materials from a cloud service provider beyond those FedRAMP requires by sending a notification to [info@fedramp.gov](mailto:info@fedramp.gov).",
-              "note": "This is an OMB policy; agencies are required to notify FedRAMP in OMB Memorandum M-24-15 section IV (a).",
-              "primary_key_word": "MUST",
-              "affects": ["Agencies"],
-              "notification": [
-                {
-                  "party": "FedRAMP",
-                  "method": "email",
-                  "target": "info@fedramp.gov"
-                }
-              ],
-              "terms": ["Agency", "Provider", "Vulnerability"],
               "updated": [
                 {
                   "date": "2026-05-04",
@@ -5318,25 +7308,6 @@
                 }
               ]
             },
-            "VDR-RPT-NID": {
-              "name": "Responsible Disclosure",
-              "statement": "Providers MUST NOT irresponsibly disclose specific sensitive information about vulnerabilities that would likely lead to exploitation, but MUST disclose sufficient information for informed risk-based decision-making to all necessary parties.",
-              "note": "This requirement will be superseded in the event of formal action related to an investigation or corrective action plan.",
-              "primary_key_word": "MUST NOT",
-              "affects": ["Providers"],
-              "terms": [
-                "All Necessary Parties",
-                "Likely",
-                "Provider",
-                "Vulnerability"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
             "VDR-RPT-VDT": {
               "name": "Vulnerability Details",
               "statement": "Providers MUST include the following information (if applicable) on detected vulnerabilities when reporting on vulnerability detection and response activity, UNLESS it is an accepted vulnerability:",
@@ -5407,6 +7378,25 @@
                 "Vulnerability",
                 "Vulnerability Detection",
                 "Vulnerability Response"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "VDR-RPT-NID": {
+              "name": "Responsible Disclosure",
+              "statement": "Providers MUST NOT irresponsibly disclose specific sensitive information about vulnerabilities that would likely lead to exploitation, but MUST disclose sufficient information for informed risk-based decision-making to all necessary parties.",
+              "note": "This requirement will be superseded in the event of formal action related to an investigation or corrective action plan.",
+              "primary_key_word": "MUST NOT",
+              "affects": ["Providers"],
+              "terms": [
+                "All Necessary Parties",
+                "Likely",
+                "Provider",
+                "Vulnerability"
               ],
               "updated": [
                 {
@@ -6238,1999 +8228,42 @@
           }
         }
       }
-    },
-    "FRC": {
-      "info": {
-        "name": "FedRAMP Certification",
-        "short_name": "FRC",
-        "web_name": "fedramp-certification",
-        "purpose": "The FedRAMP Certification rules define how cloud service offerings obtain and maintain FedRAMP Certification across certification classes and paths. They give providers, assessors, agencies, and FedRAMP a common set of expectations for required rule sets, current evidence, independent verification and validation, and ongoing certification decisions.",
-        "status": "placeholder",
-        "subsets": {
-          "FRP": {
-            "name": "FedRAMP Responsibilities",
-            "description": "These rules apply to FedRAMP.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["A", "B", "C", "D"],
-              "affects": ["FedRAMP"]
-            }
-          },
-          "CSO": {
-            "name": "General Provider Responsibilities",
-            "description": "These rules apply to cloud service providers obtaining and maintaining any FedRAMP Certification.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["A", "B", "C", "D"],
-              "affects": ["Providers"]
-            }
-          },
-          "IAS": {
-            "name": "General Independent Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["A", "B", "C", "D"],
-              "affects": ["Assessors"]
-            }
-          },
-          "CLA": {
-            "name": "FedRAMP Class A Certification Rules",
-            "description": "These rules apply to providers seeking FedRAMP Class A Certifications.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["A"],
-              "affects": ["Providers"]
-            }
-          },
-          "APP": {
-            "name": "Applying for FedRAMP Certification",
-            "description": "These rules apply to cloud service providers who have met all other relevant rules and are ready to apply for any FedRAMP Certification.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["A", "B", "C", "D"],
-              "affects": ["Providers"]
-            }
-          },
-          "APS": {
-            "name": "Applying for FedRAMP Certification with an Agency Sponsor",
-            "description": "These rules apply to cloud service providers with an Agency Sponsor who have met all other relevant rules and are ready to apply for any FedRAMP Certification.",
-            "applicability": {
-              "types": ["Rev5"],
-              "paths": ["Agency"],
-              "classes": ["B", "C", "D"],
-              "affects": ["Providers"]
-            }
-          }
-        },
-        "20x": {
-          "effective": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-07-04",
-              "maintain": "2027-05-04",
-              "grace_ends": "2027-05-04"
-            }
-          },
-          "subsets": {
-            "CSX": {
-              "name": "20x-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
-              "applicability": {
-                "types": ["20x"],
-                "paths": ["Program"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Providers"]
-              }
-            },
-            "IAX": {
-              "name": "20x-Specific Independent Assessor Responsibilities",
-              "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications.",
-              "applicability": {
-                "types": ["20x"],
-                "paths": ["Program"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Assessors"]
-              }
-            }
-          }
-        },
-        "rev5": {
-          "effective": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2027-01-01",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-01-01"
-            }
-          },
-          "subsets": {
-            "CSF": {
-              "name": "Rev5-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
-              "applicability": {
-                "types": ["Rev5"],
-                "paths": ["Program", "Agency"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Providers"]
-              }
-            },
-            "IAF": {
-              "name": "Rev5-Specific Independent Assessor Responsibilities",
-              "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications.",
-              "applicability": {
-                "types": ["Rev5"],
-                "paths": ["Program", "Agency"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Assessors"]
-              }
-            }
-          }
-        }
-      },
-      "data": {
-        "all": {
-          "FRP": {
-            "FRC-FRP-MCM": {
-              "name": "Minimum Continuous Monitoring",
-              "statement": "FedRAMP MUST perform a minimum level of continuous monitoring for cloud service offerings with FedRAMP Program Certification, including at least reviewing Ongoing Certification Reports.",
-              "primary_key_word": "MUST",
-              "affects": ["FedRAMP"],
-              "terms": ["Cloud Service Offering", "Ongoing Certification"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-FRP-ECR": {
-              "name": "Exemptions from Certification Rules",
-              "statement": "FedRAMP MAY approve exemptions from some FedRAMP Certification rules in rare circumstances by supplying an explicit waiver, based on a prioritization and risk assessment completed by FedRAMP.",
-              "notes": [
-                "FedRAMP will determine when such exemptions are appropriate.",
-                "Exemptions will typically be part of a public prioritization process and criteria will be published publicly.",
-                "Do not ask FedRAMP for an exemption unless the publicly published criteria is met."
-              ],
-              "primary_key_word": "MAY",
-              "affects": ["FedRAMP"],
-              "terms": [],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
-          "CSO": {
-            "FRC-CSO-CDS": {
-              "name": "FedRAMP Certification Data Sharing",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Certification Data Sharing (CDS) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "FedRAMP Certification Data Sharing",
-              "reference_url_web_name": "certification-data-sharing",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "controls": [
-                "ac-3",
-                "ac-4",
-                "au-2",
-                "au-3",
-                "au-6",
-                "ca-2",
-                "ir-4",
-                "ra-5",
-                "sc-8"
-              ],
-              "terms": ["Certification Data", "Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-CCM": {
-              "name": "Collaborative Continuous Monitoring",
-              "statement": "Providers MUST follow and persistently address the Collaborative Continuous Monitoring (CCM) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Collaborative Continuous Monitoring",
-              "reference_url_web_name": "collaborative-continuous-monitoring",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-FSI": {
-              "name": "FedRAMP Security Inbox",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Security Inbox (FSI) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "FedRAMP Security Inbox",
-              "reference_url_web_name": "fedramp-security-inbox",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": ["FedRAMP Security Inbox", "Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-ICP": {
-              "name": "Incident Communications Procedures",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Incident Communications Procedures (ICP) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Incident Communications Procedures",
-              "reference_url_web_name": "incident-communications-procedures",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Incident", "Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-MAS": {
-              "name": "Minimum Assessment Scope",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Minimum Assessment Scope (MAS) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Minimum Assessment Scope",
-              "reference_url_web_name": "minimum-assessment-scope",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "controls": [
-                "ac-1",
-                "ac-21",
-                "at-1",
-                "au-1",
-                "ca-1",
-                "cm-1",
-                "cp-1",
-                "cp-2.1",
-                "cp-2.8",
-                "cp-4.1",
-                "ia-1",
-                "ir-1",
-                "ma-1",
-                "mp-1",
-                "pe-1",
-                "pl-1",
-                "pl-2",
-                "pl-4",
-                "pl-4.1",
-                "ps-1",
-                "ra-1",
-                "ra-9",
-                "sa-1",
-                "sc-1",
-                "si-1",
-                "sr-1",
-                "sr-2",
-                "sr-3",
-                "sr-11"
-              ],
-              "terms": ["Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-SCG": {
-              "name": "Secure Configuration Guide",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Secure Configuration Guide (SCG) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Secure Configuration Guide",
-              "reference_url_web_name": "secure-configuration-guide",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-SCN": {
-              "name": "Significant Change Notifications",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Significant Change Notifications (SCN) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Significant Change Notifications",
-              "reference_url_web_name": "significant-change-notifications",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "controls": [
-                "ca-7.4",
-                "cm-3.4",
-                "cm-4",
-                "cm-7.1",
-                "au-5",
-                "ca-5",
-                "ca-7",
-                "ra-5",
-                "ra-5.2",
-                "sa-22",
-                "si-2",
-                "si-2.2",
-                "si-3",
-                "si-5",
-                "si-7.7",
-                "si-10",
-                "si-11"
-              ],
-              "terms": ["Persistently", "Provider", "Significant Change"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-UCM": {
-              "name": "Using Cryptographic Modules",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Using Cryptographic Modules (UCM) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Using Cryptographic Modules",
-              "reference_url_web_name": "using-cryptographic-modules",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-VDR": {
-              "name": "Vulnerability Detection and Response",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Vulnerability Detection and Response (VDR) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Vulnerability Detection and Response",
-              "reference_url_web_name": "vulnerability-detection-and-response",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "controls": [
-                "ca-2",
-                "ca-7",
-                "ca-7.6",
-                "ir-1",
-                "ir-4",
-                "ir-4.1",
-                "ir-5",
-                "ir-5.1",
-                "ir-6",
-                "ir-6.1",
-                "ir-6.2",
-                "pm-3",
-                "pm-5",
-                "pm-31",
-                "ra-2",
-                "ra-2.1",
-                "ra-3",
-                "ra-3.3",
-                "ra-5",
-                "ra-5.2",
-                "ra-5.3",
-                "ra-5.4",
-                "ra-5.5",
-                "ra-5.6",
-                "ra-5.7",
-                "ra-5.11",
-                "ra-9",
-                "ra-10",
-                "si-2",
-                "si-2.1",
-                "si-2.2",
-                "si-2.4",
-                "si-2.5",
-                "si-3",
-                "si-3.1",
-                "si-3.2",
-                "si-4",
-                "si-4.2",
-                "si-4.3",
-                "si-4.7",
-                "ca-7.4",
-                "ra-7"
-              ],
-              "terms": [
-                "Persistently",
-                "Provider",
-                "Vulnerability",
-                "Vulnerability Detection",
-                "Vulnerability Response"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-POP": {
-              "name": "Pick One Program Certification Type",
-              "statement": "Providers MUST NOT seek both FedRAMP Rev5 Program Certification and FedRAMP 20x Program Certification for the same cloud service offering; pick one type.",
-              "note": "This rule does not prevent a provider from seeking and maintaining a FedRAMP Rev5 Agency Certification and a FedRAMP 20x Program Certification for the same cloud service offering, however, doing so is strongly discouraged due to the increased complexity and risk of confusion for all parties.",
-              "primary_key_word": "MUST NOT",
-              "affects": ["Providers"],
-              "terms": ["Agency", "Cloud Service Offering", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-IVV": {
-              "name": "Independent Verification and Validation",
-              "varies_by_class": {
-                "a": {
-                  "statement": "Providers with Class A Certifications MAY persistently complete an independent verification and validation assessment at least once per year; these assessments MAY be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MAY be included in their FedRAMP Certification Data without inappropriate modification.",
-                  "primary_key_word": "MAY",
-                  "timeframe_type": "years",
-                  "timeframe_num": 1
-                },
-                "b": {
-                  "statement": "Providers with Class B Certifications MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
-                  "primary_key_word": "MUST",
-                  "timeframe_type": "years",
-                  "timeframe_num": 1
-                },
-                "c": {
-                  "statement": "Providers with Class C Certifications MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
-                  "primary_key_word": "MUST",
-                  "timeframe_type": "years",
-                  "timeframe_num": 1
-                },
-                "d": {
-                  "statement": "Providers with Class D Certifications MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
-                  "primary_key_word": "MUST",
-                  "timeframe_type": "years",
-                  "timeframe_num": 1
-                }
-              },
-              "notes": [
-                "The first such completed assessment is typically called an \"initial assessment\" while following assessments are called \"annual assessments.\"",
-                "The specific requirements for independent verification and validation assessments are documented by the FedRAMP Certification Class and Type.",
-                "The option for assessment by FedRAMP directly is limited to cloud services that are explicitly prioritized by FedRAMP, in consultation with the FedRAMP Board and the federal Chief Information Officers Council.",
-                "FedRAMP Recognized independent assessors are listed on the FedRAMP Marketplace."
-              ],
-              "affects": ["Providers"],
-              "terms": [
-                "Assessor",
-                "Certification Data",
-                "FedRAMP Recognized",
-                "Persistently",
-                "Provider",
-                "Validation",
-                "Verification"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-STE": {
-              "name": "Supply Technical Evidence",
-              "statement": "Providers SHOULD supply all necessary accessors with technical explanations, demonstrations, and other relevant supporting information about the technical capabilities they employ to address FedRAMP rules; this SHOULD be supplied as necessary to ensure the assessor can effectively complete verification and validation.",
-              "primary_key_word": "SHOULD",
-              "affects": ["Providers"],
-              "terms": ["Assessor", "Provider", "Validation", "Verification"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-RAA": {
-              "name": "Receiving Assessor Advice",
-              "statement": "Providers MAY ask for and accept advice from their assessor during assessment regarding techniques and procedures that will improve their security posture or the effectiveness, clarity, and accuracy of their verification, validation and reporting procedures, UNLESS doing so is likely to compromise the objectivity and integrity of the assessment.",
-              "primary_key_word": "MAY",
-              "affects": ["Providers"],
-              "terms": [
-                "Assessor",
-                "Likely",
-                "Provider",
-                "Validation",
-                "Verification"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
-          "IAS": {
-            "FRC-IAS-VVP": {
-              "name": "Verify and Validate Processes",
-              "statement": "Assessors MUST verify and validate the implementation of processes derived from FedRAMP requirements, including rules, controls and Key Security Indicators, to determine whether or not the provider has accurately documented their process and security goals for the cloud service offering.",
-              "primary_key_word": "MUST",
-              "affects": ["Assessors"],
-              "terms": [
-                "Assessor",
-                "Cloud Service Offering",
-                "Provider",
-                "Validation",
-                "Verification"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-IAS-OUC": {
-              "name": "Outcome Consistency",
-              "statement": "Assessors MUST verify and validate whether or not the underlying processes are consistently creating the desired security outcome documented by the provider.",
-              "primary_key_word": "MUST",
-              "affects": ["Assessors"],
-              "terms": ["Assessor", "Provider", "Validation", "Verification"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-IAS-PAD": {
-              "name": "Procedure Adherence",
-              "statement": "Assessors MUST assess whether or not procedures are consistently followed, including evaluating the processes in place to ensure this occurs, without relying solely on the existence of procedure documents.",
-              "note": "This includes evaluating tests or plans for activities that may occur in the future but have not yet occurred.",
-              "primary_key_word": "MUST",
-              "affects": ["Assessors"],
-              "terms": ["Assessor"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-IAS-MME": {
-              "name": "Mixed Methods Evaluation",
-              "statement": "Assessors MUST perform verification and validation using a combination of quantitative and expert qualitative assessment as appropriate AND document which is applied to which aspect of the assessment.",
-              "primary_key_word": "MUST",
-              "affects": ["Assessors"],
-              "terms": ["Assessor", "Validation", "Verification"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-IAS-SUM": {
-              "name": "Assessment Summary",
-              "statement": "Assessors MUST deliver a high-level summary of their assessment process and findings for each FedRAMP requirement, including rules, controls, and Key Security Indicators; this summary will be included in the FedRAMP Certification Data for the cloud service offering.",
-              "primary_key_word": "MUST",
-              "affects": ["Assessors"],
-              "terms": [
-                "Assessor",
-                "Certification Data",
-                "Cloud Service Offering"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-IAS-OSA": {
-              "name": "Overall Summary of Assessment",
-              "statement": "Assessors MUST supply an overall summary of the verification and validation assessment results, including any resulting failures or areas of dispute, to the provider and all necessary assessors.",
-              "note": "FedRAMP will make the final FedRAMP Certification decision based on the assessor's findings and other relevant information.",
-              "primary_key_word": "MUST",
-              "affects": ["Assessors"],
-              "terms": [
-                "All Necessary Assessors",
-                "Assessor",
-                "Provider",
-                "Validation",
-                "Verification"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-IAS-EPX": {
-              "name": "Engage Provider Experts",
-              "statement": "Assessors SHOULD engage provider experts in discussion to understand the decisions made by the provider and inform expert qualitative assessment, and SHOULD perform independent research to test such information as part of the expert qualitative assessment process.",
-              "primary_key_word": "SHOULD",
-              "affects": ["Assessors"],
-              "terms": ["Assessor", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-IAS-SHA": {
-              "name": "Sharing Advice",
-              "statement": "Assessors MAY share advice with providers they are assessing about techniques and procedures that will improve the provider's security posture or the effectiveness, clarity, and accuracy of their verification, validation and reporting procedures, UNLESS doing so is likely to compromise the objectivity and integrity of the assessment.",
-              "primary_key_word": "MAY",
-              "affects": ["Assessors"],
-              "terms": [
-                "Assessor",
-                "Likely",
-                "Provider",
-                "Validation",
-                "Verification"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
-          "CLA": {
-            "FRC-CLA-ASF": {
-              "name": "Approved Alternative Security Frameworks",
-              "statement": "Providers seeking a FedRAMP Class A Certification MUST have completed a certification or equivalent process, including an independent assessment, from one of the following alternative security frameworks:",
-              "following_information": [
-                "FedRAMP Ready",
-                "SOC 2 Type II",
-                "GovRAMP"
-              ],
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CLA-EAM": {
-              "name": "External Assessment Materials",
-              "statement": "Providers seeking a FedRAMP Class A Certification MUST supply the full materials from the alternative security assessment to all necessary parties as part of the FedRAMP Certification Package.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "All Necessary Parties",
-                "Certification Package",
-                "Provider"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CLA-AFR": {
-              "name": "Address FedRAMP Rules",
-              "statement": "Providers seeking a Class A FedRAMP Certification MUST address the following FedRAMP rules and supply the appropriate artifacts or information mapping in the FedRAMP Certification Package:",
-              "following_information": [
-                "FedRAMP Certification: FRC-CSO-POP (Pick One Program Certification Type)",
-                "Minimum Assessment Scope: MAS-CSO-IIR (Identify Information Resources)",
-                "Certification Data Sharing: CDS-CSO-PUB (Public Information)",
-                "Certification Data Sharing: CDS-CSO-UTC (Use Trust Centers)",
-                "Certification Data Sharing: CDS-UTC-PGD (Public Guidance)",
-                "Certification Data Sharing: CDS-UTC-AAD (Agency Access Denial)",
-                "FedRAMP Security Inbox: FSI-CSO-INB (Maintain a FedRAMP Security Inbox)",
-                "FedRAMP Security Inbox: FSI-CSO-RCV (Receive Email Without Disruption)",
-                "FedRAMP Security Inbox: FSI-CSO-CRA (Complete Required Actions)",
-                "Incident Communications Procedures: ICP-CSO-EFR (Evaluate FedRAMP Reportability)",
-                "Vulnerability Detection and Response: VDR-CSO-DET (Vulnerability Detection)",
-                "Continuous Collaborative Monitoring: CCM-OCR-AVL (Report Availability)",
-                "Continuous Collaborative Monitoring: CCM-OCR-NRD (Next Report Date)"
-              ],
-              "note": "If the alternative security framework has existing rules that align with these FedRAMP rules then a mapping to the alternative security framework content may be supplied instead of generating new artifacts.",
-              "related": [
-                "FRC-CSO-POP",
-                "MAS-CSO-IIR",
-                "CDS-CSO-PUB",
-                "CDS-CSO-UTC",
-                "CDS-UTC-PGD",
-                "CDS-UTC-AAD",
-                "FSI-CSO-INB",
-                "FSI-CSO-RCV",
-                "FSI-CSO-CRA",
-                "ICP-CSO-EFR",
-                "VDR-CSO-DET",
-                "CCM-OCR-AVL",
-                "CCM-OCR-NRD"
-              ],
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "Agency",
-                "Artifacts",
-                "Certification Data",
-                "Certification Package",
-                "FedRAMP Security Inbox",
-                "Incident",
-                "Information Resource",
-                "Initial Incident Report (IIR)",
-                "Ongoing Certification Report (OCR)",
-                "Provider",
-                "Trust Center",
-                "Vulnerability",
-                "Vulnerability Detection",
-                "Vulnerability Response"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CLA-IVV": {
-              "name": "Optional Independent Verification and Validation",
-              "statement": "Providers seeking a FedRAMP Class A Certification MAY have the FedRAMP Certification Package independently verified and validated by a FedRAMP Recognized assessor before submission to FedRAMP.",
-              "primary_key_word": "MAY",
-              "affects": ["Providers"],
-              "terms": [
-                "Assessor",
-                "Certification Package",
-                "FedRAMP Recognized",
-                "Provider",
-                "Validation",
-                "Verification"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
-          "APP": {
-            "FRC-APP-MLF": {
-              "name": "Marketplace Listing First",
-              "statement": "Providers MUST be listed in the FedRAMP Marketplace before applying for FedRAMP Certification.",
-              "note": "See FedRAMP's Marketplace Listing rules for information about being listed in the Marketplace in the Preparation Phase prior to receiving a formal FedRAMP Certification.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-APP-AFC": {
-              "name": "Applying for FedRAMP Certification",
-              "statement": "Providers MUST complete the FedRAMP Certification Application Form at https://fedramp.gov/forms/provider-listing-request/ in full to request an initial assessment by FedRAMP.",
-              "reference": "FedRAMP Certification Application Form",
-              "reference_url": "https://fedramp.gov/forms",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-APP-FCP": {
-              "name": "Fresh FedRAMP Certification Package",
-              "statement": "Providers MUST supply a fresh initial FedRAMP Certification Package that shows the current status of the cloud service offering as verified and validated by the provider within the previous 7 days.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "Certification Package",
-                "Cloud Service Offering",
-                "Provider",
-                "Validation",
-                "Verification"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-APP-FIA": {
-              "name": "Fresh Independent Assessment",
-              "statement": "Providers MUST supply a fresh initial independent verification and validation assessment that was completed by a FedRAMP Recognized Independent Assessment Service within the previous 3 months.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "FedRAMP Recognized",
-                "Provider",
-                "Validation",
-                "Verification"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
-          "APS": {
-            "FRC-APS-ATO": {
-              "name": "Agency Authorization to Operate",
-              "statement": "Providers seeking a FedRAMP Rev5 Agency Certification MUST have completed the Authorization to Operate (ATO) process with their agency sponsor for the cloud service offering, concluding with a formal signed ATO letter that the agency has sent over official government channels to FedRAMP.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Agency", "Cloud Service Offering", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          }
-        },
-        "20x": {
-          "CSX": {
-            "FRC-CSX-SUM": {
-              "name": "Implementation Summaries",
-              "statement": "Providers MUST maintain simple high-level summaries of at least the following for each Key Security Indicator:",
-              "following_information": [
-                "Goals for how it will be implemented and validated, including clear pass/fail criteria and traceability",
-                "The consolidated _information resources_ that will be validated (this should include consolidated summaries such as \"all employees with privileged access that are members of the Admin group\")",
-                "The machine-based processes for _validation_ and the _persistent_ cycle on which they will be performed (or an explanation of why this doesn't apply)",
-                "The non-machine-based processes for _validation_ and the _persistent_ cycle on which they will be performed (or an explanation of why this doesn't apply)",
-                "Current implementation status",
-                "Any clarifications or responses to the assessment summary"
-              ],
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "Machine-Based (Information Resources)",
-                "Provider",
-                "Validation"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSX-MAS": {
-              "name": "Application within MAS",
-              "statement": "Providers SHOULD apply ALL Key Security Indicators to ALL aspects of their cloud service offering that are within the FedRAMP Minimum Assessment Scope.",
-              "primary_key_word": "SHOULD",
-              "affects": ["Providers"],
-              "terms": ["Cloud Service Offering", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
-          "IAX": {
-            "FRC-IAX-STE": {
-              "name": "Static Evidence",
-              "statement": "Assessors MUST NOT rely on screenshots, configuration dumps, or other static output as evidence EXCEPT when evaluating the accuracy and reliability of a process that generates such artifacts.",
-              "primary_key_word": "MUST NOT",
-              "affects": ["Assessors"],
-              "terms": ["Artifacts", "Assessor"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-IAX-UNP": {
-              "name": "Underlying Processes",
-              "statement": "Assessors MUST verify and validate the underlying processes (both machine-based and non-machine-based) that providers use to validate Key Security Indicators; this should include at least:",
-              "following_information": [
-                "The effectiveness, completeness, and integrity of the automated processes that perform validation of the cloud service offering's security posture.",
-                "The effectiveness, completeness, and integrity of the human processes that perform validation of the cloud service offering's security posture",
-                "The coverage of these processes within the cloud service offering, including if all of the consolidated information resources listed are being validated."
-              ],
-              "primary_key_word": "MUST",
-              "affects": ["Assessors"],
-              "terms": [
-                "Assessor",
-                "Cloud Service Offering",
-                "Information Resource",
-                "Machine-Based (Information Resources)",
-                "Provider",
-                "Validation",
-                "Verification"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
-          "CLA": {
-            "FRC-CLA-KSM": {
-              "name": "Key Security Indicator Mapping",
-              "statement": "Providers seeking a FedRAMP 20x Certification Class A by leveraging an alternative security framework MUST supply a temporary mapping from the alternative security assessment to the following FedRAMP Key Security Indicators:",
-              "following_information": [
-                "KSI-CMT-LMC",
-                "KSI-CNA-RNT",
-                "KSI-CED-RAT",
-                "KSI-IAM-AAM",
-                "KSI-INR-RIR",
-                "KSI-SVC-SNT"
-              ],
-              "notes": [
-                "The mapping must be available in both machine-readable and human-readable formats.",
-                "If a mapping is not clear, the provider should supply new information indicating that the Key Security Indicator has not been independently audited."
-              ],
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Machine-Readable", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          }
-        },
-        "rev5": {
-          "CSF": {
-            "FRC-CSF-CDE": {
-              "name": "Class D Program Certification Exclusion",
-              "statement": "Providers seeking a FedRAMP Rev5 Class D Certification MUST use the FedRAMP Agency Certification path.",
-              "note": "FedRAMP will not perform FedRAMP Rev5 Class D Program Certifications.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Agency", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSF-RDY": {
-              "name": "FedRAMP Ready Conversion",
-              "statement": "Providers with FedRAMP Rev5 Ready status MUST convert to a FedRAMP Certification before the furthest date of the expiration of their most recently yearly assessment or November 17, 2026; the legacy FedRAMP Ready status will be entirely removed on December 31, 2027.",
-              "note": "Cloud services that do not wish to convert or do not meet conversion criteria will be renamed Legacy FedRAMP Ready and otherwise retired from FedRAMP Ready.",
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
-          "CLA": {
-            "FRC-CLA-CAC": {
-              "name": "Rev5 Class A Certification",
-              "statement": "Providers seeking a FedRAMP Rev5 Class A Certification by leveraging an alternative security framework that is based on the SP 800-53 Revision 5 MUST supply all Security Decision Record materials required for FedRAMP Rev5 Class B Certification.",
-              "notes": [
-                "The only approved alternative security frameworks based on the SP 800-53 Revision 5 are FedRAMP Ready and GovRAMP.",
-                "An independent assessment is not required for FedRAMP Rev5 Class A Certification."
-              ],
-              "primary_key_word": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          }
-        }
-      }
-    },
-    "SDR": {
-      "info": {
-        "name": "Security Decision Record",
-        "short_name": "SDR",
-        "web_name": "security-decision-record",
-        "purpose": "The Security Decision Record replaced a traditional System Security Plan with a persistently maintained, verified, and validated record of the security decisions made by the cloud service provider over the lifecycle of their cloud service offering.",
-        "status": "empty",
-        "subsets": {
-          "CSO": {
-            "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Certifications of any type.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["A", "B", "C", "D"],
-              "affects": ["Providers"]
-            }
-          }
-        },
-        "20x": {
-          "effective": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-07-04",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-05-04"
-            }
-          },
-          "subsets": {
-            "CSX": {
-              "name": "20x-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
-              "applicability": {
-                "types": ["20x"],
-                "paths": ["Program"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Providers"]
-              }
-            }
-          }
-        },
-        "rev5": {
-          "effective": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2027-01-01",
-              "maintain": "2027-08-01",
-              "grace_ends": "2028-02-01"
-            },
-            "signup_url": "ADDME"
-          },
-          "subsets": {
-            "CSF": {
-              "name": "Rev5-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
-              "applicability": {
-                "types": ["Rev5"],
-                "paths": ["Program", "Agency"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Providers"]
-              }
-            }
-          }
-        }
-      },
-      "data": {
-        "all": {},
-        "20x": {},
-        "rev5": {}
-      }
-    },
-    "IAP": {
-      "info": {
-        "name": "Independent Assessment Plan",
-        "short_name": "IAP",
-        "web_name": "independent-assessment-plan",
-        "purpose": "The Independent Assessment Plan rules explain how independent assessment services should approach the verification, validation, and attestation of a cloud service provider's own Security Decision Record on behalf of FedRAMP.",
-        "status": "empty",
-        "subsets": {
-          "CSO": {
-            "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Certifications of any type.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["A", "B", "C", "D"],
-              "affects": ["Providers"]
-            }
-          },
-          "IAS": {
-            "name": "General Independent Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["B", "C", "D"],
-              "affects": ["Assessors"]
-            }
-          }
-        },
-        "20x": {
-          "effective": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-07-04",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-05-04"
-            }
-          },
-          "subsets": {
-            "CSX": {
-              "name": "20x-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
-              "applicability": {
-                "types": ["20x"],
-                "paths": ["Program"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Providers"]
-              }
-            },
-            "IAX": {
-              "name": "20x-Specific Independent Assessor Responsibilities",
-              "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications.",
-              "applicability": {
-                "types": ["20x"],
-                "paths": ["Program"],
-                "classes": ["B", "C", "D"],
-                "affects": ["Assessors"]
-              }
-            }
-          }
-        },
-        "rev5": {
-          "effective": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2027-01-01",
-              "maintain": "2027-08-01",
-              "grace_ends": "2028-02-01"
-            },
-            "signup_url": "ADDME"
-          },
-          "subsets": {
-            "CSF": {
-              "name": "Rev5-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
-              "applicability": {
-                "types": ["Rev5"],
-                "paths": ["Program", "Agency"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Providers"]
-              }
-            },
-            "IAF": {
-              "name": "Rev5-Specific Independent Assessor Responsibilities",
-              "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications.",
-              "applicability": {
-                "types": ["Rev5"],
-                "paths": ["Program", "Agency"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Assessors"]
-              }
-            }
-          }
-        }
-      },
-      "data": {
-        "all": {},
-        "20x": {},
-        "rev5": {}
-      }
-    },
-    "IAR": {
-      "info": {
-        "name": "Independent Assessment Report",
-        "short_name": "IAR",
-        "web_name": "independent-assessment-report",
-        "purpose": "The Independent Assessment Report rules explain the minimum expectations for independent assessor attestations after the completion of an independent assessment for FedRAMP Certification.",
-        "status": "empty",
-        "subsets": {
-          "CSO": {
-            "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Certifications of any type.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["A", "B", "C", "D"],
-              "affects": ["Providers"]
-            }
-          },
-          "IAS": {
-            "name": "General Independent Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["B", "C", "D"],
-              "affects": ["Assessors"]
-            }
-          }
-        },
-        "20x": {
-          "effective": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-07-04",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-05-04"
-            }
-          },
-          "subsets": {
-            "CSX": {
-              "name": "20x-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
-              "applicability": {
-                "types": ["20x"],
-                "paths": ["Program"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Providers"]
-              }
-            },
-            "IAX": {
-              "name": "20x-Specific Independent Assessor Responsibilities",
-              "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications.",
-              "applicability": {
-                "types": ["20x"],
-                "paths": ["Program"],
-                "classes": ["B", "C", "D"],
-                "affects": ["Assessors"]
-              }
-            }
-          }
-        },
-        "rev5": {
-          "effective": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2027-01-01",
-              "maintain": "2027-08-01",
-              "grace_ends": "2028-02-01"
-            },
-            "signup_url": "ADDME"
-          },
-          "subsets": {
-            "CSF": {
-              "name": "Rev5-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
-              "applicability": {
-                "types": ["Rev5"],
-                "paths": ["Program", "Agency"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Providers"]
-              }
-            },
-            "IAF": {
-              "name": "Rev5-Specific Independent Assessor Responsibilities",
-              "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications.",
-              "applicability": {
-                "types": ["Rev5"],
-                "paths": ["Program", "Agency"],
-                "classes": ["B", "C", "D"],
-                "affects": ["Assessors"]
-              }
-            }
-          }
-        }
-      },
-      "data": {
-        "all": {},
-        "20x": {},
-        "rev5": {}
-      }
-    },
-    "AGU": {
-      "info": {
-        "name": "Agency Use of FedRAMP Certified Cloud Services (Needs Review)",
-        "short_name": "AGU",
-        "web_name": "agency-use",
-        "purpose": "The Agency Use rules summarize the many demands made on agencies by the FedRAMP Authorization Act and OMB Memorandum M-24-15 in a simple, clear, easy-to-follow set of FedRAMP-style rules. These rules align agency policies, authorization letters, machine-readable tools, secure configuration review, continuous monitoring, and communication with FedRAMP so certifications can be reused consistently across government.",
-        "status": "placeholder",
-        "effective": {
-          "is": "required",
-          "current_status": "Consolidated Rules for 2026",
-          "date": {
-            "obtain": "2026-07-04",
-            "maintain": "2026-07-04",
-            "grace_ends": "2026-07-04"
-          }
-        },
-        "subsets": {
-          "AGC": {
-            "name": "General Agency Responsibilities",
-            "description": "These rules apply to agencies based on the FedRAMP Authorization Act, OMB M-24-15, and related FedRAMP policies.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["A", "B", "C", "D"],
-              "affects": ["Agencies"]
-            }
-          },
-          "USE": {
-            "name": "Use of FedRAMP Certifications",
-            "description": "These rules apply when agencies use FedRAMP Certifications to make agency authorization decisions.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["A", "B", "C", "D"],
-              "affects": ["Agencies"]
-            }
-          },
-          "SPN": {
-            "name": "Agency Sponsored Certifications",
-            "description": "These rules apply when an agency sponsors a FedRAMP Rev5 Certification after completing an agency authorization.",
-            "applicability": {
-              "types": ["Rev5"],
-              "paths": ["Agency"],
-              "classes": ["B", "C", "D"],
-              "affects": ["Agencies"]
-            }
-          }
-        }
-      },
-      "data": {
-        "all": {
-          "AGC": {
-            "AGU-AGC-AIP": {
-              "name": "Agency Internal Policies",
-              "statement": "Agencies MUST maintain agency-wide policy that aligns with the requirements in OMB Memorandum M-24-15.",
-              "primary_key_word": "MUST",
-              "affects": ["Agencies"],
-              "terms": ["Agency"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "AGU-AGC-NAL": {
-              "name": "Notify FedRAMP After Authorization",
-              "statement": "Agencies MUST supply FedRAMP the following information upon authorizing the use of a cloud service within the scope of FedRAMP:",
-              "following_information": [
-                "A copy of the Authorization to Operate letter",
-                "All other supplementary information outlined at https://help.fedramp.gov/ato"
-              ],
-              "primary_key_word": "MUST",
-              "affects": ["Agencies"],
-              "notification": [
-                {
-                  "party": "FedRAMP",
-                  "method": "email",
-                  "target": "ato-letter@fedramp.gov"
-                }
-              ],
-              "terms": ["Agency"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "AGU-AGC-GRC": {
-              "name": "Governance, Risk, and Compliance Tools",
-              "statement": "Agencies MUST ensure that internal governance, risk, compliance, and inventory tools can produce and ingest machine-readable artifacts using formats identified by FedRAMP, including at least:",
-              "following_information": [
-                "Open Security Controls Assessment Language (OSCAL)",
-                "JSON"
-              ],
-              "primary_key_word": "MUST",
-              "affects": ["Agencies"],
-              "terms": ["Agency", "Artifacts", "Machine-Readable"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "AGU-AGC-NAR": {
-              "name": "No Additional Security Requirements",
-              "statement": "Agencies MUST NOT require additional information or materials from FedRAMP Certified cloud service offerings beyond those required by FedRAMP UNLESS the head of the agency or an authorized delegate determines there is a demonstrable need; this does not apply to seeking clarification or asking general questions about FedRAMP Certification Data.",
-              "note": "This is related to the Presumption of Adequacy for a FedRAMP Certification.",
-              "primary_key_word": "MUST NOT",
-              "affects": ["Agencies"],
-              "terms": [
-                "Agency",
-                "Certification Data",
-                "Cloud Service Offering",
-                "FedRAMP Certified"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "AGU-AGC-NAI": {
-              "name": "Notify Additional Information Requests",
-              "statement": "Agencies MUST notify FedRAMP after requesting any additional information or materials from a FedRAMP Certified cloud service offering beyond those FedRAMP requires.",
-              "note": "Agencies are expected to notify FedRAMP under OMB Memorandum M-24-15 section IV (a).",
-              "primary_key_word": "MUST",
-              "affects": ["Agencies"],
-              "notification": [
-                {
-                  "party": "FedRAMP",
-                  "method": "email",
-                  "target": "info@fedramp.gov"
-                }
-              ],
-              "terms": [
-                "Agency",
-                "Cloud Service Offering",
-                "FedRAMP Certified"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "AGU-AGC-WKG": {
-              "name": "FedRAMP Working Groups",
-              "statement": "Agencies SHOULD participate in FedRAMP working groups, communities of practice, and stakeholder engagements to supply feedback and align practices across government.",
-              "primary_key_word": "SHOULD",
-              "affects": ["Agencies"],
-              "terms": ["Agency"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "AGU-AGC-LIA": {
-              "name": "Agency Liaison Program",
-              "statement": "Agencies SHOULD assign at least 1 federal employee to be an active participant in the FedRAMP Agency Liaison program.",
-              "reference": "Agency Liaison Program",
-              "reference_url": "https://www.fedramp.gov/preview/2026/agencies/support/liaisons",
-              "primary_key_word": "SHOULD",
-              "affects": ["Agencies"],
-              "terms": ["Agency"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "AGU-AGC-SIN": {
-              "name": "Shared FedRAMP Inbox",
-              "statement": "Agencies SHOULD establish and maintain a dedicated shared FedRAMP agency inbox to serve as the official point of contact for communications between FedRAMP and the agency.",
-              "note": "A shared FedRAMP agency inbox may follow an agency-specific format such as agency-fedramp@agency.gov.",
-              "primary_key_word": "SHOULD",
-              "affects": ["Agencies"],
-              "terms": ["Agency"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
-          "USE": {
-            "AGU-USE-ABU": {
-              "name": "Authorization Before Use",
-              "statement": "Agencies MUST complete the Authorization to Operate process for federal information systems that use FedRAMP Certified cloud service offerings.",
-              "note": "FedRAMP provides technical assistance to help agencies navigate this process.",
-              "reference": "Using a FedRAMP Certified Cloud Service Offering",
-              "reference_url": "https://fedramp.gov/preview/2026/agencies/use",
-              "primary_key_word": "MUST",
-              "affects": ["Agencies"],
-              "terms": [
-                "Agency",
-                "Cloud Service Offering",
-                "FedRAMP Certified"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "AGU-USE-RCF": {
-              "name": "Resolve Certification Package Conflicts",
-              "statement": "Agencies MUST collaborate with FedRAMP when discrepancies or conflicts arise between agency-specific security determinations and the baseline FedRAMP Certification package.",
-              "primary_key_word": "MUST",
-              "affects": ["Agencies"],
-              "terms": ["Agency", "Certification Package"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "AGU-USE-RSG": {
-              "name": "Review Secure Configuration Guides",
-              "statement": "Agencies MUST review the Secure Configuration Guides supplied by Providers and configure relevant security settings.",
-              "primary_key_word": "MUST",
-              "affects": ["Agencies"],
-              "terms": ["Agency", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "AGU-USE-AFR": {
-              "name": "Accept FedRAMP Rules",
-              "statement": "Agencies MUST allow FedRAMP Certified cloud service offerings to follow FedRAMP rules.",
-              "primary_key_word": "MUST",
-              "affects": ["Agencies"],
-              "terms": [
-                "Agency",
-                "Cloud Service Offering",
-                "FedRAMP Certified"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "AGU-USE-ROR": {
-              "name": "Review Ongoing Authorization Reports",
-              "statement": "Agencies SHOULD review each Ongoing Authorization Report to understand how changes to the cloud service offering may impact the risk tolerance documented in the agency Authorization to Operate for the federal information system that includes the cloud service offering in its boundary.",
-              "note": "This agency review supports agency responsibilities under 44 USC § 35, OMB Circular A-130, FIPS-200, and OMB Memorandum M-24-15.",
-              "primary_key_word": "SHOULD",
-              "affects": ["Agencies"],
-              "terms": ["Agency", "Cloud Service Offering"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "AGU-USE-NFC": {
-              "name": "Notify FedRAMP of Concerns",
-              "statement": "Agencies MUST notify FedRAMP if information presented in an Ongoing Authorization Report, Quarterly Review, or other FedRAMP Certification Data causes significant concerns for the authorizing official that would likely result in rescission of their Authorization to Operate.",
-              "note": "Agencies are expected to notify FedRAMP under OMB Memorandum M-24-15 section IV (a).",
-              "primary_key_word": "MUST",
-              "affects": ["Agencies"],
-              "notification": [
-                {
-                  "party": "FedRAMP",
-                  "method": "email",
-                  "target": "info@fedramp.gov"
-                }
-              ],
-              "terms": [
-                "Agency",
-                "Certification Data",
-                "Likely",
-                "Quarterly Review"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "AGU-USE-DSO": {
-              "name": "Designate Senior Official",
-              "statement": "Agencies SHOULD designate a federal senior information security official to review Ongoing Authorization Reports and represent the agency at Quarterly Reviews for cloud service offerings included in agency information systems.",
-              "primary_key_word": "SHOULD",
-              "affects": ["Agencies"],
-              "terms": ["Agency", "Cloud Service Offering", "Quarterly Review"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "AGU-USE-NPC": {
-              "name": "Notify Provider of Concerns",
-              "statement": "Agencies SHOULD formally notify the Provider if information presented in an Ongoing Authorization Report, Quarterly Review, or other FedRAMP Certification Data causes significant concerns for the authorizing official that would likely result in rescission of their Authorization to Operate.",
-              "primary_key_word": "SHOULD",
-              "affects": ["Agencies"],
-              "notification": [
-                {
-                  "party": "Provider",
-                  "method": "email",
-                  "target": "Provider security contact"
-                }
-              ],
-              "terms": [
-                "Agency",
-                "Certification Data",
-                "Likely",
-                "Provider",
-                "Quarterly Review"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "AGU-USE-RIR": {
-              "name": "Review All Information Resources",
-              "statement": "Agencies SHOULD consider third-party information resources used by the cloud service offering during initial and ongoing authorization activities.",
-              "primary_key_word": "SHOULD",
-              "affects": ["Agencies"],
-              "terms": [
-                "Agency",
-                "Cloud Service Offering",
-                "Information Resource",
-                "Third-Party Information Resource"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
-          "SPN": {
-            "AGU-SPN-MRC": {
-              "name": "Most Recent Consolidated Rules",
-              "statement": "Agencies MUST follow the most recent FedRAMP Consolidated Rules when initiating agency-sponsored FedRAMP Certification.",
-              "primary_key_word": "MUST",
-              "affects": ["Agencies"],
-              "terms": ["Agency"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          }
-        }
-      }
-    },
-    "REC": {
-      "info": {
-        "name": "FedRAMP Recognition of Independent Assessment Services",
-        "short_name": "REC",
-        "web_name": "fedramp-recognition",
-        "purpose": "The FedRAMP Recognition of Independent Assessment Services rules explain the requirements for assessors to obtain and maintain FedRAMP Recognition in order to support the FedRAMP Certification process.",
-        "status": "placeholder",
-        "effective": {
-          "is": "required",
-          "current_status": "Consolidated Rules for 2026",
-          "date": {
-            "obtain": "2026-07-04",
-            "maintain": "2026-07-04",
-            "grace_ends": "2026-07-04"
-          }
-        },
-        "subsets": {
-          "FRP": {
-            "name": "FedRAMP Responsibilities",
-            "description": "These rules apply to FedRAMP when evaluating independent assessment services for initial or ongoing FedRAMP Recognition.",
-            "applicability": {
-              "types": [],
-              "paths": [],
-              "classes": [],
-              "affects": ["FedRAMP"]
-            }
-          },
-          "IAS": {
-            "name": "General Independent Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services seeking to obtain or maintain FedRAMP Recognition.",
-            "applicability": {
-              "types": [],
-              "paths": [],
-              "classes": [],
-              "affects": ["Assessors"]
-            }
-          }
-        }
-      },
-      "data": {
-        "all": {
-          "FRP": {
-            "REC-FRP-RAO": {
-              "name": "Recognized Assessors Only",
-              "statement": "FedRAMP MUST NOT accept verification, validation, or other attestations from independent assessors who are not FedRAMP Recognized.",
-              "primary_key_word": "MUST NOT",
-              "affects": ["FedRAMP"],
-              "terms": [
-                "Assessor",
-                "FedRAMP Recognized",
-                "Validation",
-                "Verification"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "REC-FRP-FOC": {
-              "name": "Foreign Ownership Collection",
-              "statement": "FedRAMP MUST maintain a process to collect foreign ownership, control, or influence declarations from FedRAMP Recognized assessors and updates to those declarations.",
-              "primary_key_word": "MUST",
-              "affects": ["FedRAMP"],
-              "terms": ["Assessor", "FedRAMP Recognized"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "REC-FRP-DRD": {
-              "name": "Double Revocation Disqualification",
-              "statement": "FedRAMP MUST NOT restore FedRAMP Recognition for an assessor after FedRAMP has revoked that assessor's FedRAMP Recognition 2 times.",
-              "primary_key_word": "MUST NOT",
-              "affects": ["FedRAMP"],
-              "terms": ["Assessor", "FedRAMP Recognized"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
-          "IAS": {
-            "REC-IAS-ACC": {
-              "name": "A2LA Accreditation",
-              "statement": "Assessors MUST obtain and maintain accreditation through the American Association for Laboratory Accreditation (A2LA) Cybersecurity Inspection Body Program to qualify for FedRAMP Recognition.",
-              "note": "FedRAMP will remove FedRAMP Recognition immediately after the American Association for Laboratory Accreditation notifies FedRAMP that an assessor's accreditation has lapsed.",
-              "primary_key_word": "MUST",
-              "affects": ["Assessors"],
-              "terms": ["Assessor", "FedRAMP Recognized"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "REC-IAS-ADA": {
-              "name": "Actually Do Assessments",
-              "statement": "Assessors MUST complete at least 2 initial or ongoing assessments for Class B, C, or D FedRAMP Certifications every 2 years to maintain FedRAMP Recognition.",
-              "note": "For a newly FedRAMP Recognized Assessor, this rule applies beginning on the initial date of FedRAMP Recognition if that date is later than 2026-06-01.",
-              "effective_date": {
-                "obtain": "2026-06-01",
-                "maintain": "2026-06-01",
-                "grace_ends": "2026-06-01"
-              },
-              "corrective_actions": [
-                "FedRAMP will notify assessors when they are within 6 months of losing FedRAMP Recognition under this rule and request a corrective action plan.",
-                "Assessors whose corrective action plan is not accepted will lose FedRAMP Recognition and must supply an alternative corrective action plan to move toward renewed FedRAMP Recognition."
-              ],
-              "primary_key_word": "MUST",
-              "affects": ["Assessors"],
-              "timeframe_type": "years",
-              "timeframe_num": 2,
-              "terms": ["Assessor", "FedRAMP Recognized"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "REC-IAS-PSC": {
-              "name": "Policy and Standards Compliance",
-              "statement": "Assessors MUST maintain compliance with the latest American Association for Laboratory Accreditation (A2LA) R311 - Specific Requirements - Federal Risk and Authorization Management Program to maintain FedRAMP Recognition.",
-              "reference": "A2LA Public Documents",
-              "reference_url": "https://portal.a2la.org/documents/",
-              "primary_key_word": "MUST",
-              "affects": ["Assessors"],
-              "terms": ["Assessor", "FedRAMP Recognized"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "REC-IAS-ANR": {
-              "name": "Annual Surveillance Assessment",
-              "statement": "Assessors MUST achieve a favorable annual surveillance assessment by the American Association for Laboratory Accreditation (A2LA) to maintain FedRAMP Recognition.",
-              "corrective_actions": [
-                "Assessors have 75 days to complete corrective actions for nonconformances identified by the American Association for Laboratory Accreditation (A2LA)during a surveillance assessment. If an assessor exceeds the 75 day resolution timeframe, A2LA will supply FedRAMP with a narrative of the assessor's current status, the assessor will be designated as in Remediation in the FedRAMP Marketplace, and the assessor must supply a corrective action plan to FedRAMP."
-              ],
-              "primary_key_word": "MUST",
-              "affects": ["Assessors"],
-              "timeframe_type": "years",
-              "timeframe_num": 1,
-              "terms": ["Assessor", "FedRAMP Recognized"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "REC-IAS-RAS": {
-              "name": "Full A2LA Reassessment",
-              "statement": "Assessors MUST achieve a favorable full reassessment by the American Association for Laboratory Accreditation (A2LA) at least once every 2 years to maintain FedRAMP Recognition.",
-              "corrective_actions": [
-                "Assessors have 75 days to complete corrective actions for nonconformances identified by the American Association for Laboratory Accreditation during a reassessment. If an assessor exceeds the 75 day resolution timeframe, the American Association for Laboratory Accreditation will supply FedRAMP with a narrative of the assessor's current status, the assessor will be designated as In Remediation in the FedRAMP Marketplace, and the assessor must supply a corrective action plan to FedRAMP."
-              ],
-              "primary_key_word": "MUST",
-              "affects": ["Assessors"],
-              "timeframe_type": "years",
-              "timeframe_num": 2,
-              "terms": ["Assessor", "FedRAMP Recognized"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "REC-IAS-RAR": {
-              "name": "Re-entry after Revocation",
-              "statement": "Assessors MUST satisfy all American Association for Laboratory Accreditation (A2LA) re-entry conditions before regaining FedRAMP Recognition after revocation.",
-              "note": "A revocation may require extended time in revoked status while the assessor demonstrates acceptable performance in the A2LA Cybersecurity Inspection Body Program before seeking FedRAMP Recognition again.",
-              "primary_key_word": "MUST",
-              "affects": ["Assessors"],
-              "terms": ["Assessor", "FedRAMP Recognized"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "REC-IAS-SEP": {
-              "name": "Advisory Separation",
-              "statement": "Assessors MUST NOT perform an independent assessment of the same cloud service offering within 2 years after supplying advisory or consulting services for that offering, unless FedRAMP publishes a specific exception for a limited pilot or other explicitly scoped process.",
-              "corrective_actions": [
-                "FedRAMP may require a consultation meeting, corrective action plan, or revocation for failure to comply."
-              ],
-              "primary_key_word": "MUST NOT",
-              "affects": ["Assessors"],
-              "timeframe_type": "years",
-              "timeframe_num": 2,
-              "terms": ["Assessor", "Cloud Service Offering"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "REC-IAS-RQU": {
-              "name": "Roles and Qualifications",
-              "statement": "Assessors MUST staff FedRAMP assessments with all roles required by the American Association for Laboratory Accreditation (A2LA) R311, including personnel who meet the qualifications for each role, unless FedRAMP publishes a specific exception for a limited pilot or other explicitly scoped process.",
-              "corrective_actions": [
-                "FedRAMP may require a consultation meeting, corrective action plan, or revocation for failure to comply."
-              ],
-              "primary_key_word": "MUST",
-              "affects": ["Assessors"],
-              "terms": ["Assessor"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "REC-IAS-AFI": {
-              "name": "Annual Foreign Interest Reports",
-              "statement": "Assessors MUST report information relating to any foreign interest, foreign influence, or foreign control of the independent assessment service to FedRAMP annually.",
-              "primary_key_word": "MUST",
-              "affects": ["Assessors"],
-              "timeframe_type": "years",
-              "timeframe_num": 1,
-              "notification": [
-                {
-                  "party": "FedRAMP",
-                  "method": "web",
-                  "target": "FedRAMP Foreign Ownership, Control, or Influence Declaration Form",
-                  "url": "https://help.fedramp.gov/forms/assessors/foci-declaration"
-                }
-              ],
-              "terms": ["Assessor"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "REC-IAS-CFI": {
-              "name": "Changes in Foreign Interest",
-              "statement": "Assessors MUST report updated information relating to any foreign interest, foreign influence, or foreign control of the independent assessment service within 48 hours of any change in foreign ownership or control.",
-              "primary_key_word": "MUST",
-              "affects": ["Assessors"],
-              "timeframe_type": "hours",
-              "timeframe_num": 48,
-              "notification": [
-                {
-                  "party": "FedRAMP",
-                  "method": "web",
-                  "target": "FedRAMP Foreign Ownership, Control, or Influence Declaration Form",
-                  "url": "https://help.fedramp.gov/forms/assessors/foci-declaration"
-                }
-              ],
-              "terms": ["Assessor"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "REC-IAS-PST": {
-              "name": "Performance Standards",
-              "statement": "Assessors MUST meet FedRAMP performance standards for assessor deliverables to support independent, risk-based reviews by FedRAMP and federal agencies, including at least:",
-              "following_information": [
-                "Complete Assessment Packages: Supplies complete and thoroughly prepared documents on the first submission.",
-                "Deliverable Quality: Ensures documentation content is clear, complete, concise, and consistent.",
-                "Deliverable Format: Uses current FedRAMP templates, procedures, and required formats for assessor-authored deliverables unless FedRAMP publishes an alternate format for a specific path, pilot, or process, and does not alter or delete required template content.",
-                "Timeliness and Responsiveness: Delivers documents on time according to the schedule agreed to by the federal government, provider, and assessor.",
-                "Testing Accuracy and Completeness: Ensures accurate and complete testing of a cloud service offering in accordance with ISO 17020 and FedRAMP security rules.",
-                "Assessment Integrity: Submits independent assessments of provider security implementations that are not influenced by provider demands.",
-                "Chain of Custody: Preserves the integrity and chain of custody of assessor-authored documents and provider-supplied evidence used in FedRAMP assessments."
-              ],
-              "primary_key_word": "MUST",
-              "affects": ["Assessors"],
-              "terms": [
-                "Agency",
-                "Assessor",
-                "Cloud Service Offering",
-                "Provider"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "REC-IAS-CAP": {
-              "name": "Corrective Action Plan",
-              "statement": "Assessors MUST supply a corrective action plan when FedRAMP requires one for performance standards deficiencies or organizational risks.",
-              "primary_key_word": "MUST",
-              "affects": ["Assessors"],
-              "terms": ["Assessor"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "REC-IAS-INV": {
-              "name": "Invalid Deliverables",
-              "statement": "Assessors MUST treat deliverables prepared, performed, or submitted by personnel who do not meet required role qualifications as invalid for FedRAMP purposes.",
-              "primary_key_word": "MUST",
-              "affects": ["Assessors"],
-              "terms": ["Assessor"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          }
-        }
-      }
     }
   },
   "KSI": {
+    "CED": {
+      "id": "KSI-CED",
+      "name": "Cybersecurity Education",
+      "web_name": "cybersecurity-education",
+      "short_name": "CED",
+      "status": "stable",
+      "indicators": {
+        "KSI-CED-RAT": {
+          "name": "Reviewing All Training",
+          "statement": "The effectiveness of relevant cybersecurity education and training is persistently reviewed, including at least general training for all employees, role-specific training for employees in high risk roles, training for development and engineering staff on secure software delivery, and training for staff involved with incident response or disaster recovery.",
+          "controls": [
+            "cp-3",
+            "ir-2",
+            "ps-6",
+            "at-2",
+            "at-2.2",
+            "at-2.3",
+            "at-3.5",
+            "at-4",
+            "ir-2.3",
+            "at-3",
+            "sr-11.1"
+          ],
+          "updated": [
+            {
+              "date": "2026-07-04",
+              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+            }
+          ],
+          "terms": ["Incident", "Persistently", "Vulnerability Response"]
+        }
+      }
+    },
     "CMT": {
       "id": "KSI-CMT",
       "name": "Change Management",
@@ -8464,39 +8497,6 @@
             }
           ],
           "terms": ["Persistently"]
-        }
-      }
-    },
-    "CED": {
-      "id": "KSI-CED",
-      "name": "Cybersecurity Education",
-      "web_name": "cybersecurity-education",
-      "short_name": "CED",
-      "status": "stable",
-      "indicators": {
-        "KSI-CED-RAT": {
-          "name": "Reviewing All Training",
-          "statement": "The effectiveness of relevant cybersecurity education and training is persistently reviewed, including at least general training for all employees, role-specific training for employees in high risk roles, training for development and engineering staff on secure software delivery, and training for staff involved with incident response or disaster recovery.",
-          "controls": [
-            "cp-3",
-            "ir-2",
-            "ps-6",
-            "at-2",
-            "at-2.2",
-            "at-2.3",
-            "at-3.5",
-            "at-4",
-            "ir-2.3",
-            "at-3",
-            "sr-11.1"
-          ],
-          "updated": [
-            {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-            }
-          ],
-          "terms": ["Incident", "Persistently", "Vulnerability Response"]
         }
       }
     },
@@ -9056,6 +9056,63 @@
         }
       }
     },
+    "SCR": {
+      "id": "KSI-SCR",
+      "name": "Supply Chain Risk",
+      "web_name": "supply-chain-risk",
+      "short_name": "SCR",
+      "status": "stable",
+      "indicators": {
+        "KSI-SCR-MIT": {
+          "name": "Mitigating Supply Chain Risk",
+          "statement": "Persistently identify, review, and mitigate potential supply chain risks.",
+          "controls": [
+            "ac-20",
+            "ra-3.1",
+            "sa-9",
+            "sa-10",
+            "sa-11",
+            "sa-15.3",
+            "sa-22",
+            "si-7.1",
+            "sr-5",
+            "sr-6",
+            "ca-7.4",
+            "sc-18"
+          ],
+          "updated": [
+            {
+              "date": "2026-07-04",
+              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+            }
+          ],
+          "terms": ["Persistently"]
+        },
+        "KSI-SCR-MON": {
+          "name": "Monitoring Supply Chain Risk",
+          "statement": "Third party software information resources are automatically monitored for upstream vulnerabilities using mechanisms that may include contractual notification requirements or active monitoring services.",
+          "controls": [
+            "ac-20",
+            "ca-3",
+            "ir-6.3",
+            "ps-7",
+            "ra-5",
+            "sa-9",
+            "si-5",
+            "sr-5",
+            "sr-6",
+            "sr-8"
+          ],
+          "updated": [
+            {
+              "date": "2026-07-04",
+              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+            }
+          ],
+          "terms": ["Information Resource", "Vulnerability"]
+        }
+      }
+    },
     "SVC": {
       "id": "KSI-SVC",
       "name": "Service Configuration",
@@ -9238,63 +9295,6 @@
             "Machine-Based (Information Resources)",
             "Validation"
           ]
-        }
-      }
-    },
-    "SCR": {
-      "id": "KSI-SCR",
-      "name": "Supply Chain Risk",
-      "web_name": "supply-chain-risk",
-      "short_name": "SCR",
-      "status": "stable",
-      "indicators": {
-        "KSI-SCR-MIT": {
-          "name": "Mitigating Supply Chain Risk",
-          "statement": "Persistently identify, review, and mitigate potential supply chain risks.",
-          "controls": [
-            "ac-20",
-            "ra-3.1",
-            "sa-9",
-            "sa-10",
-            "sa-11",
-            "sa-15.3",
-            "sa-22",
-            "si-7.1",
-            "sr-5",
-            "sr-6",
-            "ca-7.4",
-            "sc-18"
-          ],
-          "updated": [
-            {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-            }
-          ],
-          "terms": ["Persistently"]
-        },
-        "KSI-SCR-MON": {
-          "name": "Monitoring Supply Chain Risk",
-          "statement": "Third party software information resources are automatically monitored for upstream vulnerabilities using mechanisms that may include contractual notification requirements or active monitoring services.",
-          "controls": [
-            "ac-20",
-            "ca-3",
-            "ir-6.3",
-            "ps-7",
-            "ra-5",
-            "sa-9",
-            "si-5",
-            "sr-5",
-            "sr-6",
-            "sr-8"
-          ],
-          "updated": [
-            {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-            }
-          ],
-          "terms": ["Information Resource", "Vulnerability"]
         }
       }
     }

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -1249,7 +1249,7 @@
               ]
             },
             "AGU-USE-NFC": {
-              "name": "Notify FedRAMP of Concerns",
+              "name": "Notify FedRAMP of Monitoring Concerns",
               "statement": "Agencies MUST notify FedRAMP if information presented in an Ongoing Authorization Report, Quarterly Review, or other FedRAMP Certification Data causes significant concerns for the authorizing official that would likely result in rescission of their Authorization to Operate.",
               "note": "Agencies are expected to notify FedRAMP under OMB Memorandum M-24-15 section IV (a).",
               "force": "MUST",
@@ -1449,34 +1449,6 @@
                 }
               ]
             },
-            "CCM-AGM-NFR": {
-              "name": "Notify FedRAMP of Concerns",
-              "statement": "Agencies MUST notify FedRAMP by sending an email to info@fedramp.gov if the information presented in an Ongoing Certification Report, Quarterly Review, or other ongoing FedRAMP Certification Data causes significant concerns that may lead the agency to stop operation of the cloud service offering.",
-              "note": "Agencies are required to notify FedRAMP by OMB Memorandum M-24-15 section IV (a).",
-              "force": "MUST",
-              "affects": ["Agencies"],
-              "notification": [
-                {
-                  "party": "FedRAMP",
-                  "method": "email",
-                  "target": "info@fedramp.gov"
-                }
-              ],
-              "terms": [
-                "Agency",
-                "Certification Data",
-                "Cloud Service Offering",
-                "Ongoing Certification",
-                "Ongoing Certification Report (OCR)",
-                "Quarterly Review"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
             "CCM-AGM-NFA": {
               "name": "Notify FedRAMP After Requests",
               "statement": "Agencies MUST notify FedRAMP after requesting any additional information or materials from a cloud service provider beyond those FedRAMP requires by sending an email to info@fedramp.gov.",
@@ -1529,34 +1501,6 @@
                 "Ongoing Certification",
                 "Quarterly Review",
                 "Security Category"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "CCM-AGM-NPC": {
-              "name": "Notify Provider of Concerns",
-              "statement": "Agencies SHOULD formally notify the provider if the information presented in an Ongoing Certification Report, Quarterly Review, or other ongoing FedRAMP Certification Data causes significant concerns that may lead the agency to remove the cloud service offering from operation.",
-              "force": "SHOULD",
-              "affects": ["Agencies"],
-              "notification": [
-                {
-                  "party": "Provider",
-                  "method": "email",
-                  "target": "security-email"
-                }
-              ],
-              "terms": [
-                "Agency",
-                "Certification Data",
-                "Cloud Service Offering",
-                "Ongoing Certification",
-                "Ongoing Certification Report (OCR)",
-                "Provider",
-                "Quarterly Review"
               ],
               "updated": [
                 {
@@ -1698,7 +1642,7 @@
               ]
             },
             "CCM-OCR-RPS": {
-              "name": "Responsible Public Sharing",
+              "name": "Responsible Public Certification Report Sharing",
               "statement": "Providers MAY responsibly supply some or all of the information an Ongoing Certification Report to the public or other parties if the provider determines doing so will NOT likely have an adverse effect on the cloud service offering.",
               "force": "MAY",
               "affects": ["Providers"],
@@ -2275,7 +2219,7 @@
               ]
             },
             "CDS-CSO-RPS": {
-              "name": "Responsible Public Sharing",
+              "name": "Responsible Public Package Sharing",
               "statement": "Providers MAY responsibly share some or all of the information in a FedRAMP Certification Package publicly or with other parties if the provider determines doing so will NOT likely have an adverse effect on the cloud service offering.",
               "force": "MAY",
               "affects": ["Providers"],
@@ -2371,7 +2315,7 @@
               ]
             },
             "CDS-TRC-HMR": {
-              "name": "Human and Machine-Readable",
+              "name": "Human and Machine-Readable Certification Data",
               "statement": "Trust centers SHOULD make FedRAMP Certification Data available to view and download in both human-readable and machine-readable formats.",
               "force": "SHOULD",
               "affects": ["Providers"],
@@ -2412,7 +2356,7 @@
           },
           "UTC": {
             "CDS-UTC-PGD": {
-              "name": "Public Guidance",
+              "name": "Public Guidance for Certification Data",
               "statement": "Providers MUST publicly provide plain-language policies and guidance for all necessary parties that explains how they can obtain and manage access to FedRAMP Certification Data stored in the trust center.",
               "force": "MUST",
               "affects": ["Providers"],
@@ -3250,7 +3194,7 @@
                 "Minimum Assessment Scope: MAS-CSO-IIR (Identify Information Resources)",
                 "Certification Data Sharing: CDS-CSO-PUB (Public Information)",
                 "Certification Data Sharing: CDS-CSO-UTC (Use Trust Centers)",
-                "Certification Data Sharing: CDS-UTC-PGD (Public Guidance)",
+                "Certification Data Sharing: CDS-UTC-PGD (Public Guidance for Certification Data)",
                 "Certification Data Sharing: CDS-UTC-AAD (Agency Access Denial)",
                 "FedRAMP Security Inbox: FSI-CSO-INB (Maintain a FedRAMP Security Inbox)",
                 "FedRAMP Security Inbox: FSI-CSO-RCV (Receive Email Without Disruption)",
@@ -5883,7 +5827,7 @@
               ]
             },
             "SCG-CSO-PUB": {
-              "name": "Public Guidance",
+              "name": "Public Secure Configuration Guidance",
               "statement": "Providers SHOULD make the Secure Configuration Guide available publicly.",
               "force": "SHOULD",
               "affects": ["Providers"],
@@ -6186,7 +6130,7 @@
               ]
             },
             "SCN-CSO-HRM": {
-              "name": "Human and Machine-Readable",
+              "name": "Human and Machine-Readable Notifications",
               "statement": "Providers MUST make ALL Significant Change Notifications and related audit records available in human-readable and machine-readable formats.",
               "note": "During the SCN beta, many cloud service providers met this requirement by using carefully structured and organized csv files to meet human-readable and machine-readable requirements simultaneously.",
               "force": "MUST",
@@ -8143,8 +8087,8 @@
         },
         "20x": {
           "TFR": {
-            "VDR-TFR-PMV": {
-              "name": "Persistent Machine Verification and Validation",
+            "VDR-TFR-MVX": {
+              "name": "Persistent Machine Verification and Validation for 20x",
               "varies_by_class": {
                 "a": {
                   "statement": "Providers of FedRAMP 20x Class A offerings SHOULD verify and validate the status of machine-based information resources at least once every month.",
@@ -8184,8 +8128,8 @@
         },
         "rev5": {
           "TFR": {
-            "VDR-TFR-PMV": {
-              "name": "Persistent Machine Verification and Validation",
+            "VDR-TFR-MVF": {
+              "name": "Persistent Machine Verification and Validation for Rev5",
               "varies_by_class": {
                 "a": {
                   "statement": "Providers of FedRAMP Rev5 Class A offerings SHOULD verify and validate the status of machine-based information resources at least once every month.",

--- a/schemas/fedramp-consolidated-rules.schema.json
+++ b/schemas/fedramp-consolidated-rules.schema.json
@@ -171,10 +171,48 @@
     },
     "frr_subset_definition": {
       "type": "object",
-      "required": ["name", "description"],
+      "required": ["name", "description", "applicability"],
       "properties": {
         "name": { "type": "string" },
-        "description": { "type": "string" }
+        "description": { "type": "string" },
+        "applicability": { "$ref": "#/$defs/frr_subset_applicability" }
+      },
+      "additionalProperties": false
+    },
+    "frr_subset_applicability": {
+      "type": "object",
+      "required": ["types", "paths", "classes", "affects"],
+      "properties": {
+        "types": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["20x", "Rev5"] },
+          "uniqueItems": true
+        },
+        "paths": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["Program", "Agency"] },
+          "uniqueItems": true
+        },
+        "classes": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["A", "B", "C", "D"] },
+          "uniqueItems": true
+        },
+        "affects": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Advisors",
+              "Agencies",
+              "Assessors",
+              "FedRAMP",
+              "Providers"
+            ]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
       },
       "additionalProperties": false
     },

--- a/schemas/fedramp-consolidated-rules.schema.json
+++ b/schemas/fedramp-consolidated-rules.schema.json
@@ -445,8 +445,8 @@
       "required": ["name", "affects"],
       "oneOf": [
         {
-          "properties": { "statement": {}, "primary_key_word": {} },
-          "required": ["statement", "primary_key_word"],
+          "properties": { "statement": {}, "force": {} },
+          "required": ["statement", "force"],
           "not": {
             "properties": { "varies_by_class": {} },
             "required": ["varies_by_class"]
@@ -462,8 +462,8 @@
                 "required": ["statement"]
               },
               {
-                "properties": { "primary_key_word": {} },
-                "required": ["primary_key_word"]
+                "properties": { "force": {} },
+                "required": ["force"]
               }
             ]
           }
@@ -510,8 +510,8 @@
           "type": "array",
           "items": { "type": "string" }
         },
-        "primary_key_word": {
-          "$ref": "#/$defs/primary_key_word_enum"
+        "force": {
+          "$ref": "#/$defs/force_enum"
         },
         "affects": { "type": "array", "items": { "type": "string" } },
         "artifacts": { "$ref": "#/$defs/artifacts" },
@@ -555,14 +555,14 @@
     },
     "frr_requirement_level": {
       "type": "object",
-      "required": ["primary_key_word", "statement"],
+      "required": ["force", "statement"],
       "properties": {
         "statement": { "type": "string" },
         "following_information": {
           "type": "array",
           "items": { "type": "string" }
         },
-        "primary_key_word": { "$ref": "#/$defs/primary_key_word_enum" },
+        "force": { "$ref": "#/$defs/force_enum" },
         "effective_date": { "$ref": "#/$defs/effective_dates" },
         "timeframe_type": { "type": "string" },
         "timeframe_num": { "type": "number" },
@@ -684,9 +684,9 @@
       "type": "array",
       "items": { "type": "string" }
     },
-    "primary_key_word_enum": {
+    "force_enum": {
       "type": "string",
-      "description": "Defines the primary keyword for a requirement or indicator, indicating its strength.",
+      "description": "Defines the force of a requirement or indicator.",
       "enum": ["MUST", "SHOULD", "MAY", "MUST NOT", "SHOULD NOT"]
     },
     "updated_list": {

--- a/tools/README.md
+++ b/tools/README.md
@@ -64,9 +64,11 @@ Runs the Bun test suite through [test.ts](test.ts). Coverage includes:
 - primary keyword consistency
 - term casing and synchronization
 - schema-driven property ordering
+- alphabetical FRR and KSI primary object ordering
 - update history checks
 - text hygiene
 - class-variant sanity checks
+- FRR subset primary-keyword ordering warnings
 - controlled vocabulary consistency
 - internal cross-reference integrity
 - fix planning and application behavior
@@ -86,7 +88,7 @@ Runs [fix.ts](fix.ts), which plans and applies fixable normalizations:
 - ID alignment
 - inline rule display names
 - related rule references
-- schema-driven property ordering
+- schema-driven property ordering and alphabetical FRR/KSI primary object ordering
 
 Useful variants:
 
@@ -166,7 +168,7 @@ Shared implementation:
 - [src/terms.ts](src/terms.ts)
   Term extraction, casing, and synchronization logic.
 - [src/property-order.ts](src/property-order.ts)
-  Schema-driven property-order logic.
+  Schema-driven property-order and FRR/KSI primary object ordering logic.
 - [src/traversal.ts](src/traversal.ts)
   Shared FRD, FRR, and KSI traversal helpers.
 - [src/types.ts](src/types.ts)

--- a/tools/README.md
+++ b/tools/README.md
@@ -61,14 +61,14 @@ Runs the Bun test suite through [test.ts](test.ts). Coverage includes:
 - ID alignment
 - FRD, FRR, and KSI container alignment
 - FRR subset declaration consistency
-- primary keyword consistency
+- force consistency
 - term casing and synchronization
 - schema-driven property ordering
 - alphabetical FRR and KSI primary object ordering
 - update history checks
 - text hygiene
 - class-variant sanity checks
-- FRR subset primary-keyword ordering warnings
+- FRR subset force ordering warnings
 - controlled vocabulary consistency
 - internal cross-reference integrity
 - fix planning and application behavior
@@ -116,7 +116,7 @@ Focused test aliases:
 - `bun run test:schema`
 - `bun run test:schema-validation`
 - `bun run test:ids`
-- `bun run test:keywords`
+- `bun run test:force`
 - `bun run test:terms`
 - `bun run test:order`
 - `bun run test:consistency`
@@ -164,7 +164,7 @@ Shared implementation:
 - [src/id-alignment.ts](src/id-alignment.ts)
   ID alignment detection and rewrite logic.
 - [src/keywords.ts](src/keywords.ts)
-  Primary-keyword detection logic.
+  Force consistency logic.
 - [src/terms.ts](src/terms.ts)
   Term extraction, casing, and synchronization logic.
 - [src/property-order.ts](src/property-order.ts)

--- a/tools/export-spreadsheet.ts
+++ b/tools/export-spreadsheet.ts
@@ -86,8 +86,8 @@ function statementForClass(req: Requirement, classKey: (typeof CLASS_KEYS)[numbe
   return req.varies_by_class?.[classKey]?.statement ?? "";
 }
 
-function pkwForClass(req: Requirement, classKey: (typeof CLASS_KEYS)[number]): string {
-  return req.varies_by_class?.[classKey]?.primary_key_word ?? "";
+function forceForClass(req: Requirement, classKey: (typeof CLASS_KEYS)[number]): string {
+  return req.varies_by_class?.[classKey]?.force ?? "";
 }
 
 function buildFrrRows(document: RulesDocument) {
@@ -106,15 +106,15 @@ function buildFrrRows(document: RulesDocument) {
             Subset: subsetKey,
             Name: req.name,
             Statement: req.statement ?? "",
-            "Primary Keyword": req.primary_key_word ?? "",
+            Force: req.force ?? "",
             "Statement (Class A)": hasVariants ? statementForClass(req, "a") : "",
-            "Keyword (Class A)": hasVariants ? pkwForClass(req, "a") : "",
+            "Force (Class A)": hasVariants ? forceForClass(req, "a") : "",
             "Statement (Class B)": hasVariants ? statementForClass(req, "b") : "",
-            "Keyword (Class B)": hasVariants ? pkwForClass(req, "b") : "",
+            "Force (Class B)": hasVariants ? forceForClass(req, "b") : "",
             "Statement (Class C)": hasVariants ? statementForClass(req, "c") : "",
-            "Keyword (Class C)": hasVariants ? pkwForClass(req, "c") : "",
+            "Force (Class C)": hasVariants ? forceForClass(req, "c") : "",
             "Statement (Class D)": hasVariants ? statementForClass(req, "d") : "",
-            "Keyword (Class D)": hasVariants ? pkwForClass(req, "d") : "",
+            "Force (Class D)": hasVariants ? forceForClass(req, "d") : "",
             "Following Information": joinList(req.following_information),
             Note: req.note ?? joinList(req.notes),
             Affects: joinList(req.affects),

--- a/tools/fix.ts
+++ b/tools/fix.ts
@@ -11,13 +11,16 @@ import {
   applyIdsFix,
   applyOrderFix,
   applyRelatedFix,
+  applySubsetAffectsFix,
   applyTermsFix,
   collectAutoFixPlan,
   collectDisplayNamesFixPlan,
   collectIdsFixPlan,
   collectOrderFixPlan,
   collectRelatedFixPlan,
+  collectSubsetAffectsFixPlan,
   collectTermsFixPlan,
+  FIX_SCOPES,
   isFixScope,
 } from "./src/fix";
 import {
@@ -56,7 +59,7 @@ function writeDocument(document: RulesDocument, outputPath?: string): void {
 const scopeValue = getOptionValue("--scope") ?? "auto";
 if (!isFixScope(scopeValue)) {
   console.error(
-    `Unsupported fix scope "${scopeValue}". Expected one of: auto, terms, ids, order, related, display-names.`,
+    `Unsupported fix scope "${scopeValue}". Expected one of: ${FIX_SCOPES.join(", ")}.`,
   );
   process.exit(1);
 }
@@ -94,7 +97,9 @@ async function formatRulesFile(): Promise<void> {
 }
 
 async function exitAfterFormatting(exitCode = 0): Promise<never> {
-  await formatRulesFile();
+  if (!outputPath) {
+    await formatRulesFile();
+  }
   process.exit(exitCode);
 }
 
@@ -131,6 +136,11 @@ if (scope === "auto") {
     plan.inlineRuleDisplayNameIssueCount,
     "fix:display-names",
   );
+  printAutoCheck(
+    "test:consistency (FRR subset applicability affects)",
+    plan.subsetApplicabilityAffectsIssueCount,
+    "fix:subset-affects",
+  );
   printAutoCheck("test:order", plan.propertyOrderIssueCount, "fix:order");
 
   if (
@@ -138,6 +148,7 @@ if (scope === "auto") {
     !plan.needsIdsFix &&
     !plan.needsDisplayNamesFix &&
     !plan.needsRelatedFix &&
+    !plan.needsSubsetAffectsFix &&
     !plan.needsOrderFix
   ) {
     console.log(green("No automatic fixes were needed."));
@@ -185,6 +196,13 @@ if (scope === "auto") {
       }.`,
     );
   }
+  if (result.subsetApplicabilityAffectsFixedCount > 0) {
+    console.log(
+      `[FIX] fix:subset-affects updated ${result.subsetApplicabilityAffectsFixedCount} FRR subset applicability affects array${
+        result.subsetApplicabilityAffectsFixedCount === 1 ? "" : "s"
+      }.`,
+    );
+  }
 
   const remaining = collectAutoFixPlan(result.document, schema);
   if (
@@ -192,6 +210,7 @@ if (scope === "auto") {
     remaining.needsIdsFix ||
     remaining.needsDisplayNamesFix ||
     remaining.needsRelatedFix ||
+    remaining.needsSubsetAffectsFix ||
     remaining.needsOrderFix
   ) {
     console.error(
@@ -279,6 +298,27 @@ if (scope === "related") {
   console.log(
     green(
       `Added ${result.fixedCount} related rule reference${result.fixedCount === 1 ? "" : "s"}.`,
+    ),
+  );
+  await exitAfterFormatting();
+}
+
+if (scope === "subset-affects") {
+  const plan = collectSubsetAffectsFixPlan(source);
+  if (!plan.needsFix) {
+    console.log(
+      green("All FRR subset applicability affects match requirement affects."),
+    );
+    await exitAfterFormatting();
+  }
+
+  const result = applySubsetAffectsFix(cloneDocument(source));
+  writeDocument(result.document, outputPath);
+  console.log(
+    green(
+      `Updated ${result.fixedCount} FRR subset applicability affects array${
+        result.fixedCount === 1 ? "" : "s"
+      }.`,
     ),
   );
   await exitAfterFormatting();

--- a/tools/package.json
+++ b/tools/package.json
@@ -21,6 +21,7 @@
     "fix:order": "bun run fix -- --scope order",
     "fix:related": "bun run fix -- --scope related",
     "fix:display-names": "bun run fix -- --scope display-names",
+    "fix:subset-affects": "bun run fix -- --scope subset-affects",
     "hooks:install": "sh ./install-git-hooks.sh",
     "export": "bun run export-spreadsheet.ts"
   },

--- a/tools/package.json
+++ b/tools/package.json
@@ -12,7 +12,7 @@
     "test:schema": "bun test tests/schema.test.ts",
     "test:schema-validation": "bun test tests/schema-validation.test.ts",
     "test:ids": "bun test tests/id-alignment.test.ts",
-    "test:keywords": "bun test tests/primary-keywords.test.ts",
+    "test:force": "bun test tests/force.test.ts",
     "test:terms": "bun test tests/terms.test.ts",
     "test:order": "bun test tests/property-order.test.ts",
     "test:consistency": "bun test tests/zz-consistency-report.test.ts",

--- a/tools/src/consistency.ts
+++ b/tools/src/consistency.ts
@@ -73,16 +73,16 @@ const ALLOWED_TIMEFRAME_TYPES = [
   "months",
   "years",
 ] as const;
-const PRIMARY_KEYWORD_ORDER = [
+const FORCE_ORDER = [
   "MUST",
   "MUST NOT",
   "SHOULD",
   "SHOULD NOT",
   "MAY",
 ] as const;
-const PRIMARY_KEYWORD_ORDER_INDEX = new Map<string, number>(
-  PRIMARY_KEYWORD_ORDER.map((keyword, index): [string, number] => [
-    keyword,
+const FORCE_ORDER_INDEX = new Map<string, number>(
+  FORCE_ORDER.map((force, index): [string, number] => [
+    force,
     index,
   ]),
 );
@@ -673,13 +673,13 @@ function formatValues(values: string[] | null): string {
   return values.join(", ");
 }
 
-function getPrimaryKeywordOrderIndex(keyword: string): number | null {
-  return PRIMARY_KEYWORD_ORDER_INDEX.get(keyword) ?? null;
+function getForceOrderIndex(force: string): number | null {
+  return FORCE_ORDER_INDEX.get(force) ?? null;
 }
 
-function comparePrimaryKeywords(left: string, right: string): number {
-  const leftIndex = getPrimaryKeywordOrderIndex(left);
-  const rightIndex = getPrimaryKeywordOrderIndex(right);
+function compareForces(left: string, right: string): number {
+  const leftIndex = getForceOrderIndex(left);
+  const rightIndex = getForceOrderIndex(right);
 
   if (leftIndex === null && rightIndex === null) {
     return left.localeCompare(right);
@@ -696,37 +696,37 @@ function comparePrimaryKeywords(left: string, right: string): number {
     : leftIndex - rightIndex;
 }
 
-function getRequirementOrderingKeyword(
+function getRequirementOrderingForce(
   requirement: Requirement,
 ): string | null {
-  if (typeof requirement.primary_key_word === "string") {
-    return requirement.primary_key_word;
+  if (typeof requirement.force === "string") {
+    return requirement.force;
   }
 
-  const classKeywords = CLASS_KEYS.map(
-    (classKey) => requirement.varies_by_class?.[classKey]?.primary_key_word,
-  ).filter((keyword): keyword is string => typeof keyword === "string");
+  const classForces = CLASS_KEYS.map(
+    (classKey) => requirement.varies_by_class?.[classKey]?.force,
+  ).filter((force): force is string => typeof force === "string");
 
-  return classKeywords.sort(comparePrimaryKeywords)[0] ?? null;
+  return classForces.sort(compareForces)[0] ?? null;
 }
 
-function getKeywordRuns(keywords: string[]): string[] {
+function getForceRuns(forces: string[]): string[] {
   const runs: string[] = [];
 
-  for (const keyword of keywords) {
-    if (runs[runs.length - 1] !== keyword) {
-      runs.push(keyword);
+  for (const force of forces) {
+    if (runs[runs.length - 1] !== force) {
+      runs.push(force);
     }
   }
 
   return runs;
 }
 
-function isPrimaryKeywordOrderOutOfOrder(keywords: string[]): boolean {
+function isForceOrderOutOfOrder(forces: string[]): boolean {
   let highestSeenIndex = -1;
 
-  for (const keyword of keywords) {
-    const index = getPrimaryKeywordOrderIndex(keyword);
+  for (const force of forces) {
+    const index = getForceOrderIndex(force);
     if (index === null) {
       continue;
     }
@@ -741,7 +741,7 @@ function isPrimaryKeywordOrderOutOfOrder(keywords: string[]): boolean {
   return false;
 }
 
-export function collectFrrSubsetPrimaryKeywordOrderWarnings(
+export function collectFrrSubsetForceOrderWarnings(
   document: RulesDocument,
 ): ConsistencyIssue[] {
   const issues: ConsistencyIssue[] = [];
@@ -761,17 +761,17 @@ export function collectFrrSubsetPrimaryKeywordOrderWarnings(
       }
       checkedLocations.add(location);
 
-      const keywords = Object.values(subsetRequirements)
-        .map(getRequirementOrderingKeyword)
-        .filter((keyword): keyword is string => typeof keyword === "string");
-      if (keywords.length < 2 || !isPrimaryKeywordOrderOutOfOrder(keywords)) {
+      const forces = Object.values(subsetRequirements)
+        .map(getRequirementOrderingForce)
+        .filter((force): force is string => typeof force === "string");
+      if (forces.length < 2 || !isForceOrderOutOfOrder(forces)) {
         continue;
       }
 
       issues.push(
         issue(
           location,
-          `expected keyword groups ${joinAllowed(PRIMARY_KEYWORD_ORDER)}; found ${formatValues(getKeywordRuns(keywords))}.`,
+          `expected force groups ${joinAllowed(FORCE_ORDER)}; found ${formatValues(getForceRuns(forces))}.`,
         ),
       );
     }

--- a/tools/src/consistency.ts
+++ b/tools/src/consistency.ts
@@ -126,6 +126,14 @@ export function collectConsistencyChecks(
 ): ConsistencyCheck[] {
   return [
     {
+      title: "Unique rule IDs",
+      issues: collectDuplicateRuleIdIssues(document),
+    },
+    {
+      title: "Unique rule names",
+      issues: collectDuplicateRuleNameIssues(document),
+    },
+    {
       title: "Full ID alignment",
       issues: collectFullIdAlignmentIssues(document),
     },
@@ -329,6 +337,91 @@ function collectDefinitionEntries(document: RulesDocument): Array<{
   }
 
   return entries;
+}
+
+function collectDuplicateIdIssues(
+  label: string,
+  entries: Array<{ id: string; location: string }>,
+): ConsistencyIssue[] {
+  const locationsById = new Map<string, string[]>();
+
+  for (const entry of entries) {
+    locationsById.set(entry.id, [
+      ...(locationsById.get(entry.id) ?? []),
+      entry.location,
+    ]);
+  }
+
+  return [...locationsById.entries()]
+    .filter(([, locations]) => locations.length > 1)
+    .map(([id, locations]) =>
+      issue(
+        locations[0] ?? label,
+        `${label} ID ${id} appears in multiple locations: ${locations.join(", ")}.`,
+      ),
+    )
+    .sort((left, right) => left.message.localeCompare(right.message));
+}
+
+export function collectDuplicateRuleIdIssues(
+  document: RulesDocument,
+): ConsistencyIssue[] {
+  return [
+    ...collectDuplicateIdIssues(
+      "definition",
+      collectDefinitionEntries(document),
+    ),
+    ...collectDuplicateIdIssues(
+      "requirement",
+      collectRequirementEntries(document),
+    ),
+    ...collectDuplicateIdIssues("indicator", collectIndicatorEntries(document)),
+  ];
+}
+
+function collectDuplicateNameIssues(
+  label: string,
+  entries: Array<{ name: string; location: string }>,
+): ConsistencyIssue[] {
+  const locationsByName = new Map<string, string[]>();
+
+  for (const entry of entries) {
+    locationsByName.set(entry.name, [
+      ...(locationsByName.get(entry.name) ?? []),
+      entry.location,
+    ]);
+  }
+
+  return [...locationsByName.entries()]
+    .filter(([, locations]) => locations.length > 1)
+    .map(([name, locations]) =>
+      issue(
+        locations[0] ?? label,
+        `${label} name "${name}" appears in multiple locations: ${locations.join(", ")}.`,
+      ),
+    )
+    .sort((left, right) => left.message.localeCompare(right.message));
+}
+
+export function collectDuplicateRuleNameIssues(
+  document: RulesDocument,
+): ConsistencyIssue[] {
+  return [
+    ...collectDuplicateNameIssues(
+      "requirement",
+      collectRequirementEntries(document).map((entry) => ({
+        name: entry.requirement.name,
+        location: entry.location,
+      })),
+    ),
+    ...collectDuplicateNameIssues(
+      "indicator",
+      collectIndicatorEntries(document).map((entry) => ({
+        name: entry.indicator.name,
+        location: entry.location,
+      })),
+    ),
+  ];
 }
 
 function walkJson(

--- a/tools/src/consistency.ts
+++ b/tools/src/consistency.ts
@@ -2,6 +2,7 @@ import { visitIndicators, visitRequirements } from "./traversal";
 import type {
   ClassKey,
   DefinitionEntry,
+  FrrSubsetDefinition,
   KsiIndicator,
   Requirement,
   RequirementLike,
@@ -53,6 +54,8 @@ const ALLOWED_AFFECTS = [
   "FedRAMP",
   "Providers",
 ] as const;
+const ALLOWED_SUBSET_APPLICABILITY_TYPES = ["20x", "Rev5"] as const;
+const ALLOWED_SUBSET_APPLICABILITY_PATHS = ["Program", "Agency"] as const;
 const ALLOWED_NOTIFICATION_METHODS = ["email", "update", "web"] as const;
 const ALLOWED_NOTIFICATION_PARTIES = [
   "FedRAMP",
@@ -116,6 +119,14 @@ export function collectConsistencyChecks(
     {
       title: "FRR subset declarations",
       issues: collectFrrSubsetDeclarationIssues(document),
+    },
+    {
+      title: "FRR subset applicability affects",
+      issues: collectFrrSubsetApplicabilityAffectsIssues(document),
+    },
+    {
+      title: "FRR 20x subset applicability warnings",
+      issues: collectFrr20xSubsetApplicabilityWarnings(document),
     },
     {
       title: "Non-empty audit history",
@@ -470,7 +481,9 @@ function collectDeclaredFrrSubsets(
   info: Record<string, unknown>,
   scopeKey: string,
 ): Set<string> {
-  const subsets = new Set(Object.keys(getRecordProperty(info, "subsets") ?? {}));
+  const subsets = new Set(
+    Object.keys(getRecordProperty(info, "subsets") ?? {}),
+  );
 
   if (scopeKey === "20x" || scopeKey === "rev5") {
     const certificationInfo = getRecordProperty(info, scopeKey);
@@ -494,6 +507,319 @@ function getRecordProperty(
 
   const property = value[key];
   return isRecord(property) ? property : undefined;
+}
+
+interface FrrSubsetDeclarationEntry {
+  sectionKey: string;
+  subsetKey: string;
+  subset: FrrSubsetDefinition;
+  location: string;
+  dataScopeKeys: ApplicabilityKey[];
+  section: RulesDocument["FRR"][string];
+}
+
+interface FrrSubsetApplicabilityAffectsFixTarget {
+  location: string;
+  subset: FrrSubsetDefinition;
+  expectedAffects: string[];
+  actualAffects: string[];
+}
+
+export interface FrrSubsetApplicabilityAffectsFix {
+  location: string;
+  oldAffects: string[];
+  newAffects: string[];
+}
+
+function collectFrrInfoSubsetEntries(
+  document: RulesDocument,
+): FrrSubsetDeclarationEntry[] {
+  const entries: FrrSubsetDeclarationEntry[] = [];
+
+  for (const [sectionKey, section] of Object.entries(document.FRR ?? {})) {
+    const allDataScopeKeys = Object.keys(section.data ?? {}).filter(
+      isApplicabilityKey,
+    );
+    const commonSubsets = getRecordProperty(section.info, "subsets");
+    if (commonSubsets) {
+      for (const [subsetKey, subset] of Object.entries(commonSubsets)) {
+        entries.push({
+          sectionKey,
+          subsetKey,
+          subset: subset as FrrSubsetDefinition,
+          location: `FRR.${sectionKey}.info.subsets.${subsetKey}`,
+          dataScopeKeys: allDataScopeKeys,
+          section,
+        });
+      }
+    }
+
+    for (const certificationKey of ["20x", "rev5"] as const) {
+      const certificationInfo = getRecordProperty(
+        section.info,
+        certificationKey,
+      );
+      const certificationSubsets = getRecordProperty(
+        certificationInfo,
+        "subsets",
+      );
+      if (!certificationSubsets) {
+        continue;
+      }
+
+      for (const [subsetKey, subset] of Object.entries(certificationSubsets)) {
+        entries.push({
+          sectionKey,
+          subsetKey,
+          subset: subset as FrrSubsetDefinition,
+          location: `FRR.${sectionKey}.info.${certificationKey}.subsets.${subsetKey}`,
+          dataScopeKeys: [certificationKey],
+          section,
+        });
+      }
+    }
+  }
+
+  return entries;
+}
+
+function collectFrrSubsetRequirementAffects(entry: FrrSubsetDeclarationEntry): {
+  affects: string[];
+  requirementLocations: string[];
+} {
+  const affects: string[] = [];
+  const requirementLocations: string[] = [];
+
+  for (const scopeKey of entry.dataScopeKeys) {
+    const subsetRequirements =
+      entry.section.data?.[scopeKey]?.[entry.subsetKey];
+    if (!subsetRequirements) {
+      continue;
+    }
+
+    for (const [id, requirement] of Object.entries(subsetRequirements)) {
+      requirementLocations.push(
+        `FRR.${entry.sectionKey}.data.${scopeKey}.${entry.subsetKey}.${id}`,
+      );
+
+      for (const affectedParty of requirement.affects ?? []) {
+        if (typeof affectedParty === "string") {
+          affects.push(affectedParty);
+        }
+      }
+    }
+  }
+
+  return { affects, requirementLocations };
+}
+
+function orderAffects(values: string[]): string[] {
+  const remaining = new Set(values);
+  const ordered = (ALLOWED_AFFECTS as readonly string[]).filter((value) => {
+    if (!remaining.has(value)) {
+      return false;
+    }
+
+    remaining.delete(value);
+    return true;
+  });
+
+  return [
+    ...ordered,
+    ...[...remaining].sort((left, right) => left.localeCompare(right)),
+  ];
+}
+
+function getSubsetApplicabilityArray(
+  subset: FrrSubsetDefinition,
+  key: "types" | "paths" | "classes" | "affects",
+): string[] | null {
+  const value = subset.applicability?.[key];
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function hasSameStringSet(left: string[], right: string[]): boolean {
+  const leftSet = new Set(left);
+  const rightSet = new Set(right);
+  if (leftSet.size !== rightSet.size) {
+    return false;
+  }
+
+  return [...leftSet].every((value) => rightSet.has(value));
+}
+
+function formatValues(values: string[] | null): string {
+  if (!values || values.length === 0) {
+    return "(none)";
+  }
+
+  return values.join(", ");
+}
+
+function collectFrrSubsetApplicabilityAffectsFixTargets(
+  document: RulesDocument,
+): FrrSubsetApplicabilityAffectsFixTarget[] {
+  const targets: FrrSubsetApplicabilityAffectsFixTarget[] = [];
+
+  for (const entry of collectFrrInfoSubsetEntries(document)) {
+    const { affects, requirementLocations } =
+      collectFrrSubsetRequirementAffects(entry);
+    if (requirementLocations.length === 0) {
+      continue;
+    }
+
+    const expectedAffects = orderAffects(affects);
+    if (expectedAffects.length === 0) {
+      continue;
+    }
+
+    const actualAffects = getSubsetApplicabilityArray(entry.subset, "affects");
+    if (!actualAffects) {
+      continue;
+    }
+
+    if (!hasSameStringSet(actualAffects, expectedAffects)) {
+      targets.push({
+        location: `${entry.location}.applicability.affects`,
+        subset: entry.subset,
+        expectedAffects,
+        actualAffects,
+      });
+    }
+  }
+
+  return targets;
+}
+
+export function collectFrrSubsetApplicabilityAffectsIssues(
+  document: RulesDocument,
+): ConsistencyIssue[] {
+  const issues: ConsistencyIssue[] = [];
+
+  for (const entry of collectFrrInfoSubsetEntries(document)) {
+    const { affects, requirementLocations } =
+      collectFrrSubsetRequirementAffects(entry);
+    if (requirementLocations.length === 0) {
+      continue;
+    }
+
+    const expectedAffects = orderAffects(affects);
+    if (expectedAffects.length === 0) {
+      continue;
+    }
+
+    const actualAffects = getSubsetApplicabilityArray(entry.subset, "affects");
+    if (!actualAffects || actualAffects.length === 0) {
+      issues.push(
+        issue(
+          `${entry.location}.applicability.affects`,
+          `applicability.affects must list every party used by corresponding requirement affects arrays. Expected: ${formatValues(expectedAffects)}.`,
+        ),
+      );
+      continue;
+    }
+
+    if (hasSameStringSet(actualAffects, expectedAffects)) {
+      continue;
+    }
+
+    issues.push(
+      issue(
+        `${entry.location}.applicability.affects`,
+        `applicability.affects must match corresponding requirement affects arrays. Expected: ${formatValues(expectedAffects)}; found: ${formatValues(actualAffects)}.`,
+      ),
+    );
+  }
+
+  return issues;
+}
+
+function collectSubsetApplicabilitySetWarnings(
+  entry: FrrSubsetDeclarationEntry,
+  key: "types" | "paths",
+  expected: readonly string[],
+): ConsistencyIssue[] {
+  const actual = getSubsetApplicabilityArray(entry.subset, key);
+  if (actual && hasSameStringSet(actual, [...expected])) {
+    return [];
+  }
+
+  return [
+    issue(
+      `${entry.location}.applicability.${key}`,
+      `20x-specific subset warning: subset ${entry.subsetKey} ends in X, so applicability.${key} should only include ${formatValues([...expected])}; found: ${formatValues(actual)}.`,
+    ),
+  ];
+}
+
+export function collectFrr20xSubsetApplicabilityWarnings(
+  document: RulesDocument,
+): ConsistencyIssue[] {
+  const issues: ConsistencyIssue[] = [];
+
+  for (const entry of collectFrrInfoSubsetEntries(document)) {
+    if (!entry.subsetKey.endsWith("X")) {
+      continue;
+    }
+
+    issues.push(
+      ...collectSubsetApplicabilitySetWarnings(
+        entry,
+        "types",
+        ALLOWED_SUBSET_APPLICABILITY_TYPES.slice(0, 1),
+      ),
+      ...collectSubsetApplicabilitySetWarnings(
+        entry,
+        "paths",
+        ALLOWED_SUBSET_APPLICABILITY_PATHS.slice(0, 1),
+      ),
+    );
+  }
+
+  return issues;
+}
+
+export function collectFrrSubsetApplicabilityAffectsFixes(
+  document: RulesDocument,
+): FrrSubsetApplicabilityAffectsFix[] {
+  return collectFrrSubsetApplicabilityAffectsFixTargets(document).map(
+    (target) => ({
+      location: target.location,
+      oldAffects: target.actualAffects,
+      newAffects: target.expectedAffects,
+    }),
+  );
+}
+
+export function applyFrrSubsetApplicabilityAffectsFixes(
+  document: RulesDocument,
+): {
+  document: RulesDocument;
+  fixes: FrrSubsetApplicabilityAffectsFix[];
+  fixedCount: number;
+} {
+  const targets = collectFrrSubsetApplicabilityAffectsFixTargets(document);
+  const fixes = targets.map((target) => ({
+    location: target.location,
+    oldAffects: target.actualAffects,
+    newAffects: target.expectedAffects,
+  }));
+
+  for (const target of targets) {
+    if (target.subset.applicability) {
+      target.subset.applicability.affects = target.expectedAffects;
+    }
+  }
+
+  return {
+    document,
+    fixes,
+    fixedCount: fixes.length,
+  };
 }
 
 function collectUpdatedHistoryIssues(

--- a/tools/src/consistency.ts
+++ b/tools/src/consistency.ts
@@ -73,6 +73,19 @@ const ALLOWED_TIMEFRAME_TYPES = [
   "months",
   "years",
 ] as const;
+const PRIMARY_KEYWORD_ORDER = [
+  "MUST",
+  "MUST NOT",
+  "SHOULD",
+  "SHOULD NOT",
+  "MAY",
+] as const;
+const PRIMARY_KEYWORD_ORDER_INDEX = new Map<string, number>(
+  PRIMARY_KEYWORD_ORDER.map((keyword, index): [string, number] => [
+    keyword,
+    index,
+  ]),
+);
 
 export function formatConsistencyIssues(
   title: string,
@@ -658,6 +671,113 @@ function formatValues(values: string[] | null): string {
   }
 
   return values.join(", ");
+}
+
+function getPrimaryKeywordOrderIndex(keyword: string): number | null {
+  return PRIMARY_KEYWORD_ORDER_INDEX.get(keyword) ?? null;
+}
+
+function comparePrimaryKeywords(left: string, right: string): number {
+  const leftIndex = getPrimaryKeywordOrderIndex(left);
+  const rightIndex = getPrimaryKeywordOrderIndex(right);
+
+  if (leftIndex === null && rightIndex === null) {
+    return left.localeCompare(right);
+  }
+  if (leftIndex === null) {
+    return 1;
+  }
+  if (rightIndex === null) {
+    return -1;
+  }
+
+  return leftIndex === rightIndex
+    ? left.localeCompare(right)
+    : leftIndex - rightIndex;
+}
+
+function getRequirementOrderingKeyword(
+  requirement: Requirement,
+): string | null {
+  if (typeof requirement.primary_key_word === "string") {
+    return requirement.primary_key_word;
+  }
+
+  const classKeywords = CLASS_KEYS.map(
+    (classKey) => requirement.varies_by_class?.[classKey]?.primary_key_word,
+  ).filter((keyword): keyword is string => typeof keyword === "string");
+
+  return classKeywords.sort(comparePrimaryKeywords)[0] ?? null;
+}
+
+function getKeywordRuns(keywords: string[]): string[] {
+  const runs: string[] = [];
+
+  for (const keyword of keywords) {
+    if (runs[runs.length - 1] !== keyword) {
+      runs.push(keyword);
+    }
+  }
+
+  return runs;
+}
+
+function isPrimaryKeywordOrderOutOfOrder(keywords: string[]): boolean {
+  let highestSeenIndex = -1;
+
+  for (const keyword of keywords) {
+    const index = getPrimaryKeywordOrderIndex(keyword);
+    if (index === null) {
+      continue;
+    }
+
+    if (index < highestSeenIndex) {
+      return true;
+    }
+
+    highestSeenIndex = Math.max(highestSeenIndex, index);
+  }
+
+  return false;
+}
+
+export function collectFrrSubsetPrimaryKeywordOrderWarnings(
+  document: RulesDocument,
+): ConsistencyIssue[] {
+  const issues: ConsistencyIssue[] = [];
+  const checkedLocations = new Set<string>();
+
+  for (const entry of collectFrrInfoSubsetEntries(document)) {
+    for (const scopeKey of entry.dataScopeKeys) {
+      const subsetRequirements =
+        entry.section.data?.[scopeKey]?.[entry.subsetKey];
+      if (!subsetRequirements) {
+        continue;
+      }
+
+      const location = `FRR.${entry.sectionKey}.data.${scopeKey}.${entry.subsetKey}`;
+      if (checkedLocations.has(location)) {
+        continue;
+      }
+      checkedLocations.add(location);
+
+      const keywords = Object.values(subsetRequirements)
+        .map(getRequirementOrderingKeyword)
+        .filter((keyword): keyword is string => typeof keyword === "string");
+      if (keywords.length < 2 || !isPrimaryKeywordOrderOutOfOrder(keywords)) {
+        continue;
+      }
+
+      issues.push(
+        issue(
+          location,
+          `expected keyword groups ${joinAllowed(PRIMARY_KEYWORD_ORDER)}; found ${formatValues(getKeywordRuns(keywords))}.`,
+        ),
+      );
+    }
+  }
+
+  return issues;
 }
 
 function collectFrrSubsetApplicabilityAffectsFixTargets(

--- a/tools/src/fix.ts
+++ b/tools/src/fix.ts
@@ -5,10 +5,13 @@ import type {
 } from "./types";
 
 import {
+  applyFrrSubsetApplicabilityAffectsFixes,
   applyInlineRuleDisplayNameFixes,
   applyRelatedRuleReferenceFixes,
+  collectFrrSubsetApplicabilityAffectsFixes,
   collectInlineRuleDisplayNameFixes,
   collectRelatedRuleReferenceFixes,
+  type FrrSubsetApplicabilityAffectsFix,
   type InlineRuleDisplayNameFix,
   type RelatedRuleReferenceFix,
 } from "./consistency";
@@ -28,6 +31,7 @@ export const FIX_SCOPES = [
   "order",
   "related",
   "display-names",
+  "subset-affects",
 ] as const;
 export type FixScope = (typeof FIX_SCOPES)[number];
 
@@ -89,6 +93,17 @@ export interface DisplayNamesFixPlan {
 export interface DisplayNamesFixResult {
   document: RulesDocument;
   fixes: InlineRuleDisplayNameFix[];
+  fixedCount: number;
+}
+
+export interface SubsetAffectsFixPlan {
+  issueCount: number;
+  needsFix: boolean;
+}
+
+export interface SubsetAffectsFixResult {
+  document: RulesDocument;
+  fixes: FrrSubsetApplicabilityAffectsFix[];
   fixedCount: number;
 }
 
@@ -211,17 +226,36 @@ export function applyDisplayNamesFix(
   return applyInlineRuleDisplayNameFixes(document);
 }
 
+export function collectSubsetAffectsFixPlan(
+  document: RulesDocument,
+): SubsetAffectsFixPlan {
+  const issueCount = collectFrrSubsetApplicabilityAffectsFixes(document).length;
+
+  return {
+    issueCount,
+    needsFix: issueCount > 0,
+  };
+}
+
+export function applySubsetAffectsFix(
+  document: RulesDocument,
+): SubsetAffectsFixResult {
+  return applyFrrSubsetApplicabilityAffectsFixes(document);
+}
+
 export interface AutoFixPlan {
   definitionTermIssueCount: number;
   termSyncIssueCount: number;
   idIssueCount: number;
   inlineRuleDisplayNameIssueCount: number;
   relatedRuleIssueCount: number;
+  subsetApplicabilityAffectsIssueCount: number;
   propertyOrderIssueCount: number;
   needsTermsFix: boolean;
   needsIdsFix: boolean;
   needsDisplayNamesFix: boolean;
   needsRelatedFix: boolean;
+  needsSubsetAffectsFix: boolean;
   needsOrderFix: boolean;
 }
 
@@ -234,6 +268,7 @@ export interface AutoFixResult {
   idSkippedCount: number;
   inlineRuleDisplayNameFixedCount: number;
   relatedRuleFixedCount: number;
+  subsetApplicabilityAffectsFixedCount: number;
   propertyOrderFixedCount: number;
 }
 
@@ -245,6 +280,7 @@ export function collectAutoFixPlan(
   const idsPlan = collectIdsFixPlan(document);
   const displayNamesPlan = collectDisplayNamesFixPlan(document);
   const relatedPlan = collectRelatedFixPlan(document);
+  const subsetAffectsPlan = collectSubsetAffectsFixPlan(document);
   const orderPlan = collectOrderFixPlan(document, schemaDocument);
 
   return {
@@ -253,11 +289,13 @@ export function collectAutoFixPlan(
     idIssueCount: idsPlan.issueCount,
     inlineRuleDisplayNameIssueCount: displayNamesPlan.issueCount,
     relatedRuleIssueCount: relatedPlan.issueCount,
+    subsetApplicabilityAffectsIssueCount: subsetAffectsPlan.issueCount,
     propertyOrderIssueCount: orderPlan.issueCount,
     needsTermsFix: termsPlan.needsFix,
     needsIdsFix: idsPlan.needsFix,
     needsDisplayNamesFix: displayNamesPlan.needsFix,
     needsRelatedFix: relatedPlan.needsFix,
+    needsSubsetAffectsFix: subsetAffectsPlan.needsFix,
     needsOrderFix: orderPlan.needsFix,
   };
 }
@@ -281,6 +319,7 @@ export function applyAutoFixes(
   let idSkippedCount = 0;
   let inlineRuleDisplayNameFixedCount = 0;
   let relatedRuleFixedCount = 0;
+  let subsetApplicabilityAffectsFixedCount = 0;
   let propertyOrderFixedCount = 0;
 
   if (plan.needsIdsFix) {
@@ -310,6 +349,11 @@ export function applyAutoFixes(
     relatedRuleFixedCount = relatedResult.fixedCount;
   }
 
+  if (plan.needsSubsetAffectsFix) {
+    const subsetAffectsResult = applySubsetAffectsFix(working);
+    subsetApplicabilityAffectsFixedCount = subsetAffectsResult.fixedCount;
+  }
+
   const orderPlan = collectOrderFixPlan(working, schemaDocument);
   if (orderPlan.needsFix) {
     const propertyOrderResult = applyOrderFix(working, schemaDocument);
@@ -326,6 +370,7 @@ export function applyAutoFixes(
     idSkippedCount,
     inlineRuleDisplayNameFixedCount,
     relatedRuleFixedCount,
+    subsetApplicabilityAffectsFixedCount,
     propertyOrderFixedCount,
   };
 }

--- a/tools/src/keywords.ts
+++ b/tools/src/keywords.ts
@@ -6,18 +6,18 @@ const KEYWORD_REGEX = new RegExp(`\\b(${KEYWORDS.join("|")})\\b`);
 const CLASS_KEYS = ["a", "b", "c", "d"] as const;
 
 function validateRequirementObject(
-  obj: { statement?: string; primary_key_word?: string } | undefined,
+  obj: { statement?: string; force?: string } | undefined,
   id: string,
   location: string,
 ): ValidationIssue[] {
-  if (!obj?.statement || !obj.primary_key_word) {
+  if (!obj?.statement || !obj.force) {
     return [];
   }
 
   const match = obj.statement.match(KEYWORD_REGEX);
   const extracted = match?.[0] ?? "NO KEYWORD FOUND";
 
-  if (extracted === obj.primary_key_word) {
+  if (extracted === obj.force) {
     return [];
   }
 
@@ -25,12 +25,12 @@ function validateRequirementObject(
     {
       id,
       location,
-      message: `statement keyword is "${extracted}" but primary_key_word is "${obj.primary_key_word}"`,
+      message: `statement keyword is "${extracted}" but force is "${obj.force}"`,
     },
   ];
 }
 
-export function findPrimaryKeywordIssues(document: RulesDocument): ValidationIssue[] {
+export function findForceIssues(document: RulesDocument): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
 
   visitRequirements(document, ({ id, location, requirement }) => {

--- a/tools/src/metadata-freshness.ts
+++ b/tools/src/metadata-freshness.ts
@@ -1,0 +1,74 @@
+import { getRepoRoot } from "./config";
+import type { RulesDocument } from "./types";
+
+export type LatestCommitMetadata =
+  | { date: string; shortHash: string }
+  | { warning: string };
+
+export interface MetadataFreshnessWarning {
+  field: "info.last_updated" | "info.version" | "git";
+  message: string;
+}
+
+export function latestCommitMetadata(
+  cwd: string = getRepoRoot(),
+): LatestCommitMetadata {
+  const result = Bun.spawnSync({
+    cmd: ["git", "log", "-1", "--format=%cs%n%h"],
+    cwd,
+  });
+
+  if (result.exitCode !== 0) {
+    return {
+      warning:
+        "Could not determine the most recent git commit date for metadata freshness.",
+    };
+  }
+
+  const [date, shortHash] = result.stdout.toString().trim().split("\n");
+
+  if (!date || !shortHash) {
+    return {
+      warning:
+        "Could not parse the most recent git commit date for metadata freshness.",
+    };
+  }
+
+  return { date, shortHash };
+}
+
+export function versionDatePrefix(version: string): string | undefined {
+  return version.match(/^\d{4}\.\d{2}\.\d{2}/)?.[0];
+}
+
+export function collectMetadataFreshnessWarnings(
+  document: RulesDocument,
+  commit: LatestCommitMetadata,
+): MetadataFreshnessWarning[] {
+  if ("warning" in commit) {
+    return [{ field: "git", message: commit.warning }];
+  }
+
+  const commitVersionDate = commit.date.replaceAll("-", ".");
+  const warnings: MetadataFreshnessWarning[] = [];
+
+  if (document.info.last_updated !== commit.date) {
+    warnings.push({
+      field: "info.last_updated",
+      message: `info.last_updated is ${JSON.stringify(
+        document.info.last_updated,
+      )}; expected ${JSON.stringify(commit.date)} from commit ${commit.shortHash}.`,
+    });
+  }
+
+  if (versionDatePrefix(document.info.version) !== commitVersionDate) {
+    warnings.push({
+      field: "info.version",
+      message: `info.version is ${JSON.stringify(
+        document.info.version,
+      )}; expected a ${JSON.stringify(commitVersionDate)} date prefix from commit ${commit.shortHash}.`,
+    });
+  }
+
+  return warnings;
+}

--- a/tools/src/property-order.ts
+++ b/tools/src/property-order.ts
@@ -168,6 +168,10 @@ function compareFrdDefinitionEntries(
     : termComparison;
 }
 
+function compareKeysAlphabetically(left: string, right: string): number {
+  return left.localeCompare(right);
+}
+
 function formatPropertyList(values: string[]): string {
   return values.join(", ");
 }
@@ -178,7 +182,7 @@ export function formatPropertyOrderReport(
   const issueLabel = issues.length === 1 ? "issue" : "issues";
 
   return [
-    `Schema-defined property order failed with ${issues.length} ${issueLabel}:`,
+    `Property order failed with ${issues.length} ${issueLabel}:`,
     ...issues.map(
       (issue) =>
         `- ${issue.path}: expected order ${formatPropertyList(
@@ -194,6 +198,10 @@ function getPreferredOrder(
   value: JsonObject,
   path: string,
 ): string[] {
+  if (path === "FRR" || path === "KSI") {
+    return Object.keys(value).sort(compareKeysAlphabetically);
+  }
+
   if (path === "FRD.data.all") {
     return Object.entries(value)
       .sort(compareFrdDefinitionEntries)

--- a/tools/src/schema-validation.ts
+++ b/tools/src/schema-validation.ts
@@ -36,9 +36,9 @@ export function formatSchemaErrors(
     const value = getValueAtJsonPointer(document, instancePath);
     const location = formatJsonPointerLocation(instancePath);
 
-    if (hasOwn(value, "varies_by_class") && hasOwn(value, "primary_key_word")) {
+    if (hasOwn(value, "varies_by_class") && hasOwn(value, "force")) {
       messages.push(
-        `${location} has both varies_by_class and top-level primary_key_word, and that's not allowed. Put primary_key_word inside each varies_by_class entry instead.`,
+        `${location} has both varies_by_class and top-level force, and that's not allowed. Put force inside each varies_by_class entry instead.`,
       );
       continue;
     }

--- a/tools/src/types.ts
+++ b/tools/src/types.ts
@@ -26,7 +26,7 @@ export interface DefinitionEntry {
 export interface RequirementLevel {
   statement?: string;
   following_information?: string[];
-  primary_key_word?: string;
+  force?: string;
   timeframe_type?: string;
   timeframe_num?: number;
   pain_timeframes?: PainTimeframes;
@@ -50,7 +50,7 @@ export interface RequirementLike {
   fka?: string;
   fkas?: string[];
   statement?: string;
-  primary_key_word?: string;
+  force?: string;
   note?: string;
   notes?: string[];
   following_information?: string[];

--- a/tools/src/types.ts
+++ b/tools/src/types.ts
@@ -70,6 +70,19 @@ export interface KsiIndicator extends RequirementLike {
   name: string;
 }
 
+export interface FrrSubsetApplicability {
+  types: string[];
+  paths: string[];
+  classes: string[];
+  affects: string[];
+}
+
+export interface FrrSubsetDefinition {
+  name: string;
+  description: string;
+  applicability?: FrrSubsetApplicability;
+}
+
 export interface RulesDocument {
   info: {
     title: string;

--- a/tools/test.ts
+++ b/tools/test.ts
@@ -1,6 +1,6 @@
 import {
   collectConsistencyChecks,
-  collectFrrSubsetPrimaryKeywordOrderWarnings,
+  collectFrrSubsetForceOrderWarnings,
   type ConsistencyCheck,
   type ConsistencyIssue,
 } from "./src/consistency";
@@ -113,11 +113,11 @@ function formatMetadataFreshnessWarningSummary(
   ].join("\n");
 }
 
-function formatFrrSubsetPrimaryKeywordOrderWarningSummary(
+function formatFrrSubsetForceOrderWarningSummary(
   warnings: ConsistencyIssue[],
 ): string {
   return [
-    color("FRR subset primary keyword order warning", `${BOLD}${YELLOW}`),
+    color("FRR subset force order warning", `${BOLD}${YELLOW}`),
     ...warnings.map(
       (warning) => `  - ${formatPath(warning.location)}: ${warning.message}`,
     ),
@@ -137,8 +137,8 @@ const metadataFreshnessWarnings = collectMetadataFreshnessWarnings(
   rulesDocument,
   latestCommitMetadata(),
 );
-const frrSubsetPrimaryKeywordOrderWarnings =
-  collectFrrSubsetPrimaryKeywordOrderWarnings(rulesDocument);
+const frrSubsetForceOrderWarnings =
+  collectFrrSubsetForceOrderWarnings(rulesDocument);
 const consistencyChecks = collectConsistencyChecks(rulesDocument);
 const consistencyFailed = consistencyChecks.some(
   (check) => check.issues.length > 0,
@@ -158,10 +158,10 @@ if (metadataFreshnessWarnings.length > 0) {
   );
 }
 
-if (frrSubsetPrimaryKeywordOrderWarnings.length > 0) {
+if (frrSubsetForceOrderWarnings.length > 0) {
   console.warn(
-    `\n${color("-----", DIM)}\n\n${formatFrrSubsetPrimaryKeywordOrderWarningSummary(
-      frrSubsetPrimaryKeywordOrderWarnings,
+    `\n${color("-----", DIM)}\n\n${formatFrrSubsetForceOrderWarningSummary(
+      frrSubsetForceOrderWarnings,
     )}\n`,
   );
 }

--- a/tools/test.ts
+++ b/tools/test.ts
@@ -2,6 +2,11 @@ import {
   collectConsistencyChecks,
   type ConsistencyCheck,
 } from "./src/consistency";
+import {
+  collectMetadataFreshnessWarnings,
+  latestCommitMetadata,
+  type MetadataFreshnessWarning,
+} from "./src/metadata-freshness";
 import { collectPropertyOrderIssues } from "./src/property-order";
 import { loadRulesDocument, loadSchemaDocument } from "./src/rules";
 import type { PropertyOrderIssue } from "./src/types";
@@ -94,6 +99,18 @@ function formatPropertyOrderFailureSummary(
   return lines.join("\n");
 }
 
+function formatMetadataFreshnessWarningSummary(
+  warnings: MetadataFreshnessWarning[],
+): string {
+  return [
+    color("Metadata freshness warning", `${BOLD}${YELLOW}`),
+    ...warnings.map(
+      (warning) => `  - ${formatPath(warning.field)}: ${warning.message}`,
+    ),
+    "    Update fedramp-consolidated-rules.json metadata before publishing this branch.",
+  ].join("\n");
+}
+
 const testResult = Bun.spawnSync({
   cmd: ["bun", "test"],
   stdout: "inherit",
@@ -102,6 +119,10 @@ const testResult = Bun.spawnSync({
 
 const rulesDocument = loadRulesDocument();
 const schemaDocument = loadSchemaDocument();
+const metadataFreshnessWarnings = collectMetadataFreshnessWarnings(
+  rulesDocument,
+  latestCommitMetadata(),
+);
 const consistencyChecks = collectConsistencyChecks(rulesDocument);
 const consistencyFailed = consistencyChecks.some(
   (check) => check.issues.length > 0,
@@ -112,6 +133,14 @@ const propertyOrderIssues = collectPropertyOrderIssues(
 );
 const propertyOrderFailed = propertyOrderIssues.length > 0;
 const finalReports: string[] = [];
+
+if (metadataFreshnessWarnings.length > 0) {
+  console.warn(
+    `\n${color("-----", DIM)}\n\n${formatMetadataFreshnessWarningSummary(
+      metadataFreshnessWarnings,
+    )}\n`,
+  );
+}
 
 if (consistencyFailed) {
   finalReports.push(formatConsistencyFailureSummary(consistencyChecks));

--- a/tools/test.ts
+++ b/tools/test.ts
@@ -1,6 +1,8 @@
 import {
   collectConsistencyChecks,
+  collectFrrSubsetPrimaryKeywordOrderWarnings,
   type ConsistencyCheck,
+  type ConsistencyIssue,
 } from "./src/consistency";
 import {
   collectMetadataFreshnessWarnings,
@@ -86,7 +88,7 @@ function formatPropertyOrderFailureSummary(
 ): string {
   const lines = [
     `${formatProblem(
-      "Schema-defined property order failed",
+      "Property order failed",
     )} with ${formatProblem(`${issues.length} ${plural(issues.length, "issue")}`)}:`,
   ];
 
@@ -111,6 +113,18 @@ function formatMetadataFreshnessWarningSummary(
   ].join("\n");
 }
 
+function formatFrrSubsetPrimaryKeywordOrderWarningSummary(
+  warnings: ConsistencyIssue[],
+): string {
+  return [
+    color("FRR subset primary keyword order warning", `${BOLD}${YELLOW}`),
+    ...warnings.map(
+      (warning) => `  - ${formatPath(warning.location)}: ${warning.message}`,
+    ),
+    "    Reorder these rule groups manually; no automatic fix is provided.",
+  ].join("\n");
+}
+
 const testResult = Bun.spawnSync({
   cmd: ["bun", "test"],
   stdout: "inherit",
@@ -123,6 +137,8 @@ const metadataFreshnessWarnings = collectMetadataFreshnessWarnings(
   rulesDocument,
   latestCommitMetadata(),
 );
+const frrSubsetPrimaryKeywordOrderWarnings =
+  collectFrrSubsetPrimaryKeywordOrderWarnings(rulesDocument);
 const consistencyChecks = collectConsistencyChecks(rulesDocument);
 const consistencyFailed = consistencyChecks.some(
   (check) => check.issues.length > 0,
@@ -138,6 +154,14 @@ if (metadataFreshnessWarnings.length > 0) {
   console.warn(
     `\n${color("-----", DIM)}\n\n${formatMetadataFreshnessWarningSummary(
       metadataFreshnessWarnings,
+    )}\n`,
+  );
+}
+
+if (frrSubsetPrimaryKeywordOrderWarnings.length > 0) {
+  console.warn(
+    `\n${color("-----", DIM)}\n\n${formatFrrSubsetPrimaryKeywordOrderWarningSummary(
+      frrSubsetPrimaryKeywordOrderWarnings,
     )}\n`,
   );
 }

--- a/tools/tests/fix.test.ts
+++ b/tools/tests/fix.test.ts
@@ -4,9 +4,11 @@ import {
   applyAutoFixes,
   applyDisplayNamesFix,
   applyRelatedFix,
+  applySubsetAffectsFix,
   collectAutoFixPlan,
   collectDisplayNamesFixPlan,
   collectRelatedFixPlan,
+  collectSubsetAffectsFixPlan,
 } from "../src/fix";
 import { loadRulesDocument, loadSchemaDocument } from "../src/rules";
 import type { RulesDocument } from "../src/types";
@@ -16,6 +18,7 @@ test("the auto-fix planner reflects the current configured dataset", () => {
   const plan = collectAutoFixPlan(document, loadSchemaDocument());
   const displayNamesPlan = collectDisplayNamesFixPlan(document);
   const relatedPlan = collectRelatedFixPlan(document);
+  const subsetAffectsPlan = collectSubsetAffectsFixPlan(document);
 
   expect(plan.definitionTermIssueCount).toBe(0);
   expect(plan.termSyncIssueCount).toBe(0);
@@ -30,9 +33,13 @@ test("the auto-fix planner reflects the current configured dataset", () => {
   expect(plan.needsDisplayNamesFix).toBe(displayNamesPlan.needsFix);
   expect(plan.relatedRuleIssueCount).toBe(relatedPlan.issueCount);
   expect(plan.needsRelatedFix).toBe(relatedPlan.needsFix);
+  expect(plan.subsetApplicabilityAffectsIssueCount).toBe(
+    subsetAffectsPlan.issueCount,
+  );
+  expect(plan.needsSubsetAffectsFix).toBe(subsetAffectsPlan.needsFix);
 });
 
-test("auto-fix applies ID, term, related, and property-order fixes in one pass", () => {
+test("auto-fix applies ID, term, related, subset-affects, and property-order fixes in one pass", () => {
   const schema = {
     type: "object",
     properties: {
@@ -148,7 +155,20 @@ test("auto-fix applies ID, term, related, and property-order fixes in one pass",
     },
     FRR: {
       MAS: {
-        info: {},
+        info: {
+          subsets: {
+            CSO: {
+              name: "Provider",
+              description: "Provider subset.",
+              applicability: {
+                types: ["20x", "Rev5"],
+                paths: ["Program", "Agency"],
+                classes: ["A", "B", "C", "D"],
+                affects: ["Agencies"],
+              },
+            },
+          },
+        },
         data: {
           all: {
             CSO: {
@@ -193,11 +213,13 @@ test("auto-fix applies ID, term, related, and property-order fixes in one pass",
     idIssueCount: 1,
     inlineRuleDisplayNameIssueCount: 1,
     relatedRuleIssueCount: 1,
+    subsetApplicabilityAffectsIssueCount: 1,
     propertyOrderIssueCount: 1,
     needsTermsFix: true,
     needsIdsFix: true,
     needsDisplayNamesFix: true,
     needsRelatedFix: true,
+    needsSubsetAffectsFix: true,
     needsOrderFix: true,
   });
 
@@ -209,6 +231,7 @@ test("auto-fix applies ID, term, related, and property-order fixes in one pass",
   expect(result.idSkippedCount).toBe(0);
   expect(result.inlineRuleDisplayNameFixedCount).toBe(1);
   expect(result.relatedRuleFixedCount).toBe(1);
+  expect(result.subsetApplicabilityAffectsFixedCount).toBe(1);
   expect(result.propertyOrderFixedCount).toBe(1);
   expect(result.document.info.version).toBe("1.0.1");
   expect(result.document.info.last_updated).toBe("2026-04-19");
@@ -224,6 +247,9 @@ test("auto-fix applies ID, term, related, and property-order fixes in one pass",
   expect(
     result.document.FRR.MAS!.data.all!.CSO!["MAS-CSO-TST"]!.related,
   ).toEqual(["MAS-CSO-OLD", "MAS-CSO-REF"]);
+  expect(
+    (result.document.FRR.MAS!.info as any).subsets.CSO.applicability.affects,
+  ).toEqual(["Providers"]);
   expect(result.document.FRR.MAS!.data.all!.CSO!["MAS-CSO-TST"]!.fka).toBe(
     "MAS-CSX-TST",
   );
@@ -239,6 +265,71 @@ test("auto-fix applies ID, term, related, and property-order fixes in one pass",
     "updated",
     "fka",
   ]);
+});
+
+test("subset-affects fix synchronizes FRR subset applicability affects", () => {
+  const document = {
+    info: {
+      title: "Test",
+      description: "Test",
+      version: "1.0.0",
+      last_updated: "2026-04-12",
+    },
+    FRD: { info: {}, data: { all: {} } },
+    FRR: {
+      ABC: {
+        info: {
+          subsets: {
+            FRP: {
+              name: "FedRAMP",
+              description: "FedRAMP subset.",
+              applicability: {
+                types: ["20x", "Rev5"],
+                paths: ["Program", "Agency"],
+                classes: ["A", "B", "C", "D"],
+                affects: ["Providers"],
+              },
+            },
+          },
+        },
+        data: {
+          all: {
+            FRP: {
+              "ABC-FRP-AAA": {
+                name: "FedRAMP Rule",
+                statement: "FedRAMP MUST do the thing.",
+                primary_key_word: "MUST",
+                affects: ["FedRAMP"],
+              },
+            },
+          },
+          "20x": {
+            FRP: {
+              "ABC-FRP-BBB": {
+                name: "Agency Rule",
+                statement: "Agencies MUST do the thing.",
+                primary_key_word: "MUST",
+                affects: ["Agencies"],
+              },
+            },
+          },
+        },
+      },
+    },
+    KSI: {},
+  } as unknown as RulesDocument;
+
+  expect(collectSubsetAffectsFixPlan(document)).toEqual({
+    issueCount: 1,
+    needsFix: true,
+  });
+
+  const result = applySubsetAffectsFix(document);
+
+  expect(result.fixedCount).toBe(1);
+  expect(
+    (result.document.FRR.ABC!.info as any).subsets.FRP.applicability.affects,
+  ).toEqual(["Agencies", "FedRAMP"]);
 });
 
 test("related fix adds detected rules without deleting existing related entries", () => {

--- a/tools/tests/fix.test.ts
+++ b/tools/tests/fix.test.ts
@@ -7,6 +7,7 @@ import {
   applySubsetAffectsFix,
   collectAutoFixPlan,
   collectDisplayNamesFixPlan,
+  collectOrderFixPlan,
   collectRelatedFixPlan,
   collectSubsetAffectsFixPlan,
 } from "../src/fix";
@@ -15,18 +16,20 @@ import type { RulesDocument } from "../src/types";
 
 test("the auto-fix planner reflects the current configured dataset", () => {
   const document = loadRulesDocument();
-  const plan = collectAutoFixPlan(document, loadSchemaDocument());
+  const schema = loadSchemaDocument();
+  const plan = collectAutoFixPlan(document, schema);
   const displayNamesPlan = collectDisplayNamesFixPlan(document);
+  const orderPlan = collectOrderFixPlan(document, schema);
   const relatedPlan = collectRelatedFixPlan(document);
   const subsetAffectsPlan = collectSubsetAffectsFixPlan(document);
 
   expect(plan.definitionTermIssueCount).toBe(0);
   expect(plan.termSyncIssueCount).toBe(0);
   expect(plan.idIssueCount).toBe(0);
-  expect(plan.propertyOrderIssueCount).toBe(0);
   expect(plan.needsTermsFix).toBe(false);
   expect(plan.needsIdsFix).toBe(false);
-  expect(plan.needsOrderFix).toBe(false);
+  expect(plan.propertyOrderIssueCount).toBe(orderPlan.issueCount);
+  expect(plan.needsOrderFix).toBe(orderPlan.needsFix);
   expect(plan.inlineRuleDisplayNameIssueCount).toBe(
     displayNamesPlan.issueCount,
   );

--- a/tools/tests/fix.test.ts
+++ b/tools/tests/fix.test.ts
@@ -124,7 +124,7 @@ test("auto-fix applies ID, term, related, subset-affects, and property-order fix
               name: { type: "string" },
               statement: { type: "string" },
               related: { type: "array" },
-              primary_key_word: { type: "string" },
+              force: { type: "string" },
               affects: { type: "array" },
               terms: { type: "array" },
               updated: { type: "array" },
@@ -176,7 +176,7 @@ test("auto-fix applies ID, term, related, subset-affects, and property-order fix
           all: {
             CSO: {
               "MAS-CSX-TST": {
-                primary_key_word: "MUST",
+                force: "MUST",
                 statement:
                   "Providers MUST notify an agency and follow MAS-CSO-REF.",
                 related: ["MAS-CSO-OLD"],
@@ -188,7 +188,7 @@ test("auto-fix applies ID, term, related, subset-affects, and property-order fix
               "MAS-CSO-REF": {
                 name: "Referenced requirement",
                 statement: "Providers MUST retain the reference.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
                 terms: [],
                 updated: [],
@@ -196,7 +196,7 @@ test("auto-fix applies ID, term, related, subset-affects, and property-order fix
               "MAS-CSO-OLD": {
                 name: "Existing related requirement",
                 statement: "Providers MUST retain existing related entries.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
                 terms: [],
                 updated: [],
@@ -262,7 +262,7 @@ test("auto-fix applies ID, term, related, subset-affects, and property-order fix
     "name",
     "statement",
     "related",
-    "primary_key_word",
+    "force",
     "affects",
     "terms",
     "updated",
@@ -301,7 +301,7 @@ test("subset-affects fix synchronizes FRR subset applicability affects", () => {
               "ABC-FRP-AAA": {
                 name: "FedRAMP Rule",
                 statement: "FedRAMP MUST do the thing.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["FedRAMP"],
               },
             },
@@ -311,7 +311,7 @@ test("subset-affects fix synchronizes FRR subset applicability affects", () => {
               "ABC-FRP-BBB": {
                 name: "Agency Rule",
                 statement: "Agencies MUST do the thing.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Agencies"],
               },
             },
@@ -354,19 +354,19 @@ test("related fix adds detected rules without deleting existing related entries"
                 name: "Source Rule",
                 statement: "Providers MUST follow ABC-CSO-BBB.",
                 related: ["ABC-CSO-OLD"],
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
               "ABC-CSO-BBB": {
                 name: "Detected Rule",
                 statement: "Providers MUST do the detected thing.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
               "ABC-CSO-OLD": {
                 name: "Existing Rule",
                 statement: "Providers MUST do the existing thing.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
             },
@@ -410,25 +410,25 @@ test("display names fix adds parenthesized rule names and repairs unparenthesize
                 statement:
                   "Providers MUST follow ABC-CSO-BBB and ABC-CSO-CCC Target Rule C.",
                 note: "ABC-CSO-DDD (Target Rule D) is already formatted.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
               "ABC-CSO-BBB": {
                 name: "Target Rule B",
                 statement: "Providers MUST do the detected thing.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
               "ABC-CSO-CCC": {
                 name: "Target Rule C",
                 statement: "Providers MUST do the repaired thing.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
               "ABC-CSO-DDD": {
                 name: "Target Rule D",
                 statement: "Providers MUST do the formatted thing.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
             },

--- a/tools/tests/force.test.ts
+++ b/tools/tests/force.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test";
+
+import { findForceIssues } from "../src/keywords";
+import { loadRulesDocument } from "../src/rules";
+
+test("all force values match the first normative keyword in each statement", () => {
+  const issues = findForceIssues(loadRulesDocument());
+  expect(issues).toEqual([]);
+});

--- a/tools/tests/metadata-update.test.ts
+++ b/tools/tests/metadata-update.test.ts
@@ -1,0 +1,77 @@
+import { test } from "bun:test";
+
+import { getRepoRoot } from "../src/config";
+import { loadRulesDocument } from "../src/rules";
+
+function latestCommitMetadata():
+  | { date: string; shortHash: string }
+  | { warning: string } {
+  const result = Bun.spawnSync({
+    cmd: ["git", "log", "-1", "--format=%cs%n%h"],
+    cwd: getRepoRoot(),
+  });
+
+  if (result.exitCode !== 0) {
+    return {
+      warning:
+        "Could not determine the most recent git commit date for metadata freshness.",
+    };
+  }
+
+  const [date, shortHash] = result.stdout.toString().trim().split("\n");
+
+  if (!date || !shortHash) {
+    return {
+      warning:
+        "Could not parse the most recent git commit date for metadata freshness.",
+    };
+  }
+
+  return { date, shortHash };
+}
+
+function versionDatePrefix(version: string): string | undefined {
+  return version.match(/^\d{4}\.\d{2}\.\d{2}/)?.[0];
+}
+
+test("info.last_updated and info.version reflect the most recent git commit date", () => {
+  const document = loadRulesDocument();
+
+  const commit = latestCommitMetadata();
+  if ("warning" in commit) {
+    console.warn(`Metadata freshness warning: ${commit.warning}`);
+    return;
+  }
+
+  const commitVersionDate = commit.date.replaceAll("-", ".");
+  const lastUpdated = document.info.last_updated;
+  const version = document.info.version;
+  const versionDate = versionDatePrefix(version);
+  const warnings: string[] = [];
+
+  if (lastUpdated !== commit.date) {
+    warnings.push(
+      `info.last_updated is ${JSON.stringify(
+        lastUpdated,
+      )}; expected ${JSON.stringify(commit.date)} from commit ${commit.shortHash}.`,
+    );
+  }
+
+  if (versionDate !== commitVersionDate) {
+    warnings.push(
+      `info.version is ${JSON.stringify(
+        version,
+      )}; expected a ${JSON.stringify(commitVersionDate)} date prefix from commit ${commit.shortHash}.`,
+    );
+  }
+
+  if (warnings.length > 0) {
+    console.warn(
+      [
+        "Metadata freshness warning:",
+        ...warnings.map((warning) => `- ${warning}`),
+        "Update fedramp-consolidated-rules.json metadata before publishing this branch.",
+      ].join("\n"),
+    );
+  }
+});

--- a/tools/tests/metadata-update.test.ts
+++ b/tools/tests/metadata-update.test.ts
@@ -1,77 +1,54 @@
-import { test } from "bun:test";
+import { expect, test } from "bun:test";
 
-import { getRepoRoot } from "../src/config";
-import { loadRulesDocument } from "../src/rules";
+import {
+  collectMetadataFreshnessWarnings,
+  versionDatePrefix,
+} from "../src/metadata-freshness";
+import type { RulesDocument } from "../src/types";
 
-function latestCommitMetadata():
-  | { date: string; shortHash: string }
-  | { warning: string } {
-  const result = Bun.spawnSync({
-    cmd: ["git", "log", "-1", "--format=%cs%n%h"],
-    cwd: getRepoRoot(),
-  });
-
-  if (result.exitCode !== 0) {
-    return {
-      warning:
-        "Could not determine the most recent git commit date for metadata freshness.",
-    };
-  }
-
-  const [date, shortHash] = result.stdout.toString().trim().split("\n");
-
-  if (!date || !shortHash) {
-    return {
-      warning:
-        "Could not parse the most recent git commit date for metadata freshness.",
-    };
-  }
-
-  return { date, shortHash };
+function testDocument(version: string, lastUpdated: string): RulesDocument {
+  return {
+    info: {
+      title: "Test",
+      description: "Test",
+      version,
+      last_updated: lastUpdated,
+    },
+    FRD: { info: {}, data: { all: {} } },
+    FRR: {},
+    KSI: {},
+  } as RulesDocument;
 }
 
-function versionDatePrefix(version: string): string | undefined {
-  return version.match(/^\d{4}\.\d{2}\.\d{2}/)?.[0];
-}
+test("metadata freshness warnings detect stale info.last_updated and info.version dates", () => {
+  const warnings = collectMetadataFreshnessWarnings(
+    testDocument("2026.05.28.01-preview", "2026-05-28"),
+    { date: "2026-05-29", shortHash: "abc1234" },
+  );
 
-test("info.last_updated and info.version reflect the most recent git commit date", () => {
-  const document = loadRulesDocument();
+  expect(warnings).toEqual([
+    {
+      field: "info.last_updated",
+      message:
+        'info.last_updated is "2026-05-28"; expected "2026-05-29" from commit abc1234.',
+    },
+    {
+      field: "info.version",
+      message:
+        'info.version is "2026.05.28.01-preview"; expected a "2026.05.29" date prefix from commit abc1234.',
+    },
+  ]);
+});
 
-  const commit = latestCommitMetadata();
-  if ("warning" in commit) {
-    console.warn(`Metadata freshness warning: ${commit.warning}`);
-    return;
-  }
+test("metadata freshness warnings accept matching date metadata", () => {
+  expect(
+    collectMetadataFreshnessWarnings(
+      testDocument("2026.05.29.01-preview", "2026-05-29"),
+      { date: "2026-05-29", shortHash: "abc1234" },
+    ),
+  ).toEqual([]);
+});
 
-  const commitVersionDate = commit.date.replaceAll("-", ".");
-  const lastUpdated = document.info.last_updated;
-  const version = document.info.version;
-  const versionDate = versionDatePrefix(version);
-  const warnings: string[] = [];
-
-  if (lastUpdated !== commit.date) {
-    warnings.push(
-      `info.last_updated is ${JSON.stringify(
-        lastUpdated,
-      )}; expected ${JSON.stringify(commit.date)} from commit ${commit.shortHash}.`,
-    );
-  }
-
-  if (versionDate !== commitVersionDate) {
-    warnings.push(
-      `info.version is ${JSON.stringify(
-        version,
-      )}; expected a ${JSON.stringify(commitVersionDate)} date prefix from commit ${commit.shortHash}.`,
-    );
-  }
-
-  if (warnings.length > 0) {
-    console.warn(
-      [
-        "Metadata freshness warning:",
-        ...warnings.map((warning) => `- ${warning}`),
-        "Update fedramp-consolidated-rules.json metadata before publishing this branch.",
-      ].join("\n"),
-    );
-  }
+test("versionDatePrefix reads the leading date from preview versions", () => {
+  expect(versionDatePrefix("2026.05.29.01-preview")).toBe("2026.05.29");
 });

--- a/tools/tests/primary-keywords.test.ts
+++ b/tools/tests/primary-keywords.test.ts
@@ -1,9 +1,0 @@
-import { expect, test } from "bun:test";
-
-import { findPrimaryKeywordIssues } from "../src/keywords";
-import { loadRulesDocument } from "../src/rules";
-
-test("all primary keywords match the first normative keyword in each statement", () => {
-  const issues = findPrimaryKeywordIssues(loadRulesDocument());
-  expect(issues).toEqual([]);
-});

--- a/tools/tests/property-order.test.ts
+++ b/tools/tests/property-order.test.ts
@@ -8,7 +8,7 @@ import {
 import { loadRulesDocument, loadSchemaDocument } from "../src/rules";
 import type { RulesDocument } from "../src/types";
 
-test("the consolidated rules document follows the schema-defined property order", () => {
+test("the consolidated rules document follows the configured property order", () => {
   const issues = collectPropertyOrderIssues(
     loadRulesDocument(),
     loadSchemaDocument(),
@@ -139,6 +139,62 @@ test("property order fixes sort FRD shared definitions by term instead of ID", (
     "FRD-MMM",
     "FRD-AAA",
   ]);
+});
+
+test("property order fixes alphabetize FRR and KSI primary objects", () => {
+  const document = {
+    FRR: {
+      VDR: { info: {}, data: {} },
+      CDS: { info: {}, data: {} },
+      CMT: { info: {}, data: {} },
+    },
+    KSI: {
+      MLA: {
+        id: "KSI-MLA",
+        name: "Monitoring, Logging, and Auditing",
+        web_name: "Monitoring, Logging, and Auditing",
+        short_name: "MLA",
+        status: "stable",
+        indicators: {},
+      },
+      CNA: {
+        id: "KSI-CNA",
+        name: "Cloud Native Architecture",
+        web_name: "Cloud Native Architecture",
+        short_name: "CNA",
+        status: "stable",
+        indicators: {},
+      },
+      CMT: {
+        id: "KSI-CMT",
+        name: "Configuration Management",
+        web_name: "Configuration Management",
+        short_name: "CMT",
+        status: "stable",
+        indicators: {},
+      },
+    },
+  } as unknown as RulesDocument;
+
+  const schema = loadSchemaDocument();
+  const checkIssues = collectPropertyOrderIssues(document, schema);
+  expect(checkIssues).toEqual([
+    {
+      path: "FRR",
+      actualOrder: ["VDR", "CDS", "CMT"],
+      expectedOrder: ["CDS", "CMT", "VDR"],
+    },
+    {
+      path: "KSI",
+      actualOrder: ["MLA", "CNA", "CMT"],
+      expectedOrder: ["CMT", "CNA", "MLA"],
+    },
+  ]);
+
+  const fixed = fixPropertyOrder(document, schema);
+  expect(fixed.fixedCount).toBe(2);
+  expect(Object.keys(fixed.document.FRR)).toEqual(["CDS", "CMT", "VDR"]);
+  expect(Object.keys(fixed.document.KSI)).toEqual(["CMT", "CNA", "MLA"]);
 });
 
 test("property order fixes use schema propertyNames enum order for FRR subsets and subset groups", () => {

--- a/tools/tests/schema.test.ts
+++ b/tools/tests/schema.test.ts
@@ -27,6 +27,20 @@ function effectiveEntry() {
   };
 }
 
+function subsetDefinition(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "Common",
+    description: "Common subset.",
+    applicability: {
+      types: ["20x", "Rev5"],
+      paths: ["Program", "Agency"],
+      classes: ["A", "B", "C", "D"],
+      affects: ["Providers"],
+    },
+    ...overrides,
+  };
+}
+
 function minimalRulesDocument(): RulesDocument {
   return {
     info: {
@@ -178,18 +192,36 @@ function expectSchemaRejects(
 test("the schema accepts common FRR info with certification-specific subsets and flows", () => {
   const document = minimalRulesDocument();
   (document as any).FRR.ABC.info.subsets = {
-    CSO: { name: "Common", description: "Common subset." },
+    CSO: subsetDefinition(),
   };
   (document as any).FRR.ABC.info.flows = ["Common flow"];
   (document as any).FRR.ABC.info["20x"] = {
     subsets: {
-      CSX: { name: "20x", description: "20x subset." },
+      CSX: subsetDefinition({
+        name: "20x",
+        description: "20x subset.",
+        applicability: {
+          types: ["20x"],
+          paths: ["Program"],
+          classes: ["A", "B", "C", "D"],
+          affects: ["Providers"],
+        },
+      }),
     },
     flows: ["20x flow"],
   };
   (document as any).FRR.ABC.info.rev5 = {
     subsets: {
-      CSF: { name: "Rev5", description: "Rev5 subset." },
+      CSF: subsetDefinition({
+        name: "Rev5",
+        description: "Rev5 subset.",
+        applicability: {
+          types: ["Rev5"],
+          paths: ["Program", "Agency"],
+          classes: ["A", "B", "C", "D"],
+          affects: ["Providers"],
+        },
+      }),
     },
     flows: ["Rev5 flow"],
   };
@@ -198,6 +230,87 @@ test("the schema accepts common FRR info with certification-specific subsets and
     "FRR certification-specific subsets and flows overlay common info",
     document,
   );
+});
+
+test("the schema requires FRR subset applicability fields", () => {
+  const missingApplicabilityDocument = minimalRulesDocument();
+  (missingApplicabilityDocument as any).FRR.ABC.info.subsets = {
+    CSO: { name: "Common", description: "Common subset." },
+  };
+
+  expectSchemaRejects(
+    "FRR subset without applicability metadata",
+    missingApplicabilityDocument,
+  );
+
+  const missingFieldDocument = minimalRulesDocument();
+  (missingFieldDocument as any).FRR.ABC.info.subsets = {
+    CSO: subsetDefinition({
+      applicability: {
+        types: ["20x", "Rev5"],
+        paths: ["Program", "Agency"],
+        affects: ["Providers"],
+      },
+    }),
+  };
+
+  expectSchemaRejects(
+    "FRR subset applicability without classes",
+    missingFieldDocument,
+  );
+});
+
+test("the schema permits empty type, path, and class applicability arrays", () => {
+  const document = minimalRulesDocument();
+  (document as any).FRR.ABC.info.subsets = {
+    IAS: subsetDefinition({
+      name: "Independent Assessors",
+      description: "Non-certification subset.",
+      applicability: {
+        types: [],
+        paths: [],
+        classes: [],
+        affects: ["Assessors"],
+      },
+    }),
+  };
+
+  expectSchemaAccepts(
+    "FRR subset applicability with empty non-affects arrays",
+    document,
+  );
+});
+
+test("the schema rejects unsupported FRR subset applicability values", () => {
+  const document = minimalRulesDocument();
+  (document as any).FRR.ABC.info.subsets = {
+    CSO: subsetDefinition({
+      applicability: {
+        types: ["Rev4"],
+        paths: ["Program"],
+        classes: ["A"],
+        affects: ["Providers"],
+      },
+    }),
+  };
+
+  expectSchemaRejects("FRR subset applicability with unknown type", document);
+});
+
+test("the schema requires FRR subset applicability affects to be populated", () => {
+  const document = minimalRulesDocument();
+  (document as any).FRR.ABC.info.subsets = {
+    CSO: subsetDefinition({
+      applicability: {
+        types: ["20x", "Rev5"],
+        paths: ["Program", "Agency"],
+        classes: ["A", "B", "C", "D"],
+        affects: [],
+      },
+    }),
+  };
+
+  expectSchemaRejects("FRR subset applicability without affects", document);
 });
 
 test("the schema requires certification-specific effective entries to be paired", () => {

--- a/tools/tests/schema.test.ts
+++ b/tools/tests/schema.test.ts
@@ -11,7 +11,7 @@ import type { RulesDocument } from "../src/types";
 
 type MutableRuleEntity = Record<string, unknown> & {
   statement?: string;
-  primary_key_word?: string;
+  force?: string;
   varies_by_class?: Record<string, unknown>;
 };
 
@@ -86,7 +86,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function hasSingleRequirementStatement(entity: MutableRuleEntity): boolean {
   return (
     typeof entity.statement === "string" &&
-    typeof entity.primary_key_word === "string" &&
+    typeof entity.force === "string" &&
     !isRecord(entity.varies_by_class)
   );
 }
@@ -363,11 +363,11 @@ test("the schema rejects FRR requirements that mix top-level and class-specific 
   singleStatementRequirement.varies_by_class = {
     b: {
       statement: singleStatementRequirement.statement,
-      primary_key_word: singleStatementRequirement.primary_key_word,
+      force: singleStatementRequirement.force,
     },
     c: {
       statement: singleStatementRequirement.statement,
-      primary_key_word: singleStatementRequirement.primary_key_word,
+      force: singleStatementRequirement.force,
     },
   };
 

--- a/tools/tests/terms.test.ts
+++ b/tools/tests/terms.test.ts
@@ -104,7 +104,7 @@ test("term sync updates terms without appending to updated history by default", 
                 name: "Test requirement",
                 affects: ["Providers"],
                 statement: "Providers MUST notify an agency.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 terms: [],
                 updated: [
                   {
@@ -163,7 +163,7 @@ test("term sync prepends an updated entry when comment mode is enabled", () => {
                 name: "Test requirement",
                 affects: ["Providers"],
                 statement: "Providers MUST notify an agency.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 terms: [],
                 updated: [
                   {
@@ -225,7 +225,7 @@ test("term sync appends to an existing comment when comment mode is enabled and 
                 name: "Test requirement",
                 affects: ["Providers"],
                 statement: "Providers MUST notify an agency.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 terms: [],
                 updated: [
                   {

--- a/tools/tests/zz-consistency-report.test.ts
+++ b/tools/tests/zz-consistency-report.test.ts
@@ -2,6 +2,8 @@ import { expect, test } from "bun:test";
 
 import {
   collectConsistencyChecks,
+  collectDuplicateRuleIdIssues,
+  collectDuplicateRuleNameIssues,
   collectFrr20xSubsetApplicabilityWarnings,
   collectFrrSubsetForceOrderWarnings,
   collectFrrSubsetApplicabilityAffectsIssues,
@@ -19,6 +21,94 @@ test("consistency validation report", () => {
   if (checks.some((check) => check.issues.length > 0)) {
     throw new Error(formatConsistencyReport(checks));
   }
+});
+
+test("duplicate rule IDs fail consistency validation", () => {
+  const document = {
+    FRD: {
+      data: {
+        all: {},
+      },
+    },
+    FRR: {
+      ABC: {
+        data: {
+          all: {
+            CSO: {
+              "ABC-CSO-001": {
+                name: "Common Rule",
+                statement: "Providers MUST do the thing.",
+                force: "MUST",
+                affects: ["Providers"],
+              },
+            },
+          },
+          rev5: {
+            CSO: {
+              "ABC-CSO-001": {
+                name: "Rev5 Rule",
+                statement: "Providers MUST do the other thing.",
+                force: "MUST",
+                affects: ["Providers"],
+              },
+            },
+          },
+        },
+      },
+    },
+    KSI: {},
+  } as unknown as RulesDocument;
+
+  expect(collectDuplicateRuleIdIssues(document)).toEqual([
+    {
+      location: "FRR.ABC.data.all.CSO.ABC-CSO-001",
+      message:
+        "requirement ID ABC-CSO-001 appears in multiple locations: " +
+        "FRR.ABC.data.all.CSO.ABC-CSO-001, FRR.ABC.data.rev5.CSO.ABC-CSO-001.",
+    },
+  ]);
+});
+
+test("duplicate rule names fail consistency validation", () => {
+  const document = {
+    FRD: {
+      data: {
+        all: {},
+      },
+    },
+    FRR: {
+      ABC: {
+        data: {
+          all: {
+            CSO: {
+              "ABC-CSO-001": {
+                name: "Shared Rule Name",
+                statement: "Providers MUST do the thing.",
+                force: "MUST",
+                affects: ["Providers"],
+              },
+              "ABC-CSO-002": {
+                name: "Shared Rule Name",
+                statement: "Providers MUST do the other thing.",
+                force: "MUST",
+                affects: ["Providers"],
+              },
+            },
+          },
+        },
+      },
+    },
+    KSI: {},
+  } as unknown as RulesDocument;
+
+  expect(collectDuplicateRuleNameIssues(document)).toEqual([
+    {
+      location: "FRR.ABC.data.all.CSO.ABC-CSO-001",
+      message:
+        'requirement name "Shared Rule Name" appears in multiple locations: ' +
+        "FRR.ABC.data.all.CSO.ABC-CSO-001, FRR.ABC.data.all.CSO.ABC-CSO-002.",
+    },
+  ]);
 });
 
 test("FRR subset declarations include certification-specific info subsets", () => {

--- a/tools/tests/zz-consistency-report.test.ts
+++ b/tools/tests/zz-consistency-report.test.ts
@@ -2,6 +2,8 @@ import { expect, test } from "bun:test";
 
 import {
   collectConsistencyChecks,
+  collectFrr20xSubsetApplicabilityWarnings,
+  collectFrrSubsetApplicabilityAffectsIssues,
   collectFrrSubsetDeclarationIssues,
   collectInlineRuleDisplayNameIssues,
   collectRelatedRuleReferenceIssues,
@@ -55,6 +57,153 @@ test("FRR subset declarations include certification-specific info subsets", () =
   } as unknown as RulesDocument;
 
   expect(collectFrrSubsetDeclarationIssues(document)).toEqual([]);
+});
+
+test("FRR subset applicability affects match corresponding requirement affects", () => {
+  const document = {
+    FRR: {
+      ABC: {
+        info: {
+          subsets: {
+            FRP: {
+              name: "FedRAMP",
+              description: "FedRAMP subset.",
+              applicability: {
+                types: ["20x", "Rev5"],
+                paths: ["Program", "Agency"],
+                classes: ["A", "B", "C", "D"],
+                affects: ["Providers"],
+              },
+            },
+          },
+        },
+        data: {
+          all: {
+            FRP: {
+              "ABC-FRP-AAA": {
+                name: "FedRAMP Rule",
+                statement: "FedRAMP MUST do the thing.",
+                primary_key_word: "MUST",
+                affects: ["FedRAMP"],
+              },
+            },
+          },
+          rev5: {
+            FRP: {
+              "ABC-FRP-BBB": {
+                name: "Agency Rule",
+                statement: "Agencies MUST do the thing.",
+                primary_key_word: "MUST",
+                affects: ["Agencies"],
+              },
+            },
+          },
+        },
+      },
+    },
+  } as unknown as RulesDocument;
+
+  expect(collectFrrSubsetApplicabilityAffectsIssues(document)).toEqual([
+    {
+      location: "FRR.ABC.info.subsets.FRP.applicability.affects",
+      message:
+        "applicability.affects must match corresponding requirement affects arrays. " +
+        "Expected: Agencies, FedRAMP; found: Providers.",
+    },
+  ]);
+
+  (document.FRR.ABC!.info as any).subsets.FRP.applicability.affects = [
+    "Agencies",
+    "FedRAMP",
+  ];
+
+  expect(collectFrrSubsetApplicabilityAffectsIssues(document)).toEqual([]);
+});
+
+test("FRR subset applicability affects require a populated affects array when rules exist", () => {
+  const document = {
+    FRR: {
+      ABC: {
+        info: {
+          subsets: {
+            FRP: {
+              name: "FedRAMP",
+              description: "FedRAMP subset.",
+              applicability: {
+                types: ["20x", "Rev5"],
+                paths: ["Program", "Agency"],
+                classes: ["A", "B", "C", "D"],
+                affects: [],
+              },
+            },
+          },
+        },
+        data: {
+          all: {
+            FRP: {
+              "ABC-FRP-AAA": {
+                name: "FedRAMP Rule",
+                statement: "FedRAMP MUST do the thing.",
+                primary_key_word: "MUST",
+                affects: ["FedRAMP"],
+              },
+            },
+          },
+        },
+      },
+    },
+  } as unknown as RulesDocument;
+
+  expect(collectFrrSubsetApplicabilityAffectsIssues(document)).toEqual([
+    {
+      location: "FRR.ABC.info.subsets.FRP.applicability.affects",
+      message:
+        "applicability.affects must list every party used by corresponding requirement affects arrays. " +
+        "Expected: FedRAMP.",
+    },
+  ]);
+});
+
+test("X-suffix FRR subsets warn unless they are 20x Program only", () => {
+  const document = {
+    FRR: {
+      ABC: {
+        info: {
+          subsets: {
+            CSX: {
+              name: "20x Provider",
+              description: "20x subset.",
+              applicability: {
+                types: ["20x", "Rev5"],
+                paths: ["Program", "Agency"],
+                classes: ["A", "B", "C", "D"],
+                affects: ["Providers"],
+              },
+            },
+          },
+        },
+        data: {},
+      },
+    },
+  } as unknown as RulesDocument;
+
+  expect(collectFrr20xSubsetApplicabilityWarnings(document)).toEqual([
+    {
+      location: "FRR.ABC.info.subsets.CSX.applicability.types",
+      message:
+        "20x-specific subset warning: subset CSX ends in X, so applicability.types should only include 20x; found: 20x, Rev5.",
+    },
+    {
+      location: "FRR.ABC.info.subsets.CSX.applicability.paths",
+      message:
+        "20x-specific subset warning: subset CSX ends in X, so applicability.paths should only include Program; found: Program, Agency.",
+    },
+  ]);
+
+  (document.FRR.ABC!.info as any).subsets.CSX.applicability.types = ["20x"];
+  (document.FRR.ABC!.info as any).subsets.CSX.applicability.paths = ["Program"];
+
+  expect(collectFrr20xSubsetApplicabilityWarnings(document)).toEqual([]);
 });
 
 test("related rule references cover inline FRR IDs in requirement text fields", () => {

--- a/tools/tests/zz-consistency-report.test.ts
+++ b/tools/tests/zz-consistency-report.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "bun:test";
 import {
   collectConsistencyChecks,
   collectFrr20xSubsetApplicabilityWarnings,
+  collectFrrSubsetPrimaryKeywordOrderWarnings,
   collectFrrSubsetApplicabilityAffectsIssues,
   collectFrrSubsetDeclarationIssues,
   collectInlineRuleDisplayNameIssues,
@@ -204,6 +205,107 @@ test("X-suffix FRR subsets warn unless they are 20x Program only", () => {
   (document.FRR.ABC!.info as any).subsets.CSX.applicability.paths = ["Program"];
 
   expect(collectFrr20xSubsetApplicabilityWarnings(document)).toEqual([]);
+});
+
+test("FRR subset primary keyword order warnings detect out-of-order groups", () => {
+  const document = {
+    FRR: {
+      ABC: {
+        info: {
+          subsets: {
+            CSO: { name: "Provider", description: "Provider subset." },
+          },
+        },
+        data: {
+          all: {
+            CSO: {
+              "ABC-CSO-001": {
+                name: "Must Rule",
+                statement: "Providers MUST do the first thing.",
+                primary_key_word: "MUST",
+                affects: ["Providers"],
+              },
+              "ABC-CSO-002": {
+                name: "Should Rule",
+                statement: "Providers SHOULD do the second thing.",
+                primary_key_word: "SHOULD",
+                affects: ["Providers"],
+              },
+              "ABC-CSO-003": {
+                name: "Must Not Rule",
+                statement: "Providers MUST NOT do the third thing.",
+                primary_key_word: "MUST NOT",
+                affects: ["Providers"],
+              },
+            },
+          },
+        },
+      },
+    },
+  } as unknown as RulesDocument;
+
+  expect(collectFrrSubsetPrimaryKeywordOrderWarnings(document)).toEqual([
+    {
+      location: "FRR.ABC.data.all.CSO",
+      message:
+        "expected keyword groups MUST, MUST NOT, SHOULD, SHOULD NOT, MAY; found MUST, SHOULD, MUST NOT.",
+    },
+  ]);
+
+  const orderedRequirements = document.FRR.ABC!.data.all!.CSO!;
+  const shouldRequirement = orderedRequirements["ABC-CSO-002"]!;
+  delete orderedRequirements["ABC-CSO-002"];
+  orderedRequirements["ABC-CSO-002"] = shouldRequirement;
+
+  expect(collectFrrSubsetPrimaryKeywordOrderWarnings(document)).toEqual([]);
+});
+
+test("FRR subset primary keyword order warnings use class-specific keywords", () => {
+  const document = {
+    FRR: {
+      ABC: {
+        info: {
+          subsets: {
+            CSO: { name: "Provider", description: "Provider subset." },
+          },
+        },
+        data: {
+          all: {
+            CSO: {
+              "ABC-CSO-001": {
+                name: "Class Should Rule",
+                varies_by_class: {
+                  a: {
+                    statement: "Class A providers SHOULD do the first thing.",
+                    primary_key_word: "SHOULD",
+                  },
+                },
+                affects: ["Providers"],
+              },
+              "ABC-CSO-002": {
+                name: "Class Must Rule",
+                varies_by_class: {
+                  a: {
+                    statement: "Class A providers MUST do the second thing.",
+                    primary_key_word: "MUST",
+                  },
+                },
+                affects: ["Providers"],
+              },
+            },
+          },
+        },
+      },
+    },
+  } as unknown as RulesDocument;
+
+  expect(collectFrrSubsetPrimaryKeywordOrderWarnings(document)).toEqual([
+    {
+      location: "FRR.ABC.data.all.CSO",
+      message:
+        "expected keyword groups MUST, MUST NOT, SHOULD, SHOULD NOT, MAY; found SHOULD, MUST.",
+    },
+  ]);
 });
 
 test("related rule references cover inline FRR IDs in requirement text fields", () => {

--- a/tools/tests/zz-consistency-report.test.ts
+++ b/tools/tests/zz-consistency-report.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "bun:test";
 import {
   collectConsistencyChecks,
   collectFrr20xSubsetApplicabilityWarnings,
-  collectFrrSubsetPrimaryKeywordOrderWarnings,
+  collectFrrSubsetForceOrderWarnings,
   collectFrrSubsetApplicabilityAffectsIssues,
   collectFrrSubsetDeclarationIssues,
   collectInlineRuleDisplayNameIssues,
@@ -84,7 +84,7 @@ test("FRR subset applicability affects match corresponding requirement affects",
               "ABC-FRP-AAA": {
                 name: "FedRAMP Rule",
                 statement: "FedRAMP MUST do the thing.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["FedRAMP"],
               },
             },
@@ -94,7 +94,7 @@ test("FRR subset applicability affects match corresponding requirement affects",
               "ABC-FRP-BBB": {
                 name: "Agency Rule",
                 statement: "Agencies MUST do the thing.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Agencies"],
               },
             },
@@ -145,7 +145,7 @@ test("FRR subset applicability affects require a populated affects array when ru
               "ABC-FRP-AAA": {
                 name: "FedRAMP Rule",
                 statement: "FedRAMP MUST do the thing.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["FedRAMP"],
               },
             },
@@ -207,7 +207,7 @@ test("X-suffix FRR subsets warn unless they are 20x Program only", () => {
   expect(collectFrr20xSubsetApplicabilityWarnings(document)).toEqual([]);
 });
 
-test("FRR subset primary keyword order warnings detect out-of-order groups", () => {
+test("FRR subset force order warnings detect out-of-order groups", () => {
   const document = {
     FRR: {
       ABC: {
@@ -222,19 +222,19 @@ test("FRR subset primary keyword order warnings detect out-of-order groups", () 
               "ABC-CSO-001": {
                 name: "Must Rule",
                 statement: "Providers MUST do the first thing.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
               "ABC-CSO-002": {
                 name: "Should Rule",
                 statement: "Providers SHOULD do the second thing.",
-                primary_key_word: "SHOULD",
+                force: "SHOULD",
                 affects: ["Providers"],
               },
               "ABC-CSO-003": {
                 name: "Must Not Rule",
                 statement: "Providers MUST NOT do the third thing.",
-                primary_key_word: "MUST NOT",
+                force: "MUST NOT",
                 affects: ["Providers"],
               },
             },
@@ -244,11 +244,11 @@ test("FRR subset primary keyword order warnings detect out-of-order groups", () 
     },
   } as unknown as RulesDocument;
 
-  expect(collectFrrSubsetPrimaryKeywordOrderWarnings(document)).toEqual([
+  expect(collectFrrSubsetForceOrderWarnings(document)).toEqual([
     {
       location: "FRR.ABC.data.all.CSO",
       message:
-        "expected keyword groups MUST, MUST NOT, SHOULD, SHOULD NOT, MAY; found MUST, SHOULD, MUST NOT.",
+        "expected force groups MUST, MUST NOT, SHOULD, SHOULD NOT, MAY; found MUST, SHOULD, MUST NOT.",
     },
   ]);
 
@@ -257,10 +257,10 @@ test("FRR subset primary keyword order warnings detect out-of-order groups", () 
   delete orderedRequirements["ABC-CSO-002"];
   orderedRequirements["ABC-CSO-002"] = shouldRequirement;
 
-  expect(collectFrrSubsetPrimaryKeywordOrderWarnings(document)).toEqual([]);
+  expect(collectFrrSubsetForceOrderWarnings(document)).toEqual([]);
 });
 
-test("FRR subset primary keyword order warnings use class-specific keywords", () => {
+test("FRR subset force order warnings use class-specific force values", () => {
   const document = {
     FRR: {
       ABC: {
@@ -277,7 +277,7 @@ test("FRR subset primary keyword order warnings use class-specific keywords", ()
                 varies_by_class: {
                   a: {
                     statement: "Class A providers SHOULD do the first thing.",
-                    primary_key_word: "SHOULD",
+                    force: "SHOULD",
                   },
                 },
                 affects: ["Providers"],
@@ -287,7 +287,7 @@ test("FRR subset primary keyword order warnings use class-specific keywords", ()
                 varies_by_class: {
                   a: {
                     statement: "Class A providers MUST do the second thing.",
-                    primary_key_word: "MUST",
+                    force: "MUST",
                   },
                 },
                 affects: ["Providers"],
@@ -299,11 +299,11 @@ test("FRR subset primary keyword order warnings use class-specific keywords", ()
     },
   } as unknown as RulesDocument;
 
-  expect(collectFrrSubsetPrimaryKeywordOrderWarnings(document)).toEqual([
+  expect(collectFrrSubsetForceOrderWarnings(document)).toEqual([
     {
       location: "FRR.ABC.data.all.CSO",
       message:
-        "expected keyword groups MUST, MUST NOT, SHOULD, SHOULD NOT, MAY; found SHOULD, MUST.",
+        "expected force groups MUST, MUST NOT, SHOULD, SHOULD NOT, MAY; found SHOULD, MUST.",
     },
   ]);
 });
@@ -327,43 +327,43 @@ test("related rule references cover inline FRR IDs in requirement text fields", 
                 following_information_bullets: [
                   "Escalate when ABC-CSO-FFF applies.",
                 ],
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
               "ABC-CSO-BBB": {
                 name: "Target Rule B",
                 statement: "Providers MUST do the thing.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
               "ABC-CSO-CCC": {
                 name: "Target Rule C",
                 statement: "Providers MUST do the other thing.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
               "ABC-CSO-DDD": {
                 name: "Target Rule D",
                 statement: "Providers MUST do the final thing.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
               "ABC-CSO-EEE": {
                 name: "Target Rule E",
                 statement: "Providers MUST document the outcome.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
               "ABC-CSO-FFF": {
                 name: "Target Rule F",
                 statement: "Providers MUST escalate the outcome.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
               "ABC-CSO-GGG": {
                 name: "Target Rule G",
                 statement: "Providers MUST preserve the outcome.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
             },
@@ -444,11 +444,11 @@ test("related rule references cover class-specific statements and following info
                     statement:
                       "Providers with Class B MUST follow ABC-CSO-BBB.",
                     following_information: ["Document ABC-CSO-CCC evidence."],
-                    primary_key_word: "MUST",
+                    force: "MUST",
                   },
                   c: {
                     statement: "Providers with Class C MUST do the thing.",
-                    primary_key_word: "MUST",
+                    force: "MUST",
                   },
                 },
                 related: ["ABC-CSO-BBB"],
@@ -457,13 +457,13 @@ test("related rule references cover class-specific statements and following info
               "ABC-CSO-BBB": {
                 name: "Target Rule B",
                 statement: "Providers MUST do the thing.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
               "ABC-CSO-CCC": {
                 name: "Target Rule C",
                 statement: "Providers MUST document the evidence.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
             },
@@ -494,13 +494,13 @@ test("related rule references reject IDs that are not mentioned anywhere", () =>
                 name: "Source Rule",
                 statement: "Providers MUST do the source thing.",
                 related: ["ABC-CSO-BBB"],
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
               "ABC-CSO-BBB": {
                 name: "Unmentioned Rule",
                 statement: "Providers MUST do the unmentioned thing.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
             },
@@ -532,25 +532,25 @@ test("inline rule IDs are followed by their rule names in parentheses", () => {
                 statement:
                   "Providers MUST use ABC-CSO-BBB and ABC-CSO-CCC Target Rule C.",
                 note: "ABC-CSO-DDD (Target Rule D) is already formatted.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
               "ABC-CSO-BBB": {
                 name: "Target Rule B",
                 statement: "Providers MUST do the missing-name thing.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
               "ABC-CSO-CCC": {
                 name: "Target Rule C",
                 statement: "Providers MUST do the unparenthesized-name thing.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
               "ABC-CSO-DDD": {
                 name: "Target Rule D",
                 statement: "Providers MUST do the correctly formatted thing.",
-                primary_key_word: "MUST",
+                force: "MUST",
                 affects: ["Providers"],
               },
             },


### PR DESCRIPTION
## Rules Content Changes

- `info.version` changed from `2026.05.25.01-preview` to `2026.05.31.01-preview`, and `info.last_updated` changed from `2026-05-25` to `2026-05-31`.
- `FRD-FMV` adds the alternate term `fully mitigate vulnerabilities`.
- `FRD-PMV` adds the alternate term `partially mitigate vulnerabilities`.
- `FRD-RMV` adds the alternate term `remediate vulnerabilities`.
- `AGU-USE-NFC` is renamed from `Notify FedRAMP of Concerns` to `Notify FedRAMP of Monitoring Concerns`.
- `CCM-AGM-NFR` was removed from Continuous Collaborative Monitoring.
- `CCM-AGM-NPC` was removed from Continuous Collaborative Monitoring.
- `CCM-OCR-RPS` is renamed from `Responsible Public Sharing` to `Responsible Public Certification Report Sharing`.
- `CDS-CSO-RPS` is renamed from `Responsible Public Sharing` to `Responsible Public Package Sharing`.
- `CDS-TRC-HMR` is renamed from `Human and Machine-Readable` to `Human and Machine-Readable Certification Data`.
- `CDS-UTC-PGD` is renamed from `Public Guidance` to `Public Guidance for Certification Data`.
- `FRC-CLA-AFR` updates its following-information display reference for `CDS-UTC-PGD` to use `Public Guidance for Certification Data`.
- Structural: `FRC-CSF-PMV` moved from `FRR.FRC.data.rev5.CSF` to new rule `VDR-TFR-MVF` under `FRR.VDR.data.rev5.TFR`, preserving the Rev5 class-specific persistent machine verification and validation cadence.
- Structural: `FRC-CSX-PMV` moved from `FRR.FRC.data.20x.CSX` to new rule `VDR-TFR-MVX` under `FRR.VDR.data.20x.TFR`, preserving the 20x class-specific persistent machine verification and validation cadence.
- Structural: `FRC-CSO-NMV` moved from `FRR.FRC.data.all.CSO` to new rule `VDR-TFR-NMV` under `FRR.VDR.data.all.TFR`, preserving the non-machine verification and validation requirement.
- Structural: `FRC-CSO-FAV` moved from `FRR.FRC.data.all.CSO` to new rule `VDR-CSO-FAV` under `FRR.VDR.data.all.CSO`, with the statement narrowed to failures in vulnerability detection and response processes.
- `FRC-CSO-PVV` was removed as a standalone FRC rule; structurally, the persistent verification and validation concept is now incorporated into `VDR-CSO-DET`.
- `SCG-CSO-PUB` is renamed from `Public Guidance` to `Public Secure Configuration Guidance`.
- `SCN-CSO-HRM` is renamed from `Human and Machine-Readable` to `Human and Machine-Readable Notifications`.
- `VDR-CSO-DET` expands vulnerability detection to include penetration testing, incident response, automated control testing, and persistent verification and validation of information resources and processes.
- `VDR-CSO-FAV` adds the VDR rule requiring providers to treat problems or failures with vulnerability detection and response processes as vulnerabilities.
- `VDR-CSO-RES` converts a single note into expanded notes that distinguish partial mitigation, full mitigation, and remediation, and adds the corresponding FRD terms.
- `VDR-TFR-IRI` updates class-specific incident-treatment wording to use `Partially Mitigated Vulnerability` terminology for internet-reachable likely exploitable vulnerabilities at N3 or below.
- `VDR-TFR-NRI` updates class-specific incident-treatment wording to use `Partially Mitigated Vulnerability` terminology for non-internet-reachable likely exploitable vulnerabilities at N4 or below.
- `VDR-TFR-PVR` updates class-specific vulnerability response wording to use the defined partial mitigation, full mitigation, and remediation terms without changing the PAIN timeframes.

## Schema And Structure Changes

- **Breaking:** FRR requirement force metadata changed from old shape `primary_key_word` to new shape `force`, including inside `varies_by_class`; consumers, validators, exporters, and queries reading `primary_key_word` must be updated.
- **Breaking:** The schema definition changed from `primary_key_word_enum` to `force_enum`; tooling resolving the old `$defs.primary_key_word_enum` reference must be updated.
- **Breaking:** FRR subset definitions changed from old shape `{ name, description }` to new required shape `{ name, description, applicability }`; strict consumers or producers of subset metadata must handle `applicability.types`, `applicability.paths`, `applicability.classes`, and `applicability.affects`.
- Structural: all 63 FRR subset declarations now include applicability metadata with controlled values for certification type, path, class, and affected party.
- Structural: the rules JSON was reordered to follow updated property-order rules, including alphabetical primary ordering for FRR/KSI objects and schema-driven ordering for requirement properties.

## Tooling And Test Changes

- **Breaking:** `tools/export-spreadsheet.ts` changes spreadsheet output columns from `Primary Keyword` / `Keyword (Class X)` to `Force` / `Force (Class X)`; consumers of exported spreadsheets must update column references.
- `tools/src/keywords.ts`, `tools/package.json`, and tests rename primary-keyword validation to force validation, replacing `test:keywords` with `test:force`.
- `tools/src/types.ts` now models `force` and adds FRR subset applicability types.
- `tools/src/consistency.ts` adds duplicate rule ID/name checks, FRR subset applicability-affects validation, 20x X-suffix applicability warnings, and FRR subset force-order warnings.
- `tools/src/fix.ts` and `tools/fix.ts` add the `subset-affects` fix scope and include it in auto-fix planning/application.
- `tools/src/metadata-freshness.ts` and `tools/test.ts` add metadata freshness warnings comparing `info.last_updated` and `info.version` against the latest commit date.
- `tools/src/property-order.ts` adds alphabetical ordering for top-level FRR and KSI objects and updates property-order reporting language.
- Tests were expanded for schema subset applicability, force validation, metadata freshness, subset-affects fixes, duplicate IDs/names, property ordering, and force-order warnings.
- `tools/README.md` was updated for the new `force` terminology, subset-affects fix command, and ordering checks.
- `AGENTS.md` adds an explicit guardrail requiring user confirmation before editing `fedramp-consolidated-rules.json`, updates FRR guidance from `primary_key_word` to `force`, and clarifies that moved rule content is not automatically a breaking change.
