### PR TITLE
ICP tuning before public notice

### DIFF
--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -2,8 +2,8 @@
   "info": {
     "title": "FedRAMP Consolidated Rules for 2026 Public Preview",
     "description": "This datafile contains the Consolidated Rules for FedRAMP in structured machine-readable text. It includes definitions, requirements, recommendations, and key security indicators.",
-    "version": "2026.05.31.01-preview",
-    "last_updated": "2026-05-31",
+    "version": "2026.06.03.01-preview",
+    "last_updated": "2026-06-03",
     "default_artifacts": {
       "FRR": [
         "Explanation of how the rule is followed, or an explanation of the reason and resulting risk to customers for not following the rule.",
@@ -2024,8 +2024,8 @@
                 }
               ]
             },
-            "CDS-CSO-PAR": {
-              "name": "Public Availability Reporting",
+            "CDS-CSO-AVR": {
+              "name": "Availability Reporting",
               "varies_by_class": {
                 "a": {
                   "statement": "Providers with Class A Certifications SHOULD maintain a web service, available to all necessary parties, that indicates current and historical availability of core services within the cloud service offering over at least the past 30 days, including availability incidents, in both human-readable and machine-readable formats; this service SHOULD be available even if the primary cloud service offering is unavailable.",

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -4205,7 +4205,7 @@
               "name": "Initial Incident Report",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers with Class A Certifications SHOULD responsibly notify all affected parties after identifying FedRAMP Reportable Incidents by providing an Initial Incident Report with as much of the following information that is available at the time of reporting:",
+                  "statement": "Providers with Class A Certifications SHOULD responsibly notify all affected parties after identifying FedRAMP Reportable Incidents by providing an Initial Incident Report with as much of the following information that is available at the time of reporting and/or the current relevant status for each item:",
                   "following_information": [
                     "Contact information for the federal incident response coordinator.",
                     "Provider's internally assigned tracking identifier",
@@ -4256,7 +4256,7 @@
                   }
                 },
                 "b": {
-                  "statement": "Providers with Class B Certifications MUST responsibly notify all affected parties after identifying FedRAMP Reportable Incidents by providing an Initial Incident Report with as much of the following information that is available at the time of reporting:",
+                  "statement": "Providers with Class B Certifications MUST responsibly notify all affected parties after identifying FedRAMP Reportable Incidents by providing an Initial Incident Report with as much of the following information that is available at the time of reporting and/or the current relevant status for each item:",
                   "following_information": [
                     "Contact information for the federal incident response coordinator.",
                     "Provider's internally assigned tracking identifier",
@@ -4307,7 +4307,7 @@
                   }
                 },
                 "c": {
-                  "statement": "Providers with Class C Certifications MUST responsibly notify all affected parties after identifying FedRAMP Reportable Incidents by providing an Initial Incident Report with as much of the following information that is available at the time of reporting:",
+                  "statement": "Providers with Class C Certifications MUST responsibly notify all affected parties after identifying FedRAMP Reportable Incidents by providing an Initial Incident Report with as much of the following information that is available at the time of reporting and/or the current relevant status for each item:",
                   "following_information": [
                     "Contact information for the federal incident response coordinator.",
                     "Provider's internally assigned tracking identifier",
@@ -4358,7 +4358,7 @@
                   }
                 },
                 "d": {
-                  "statement": "Providers with Class D Certifications MUST responsibly notify all affected parties after identifying FedRAMP Reportable Incidents by providing an Initial Incident Report with as much of the following information that is available at the time of reporting:",
+                  "statement": "Providers with Class D Certifications MUST responsibly notify all affected parties after identifying FedRAMP Reportable Incidents by providing an Initial Incident Report with as much of the following information that is available at the time of reporting and/or the current relevant status for each item:",
                   "following_information": [
                     "Contact information for the federal incident response coordinator.",
                     "Provider's internally assigned tracking identifier",
@@ -4447,7 +4447,7 @@
               "name": "Ongoing Incident Reports",
               "varies_by_class": {
                 "a": {
-                  "statement": "Providers with Class A Certifications SHOULD responsibly notify all affected parties of ongoing activity as new information becomes available during incident response for FedRAMP Reportable Incidents, including updates (or lack of updates) to all previously reported information and as much of the the following additional information that is available:",
+                  "statement": "Providers with Class A Certifications SHOULD responsibly notify all affected parties of ongoing activity as new information becomes available during incident response for FedRAMP Reportable Incidents, including updates (or lack of updates) to all previously reported information and as much of the the following additional information that is available and/or the current relevant status for each item:",
                   "following_information": [
                     "Observed incident activity",
                     "Indicators of compromise",
@@ -4495,7 +4495,7 @@
                   }
                 },
                 "b": {
-                  "statement": "Providers with Class B Certifications MUST responsibly notify all affected parties of ongoing activity as new information becomes available during incident response for FedRAMP Reportable Incidents, including updates (or lack of updates) to all previously reported information and as much of the the following additional information that is available:",
+                  "statement": "Providers with Class B Certifications MUST responsibly notify all affected parties of ongoing activity as new information becomes available during incident response for FedRAMP Reportable Incidents, including updates (or lack of updates) to all previously reported information and as much of the the following additional information that is available and/or the current relevant status for each item:",
                   "following_information": [
                     "Observed incident activity",
                     "Indicators of compromise",
@@ -4543,7 +4543,7 @@
                   }
                 },
                 "c": {
-                  "statement": "Providers with Class C Certifications MUST responsibly notify all affected parties of ongoing activity as new information becomes available during incident response for FedRAMP Reportable Incidents, including updates (or lack of updates) to all previously reported information and as much of the the following additional information that is available:",
+                  "statement": "Providers with Class C Certifications MUST responsibly notify all affected parties of ongoing activity as new information becomes available during incident response for FedRAMP Reportable Incidents, including updates (or lack of updates) to all previously reported information and as much of the the following additional information that is available and/or the current relevant status for each item:",
                   "following_information": [
                     "Observed incident activity",
                     "Indicators of compromise",
@@ -4591,7 +4591,7 @@
                   }
                 },
                 "d": {
-                  "statement": "Providers with Class D Certifications MUST responsibly notify all affected parties of ongoing activity as new information becomes available during incident response for FedRAMP Reportable Incidents, including updates (or lack of updates) to all previously reported information and as much of the the following additional information that is available:",
+                  "statement": "Providers with Class D Certifications MUST responsibly notify all affected parties of ongoing activity as new information becomes available during incident response for FedRAMP Reportable Incidents, including updates (or lack of updates) to all previously reported information and as much of the the following additional information that is available and/or the current relevant status for each item:",
                   "following_information": [
                     "Observed incident activity",
                     "Indicators of compromise",


### PR DESCRIPTION
## Rules Content Changes

- **CDS-CSO-AVR** (formerly `CDS-CSO-PAR`): Renamed rule from "Public Availability Reporting" to "Availability Reporting". Rule ID changed from `CDS-CSO-PAR` to `CDS-CSO-AVR` to align with naming conventions. All class variants (a, b, c, d) retain their existing requirements and artifacts.
- **ICP-CSP-IIR** (Initial Incident Report): Clarified language across all class variants (a, b, c, d) to state that providers SHOULD/MUST provide information "as much of the following information that is available at the time of reporting and/or the current relevant status for each item". This addition applies to Classes A, B, C, and D statements.
- **ICP-CSO-OIR** (Ongoing Incident Reports): Clarified language across all class variants (a, b, c, d) to state that providers SHOULD/MUST provide "as much of the the following additional information that is available and/or the current relevant status for each item". This addition applies to Classes A, B, C, and D statements.
