### PR TITLE
Jun 4 updates

### DIFF
--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -4107,7 +4107,7 @@
       "info": {
         "name": "Obtaining Initial FedRAMP Certification",
         "short_name": "IFR",
-        "web_name": "fedramp-certification",
+        "web_name": "initial-fedramp-certification",
         "purpose": "This ruleset explains how cloud service offerings obtain initial FedRAMP Certification across certification classes and paths.",
         "status": "placeholder",
         "subsets": {
@@ -4803,11 +4803,11 @@
         }
       }
     },
-    "MFR": {
+    "OFR": {
       "info": {
-        "name": "Maintaining FedRAMP Certification",
-        "short_name": "MFR",
-        "web_name": "fedramp-certification",
+        "name": "Maintaining Ongoing FedRAMP Certification",
+        "short_name": "OFR",
+        "web_name": "ongoing-fedramp-certification",
         "purpose": "This ruleset explains how cloud service offerings maintain ongoing FedRAMP Certification across certification classes and paths.",
         "status": "placeholder",
         "subsets": {
@@ -4892,7 +4892,7 @@
       "data": {
         "all": {
           "FRP": {
-            "MFR-FRP-MCM": {
+            "OFR-FRP-MCM": {
               "name": "Minimum Continuous Monitoring",
               "statement": "FedRAMP MUST perform a minimum level of continuous monitoring for cloud service offerings with FedRAMP Program Certification, including at least reviewing Ongoing Certification Reports.",
               "force": "MUST",
@@ -4907,7 +4907,7 @@
             }
           },
           "CSO": {
-            "MFR-CSO-IVV": {
+            "OFR-CSO-IVV": {
               "name": "Independent Verification and Validation",
               "varies_by_class": {
                 "a": {
@@ -4960,7 +4960,7 @@
             }
           },
           "AFR": {
-            "MFR-AFR-CDS": {
+            "OFR-AFR-CDS": {
               "name": "FedRAMP Certification Data Sharing",
               "statement": "Providers MUST follow and persistently address the FedRAMP Certification Data Sharing (CDS) rules, based on the applicability and effective date(s) in those rules.",
               "reference": "FedRAMP Certification Data Sharing",
@@ -4986,7 +4986,7 @@
                 }
               ]
             },
-            "MFR-AFR-CCM": {
+            "OFR-AFR-CCM": {
               "name": "Collaborative Continuous Monitoring",
               "statement": "Providers MUST follow and persistently address the Collaborative Continuous Monitoring (CCM) rules, based on the applicability and effective date(s) in those rules.",
               "reference": "Collaborative Continuous Monitoring",
@@ -5001,7 +5001,7 @@
                 }
               ]
             },
-            "MFR-AFR-FSI": {
+            "OFR-AFR-FSI": {
               "name": "FedRAMP Security Inbox",
               "statement": "Providers MUST follow and persistently address the FedRAMP Security Inbox (FSI) rules, based on the applicability and effective date(s) in those rules.",
               "reference": "FedRAMP Security Inbox",
@@ -5016,7 +5016,7 @@
                 }
               ]
             },
-            "MFR-AFR-ICP": {
+            "OFR-AFR-ICP": {
               "name": "Incident Communications Procedures",
               "statement": "Providers MUST follow and persistently address the FedRAMP Incident Communications Procedures (ICP) rules, based on the applicability and effective date(s) in those rules.",
               "reference": "Incident Communications Procedures",
@@ -5031,7 +5031,7 @@
                 }
               ]
             },
-            "MFR-AFR-MAS": {
+            "OFR-AFR-MAS": {
               "name": "Minimum Assessment Scope",
               "statement": "Providers MUST follow and persistently address the FedRAMP Minimum Assessment Scope (MAS) rules, based on the applicability and effective date(s) in those rules.",
               "reference": "Minimum Assessment Scope",
@@ -5077,7 +5077,7 @@
                 }
               ]
             },
-            "MFR-AFR-SCN": {
+            "OFR-AFR-SCN": {
               "name": "Significant Change Notifications",
               "statement": "Providers MUST follow and persistently address the FedRAMP Significant Change Notifications (SCN) rules, based on the applicability and effective date(s) in those rules.",
               "reference": "Significant Change Notifications",
@@ -5111,7 +5111,7 @@
                 }
               ]
             },
-            "MFR-AFR-UCM": {
+            "OFR-AFR-UCM": {
               "name": "Using Cryptographic Modules",
               "statement": "Providers MUST follow and persistently address the FedRAMP Using Cryptographic Modules (UCM) rules, based on the applicability and effective date(s) in those rules.",
               "reference": "Using Cryptographic Modules",
@@ -5126,7 +5126,7 @@
                 }
               ]
             },
-            "MFR-AFR-VDR": {
+            "OFR-AFR-VDR": {
               "name": "Vulnerability Detection and Response",
               "statement": "Providers MUST follow and persistently address the FedRAMP Vulnerability Detection and Response (VDR) rules, based on the applicability and effective date(s) in those rules.",
               "reference": "Vulnerability Detection and Response",
@@ -5191,7 +5191,7 @@
                 }
               ]
             },
-            "MFR-AFR-SCG": {
+            "OFR-AFR-SCG": {
               "name": "Secure Configuration Guide",
               "statement": "Providers MUST follow and persistently address the FedRAMP Secure Configuration Guide (SCG) rules, based on the applicability and effective date(s) in those rules.",
               "reference": "Secure Configuration Guide",

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -2,8 +2,8 @@
   "info": {
     "title": "FedRAMP Consolidated Rules for 2026 Public Preview",
     "description": "This datafile contains the Consolidated Rules for FedRAMP in structured machine-readable text. It includes definitions, requirements, recommendations, and key security indicators.",
-    "version": "2026.06.4.01-preview",
-    "last_updated": "2026-06-03",
+    "version": "2026.06.04.01-preview",
+    "last_updated": "2026-06-04",
     "default_artifacts": {
       "FRR": [
         "Explanation of how the rule is followed, or an explanation of the reason and resulting risk to customers for not following the rule.",
@@ -4351,7 +4351,6 @@
                 "Minimum Assessment Scope: MAS-CSO-IIR (Identify Information Resources)",
                 "Certification Data Sharing: CDS-CSO-PUB (Public Information)",
                 "Certification Data Sharing: CDS-CSO-UTC (Use Trust Centers)",
-                "Certification Data Sharing: CDS-UTC-PGD (Public Guidance for Certification Data)",
                 "Certification Data Sharing: CDS-UTC-AAD (Agency Access Denial)",
                 "FedRAMP Security Inbox: FSI-CSO-INB (Maintain a FedRAMP Security Inbox)",
                 "FedRAMP Security Inbox: FSI-CSO-RCV (Receive Email Without Disruption)",
@@ -4367,7 +4366,6 @@
                 "MAS-CSO-IIR",
                 "CDS-CSO-PUB",
                 "CDS-CSO-UTC",
-                "CDS-UTC-PGD",
                 "CDS-UTC-AAD",
                 "FSI-CSO-INB",
                 "FSI-CSO-RCV",
@@ -4769,6 +4767,331 @@
                 "Information Resource",
                 "Provider"
               ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "MKT": {
+      "info": {
+        "name": "Marketplace Listing",
+        "short_name": "MKT",
+        "web_name": "marketplace-listing",
+        "purpose": "The Marketplace Listing rules define how FedRAMP decides which cloud service offerings, assessors, and advisors may be listed in the FedRAMP Marketplace. These rules help agencies and other customers rely on the Marketplace as a consistent source of eligible services and supporting organizations, while requiring listed organizations to supply accurate, accessible, and machine-readable information.",
+        "status": "placeholder",
+        "subsets": {
+          "FRP": {
+            "name": "FedRAMP Responsibilities",
+            "description": "These rules apply to FedRAMP activities related to the FedRAMP Marketplace.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["FedRAMP"]
+            }
+          },
+          "CSO": {
+            "name": "General Provider Responsibilities",
+            "description": "These rules apply to providers seeking a listing in the FedRAMP Marketplace.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
+          },
+          "IAS": {
+            "name": "General Assessor Responsibilities",
+            "description": "These rules apply to independent assessment services seeking a listing in the FedRAMP Marketplace.",
+            "applicability": {
+              "types": [],
+              "paths": [],
+              "classes": [],
+              "affects": ["Assessors"]
+            }
+          },
+          "CAS": {
+            "name": "General Advisor Responsibilities",
+            "description": "These rules apply to consulting and advisory services seeking a listing in the FedRAMP Marketplace.",
+            "applicability": {
+              "types": [],
+              "paths": [],
+              "classes": [],
+              "affects": ["Advisors"]
+            }
+          },
+          "PRE": {
+            "name": "Provider Responsibilities for Preparation Phase Listings",
+            "description": "These rules apply to providers seeking a Preparation Phase listing in the FedRAMP Marketplace.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": [],
+              "affects": ["Providers"]
+            }
+          }
+        },
+        "20x": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2026-07-04",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-05-04"
+            }
+          }
+        },
+        "rev5": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2027-01-01",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-06-01"
+            }
+          }
+        }
+      },
+      "data": {
+        "all": {
+          "FRP": {
+            "MKT-FRP-DSM": {
+              "name": "Decision Summaries",
+              "statement": "FedRAMP MUST include a summary with any Marketplace listing decision that explains why the decision was made, including an explanation of deficiencies if applicable.",
+              "force": "MUST",
+              "affects": ["FedRAMP"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "MKT-FRP-MJS": {
+              "name": "Marketplace JSON Schemas",
+              "statement": "FedRAMP MUST publish and maintain JSON schemas for required machine-readable Marketplace web information supplied by advisors and assessors.",
+              "reference": "FedRAMP JSON Schemas on GitHub",
+              "reference_url": "https://github.com/FedRAMP/schemas",
+              "force": "MUST",
+              "affects": ["FedRAMP"],
+              "terms": ["Advisor", "Assessor", "Machine-Readable"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "MKT-FRP-SOF": {
+              "name": "Scope of FedRAMP",
+              "statement": "FedRAMP MUST NOT list cloud service offerings in the Marketplace or perform any FedRAMP Certification activities unless it determines the cloud service offering is within the scope of FedRAMP.",
+              "reference": "Scope of FedRAMP",
+              "reference_url": "https://fedramp.gov/docs/authority/scope",
+              "force": "MUST NOT",
+              "affects": ["FedRAMP"],
+              "terms": ["Cloud Service Offering"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "CSO": {
+            "MKT-CSO-AGU": {
+              "name": "Agency Use Cases",
+              "statement": "Providers MUST demonstrate that a cloud service offering is intended for one of the following use cases:",
+              "following_information": [
+                "Direct Use: The product will be used directly by agency customers for integration into a federal information system that falls within the scope of 44 USC § 3506 and will receive an agency Authorization to Operate.",
+                "Indirect Use: The product will be included as a third-party information resource in other cloud service offerings that are directly used by agency customers."
+              ],
+              "notes": [
+                "FedRAMP will not list products or services that are outside the explicit statutory scope of FedRAMP; See MKT-FRP-SOF (Scope of FedRAMP).",
+                "Services used by private companies to meet other compliance requirements (such as CMMC) that do not also meet one of the above use cases are outside the scope of FedRAMP."
+              ],
+              "related": ["MKT-FRP-SOF"],
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": [
+                "Agency",
+                "Cloud Service Offering",
+                "Information Resource",
+                "Provider",
+                "Third-Party Information Resource"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "MKT-CSO-LRQ": {
+              "name": "Listing Requests for Providers",
+              "statement": "Providers MUST complete the Provider Listing Request Form at https://fedramp.gov/forms/provider-listing-request/ in full to request listing in the FedRAMP Marketplace.",
+              "reference": "FedRAMP Marketplace Provider Listing Request Form",
+              "reference_url": "https://fedramp.gov/forms",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "IAS": {
+            "MKT-IAS-OFR": {
+              "name": "Only FedRAMP Recognized Assessors",
+              "statement": "Assessors MUST obtain and maintain FedRAMP Recognition to be listed in the FedRAMP Marketplace.",
+              "force": "MUST",
+              "affects": ["Assessors"],
+              "terms": ["Assessor", "FedRAMP Recognized"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "MKT-IAS-WEB": {
+              "name": "Website Requirements for Assessors",
+              "statement": "Assessors MUST have an appropriate web site that publicly supplies at least the following information in consistent machine-readable and human-readable formats:",
+              "following_information": [
+                "General description of the independent assessment service",
+                "Contact information",
+                "Types of independent services offered",
+                "Optional: Positive attestations from customers or customer references"
+              ],
+              "force": "MUST",
+              "affects": ["Assessors"],
+              "terms": ["Assessor", "Machine-Readable"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "MKT-IAS-LRQ": {
+              "name": "Listing Requests for Assessors",
+              "statement": "Assessors MUST complete the Assessor Listing Request Form at https://fedramp.gov/forms/assessor-listing-request/ to request listing in the FedRAMP Marketplace.",
+              "force": "MUST",
+              "affects": ["Assessors"],
+              "terms": ["Assessor"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "CAS": {
+            "MKT-CAS-WEB": {
+              "name": "Website Requirements for Advisors",
+              "statement": "Advisors MUST have an appropriate web site that publicly supplies at least the following information in consistent machine-readable and human-readable formats:",
+              "following_information": [
+                "General description of the consulting or advisory service",
+                "Contact information",
+                "Types of consulting or advisory services offered",
+                "Optional: Positive attestations from customers or customer references"
+              ],
+              "force": "MUST",
+              "affects": ["Advisors"],
+              "terms": ["Advisor", "Machine-Readable"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "MKT-CAS-LRQ": {
+              "name": "Listing Requests for Advisors",
+              "statement": "Advisors MUST complete the Advisor Listing Request Form at https://fedramp.gov/forms/advisor-listing-request/ to request listing in the FedRAMP Marketplace.",
+              "force": "MUST",
+              "affects": ["Advisors"],
+              "terms": ["Advisor"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "MKT-CAS-RFR": {
+              "name": "Advisor Responses to FedRAMP",
+              "statement": "Advisors MUST reply to all requests from @fedramp.gov or @gsa.gov email addresses sent to the contact information provided in their advisor listing within 5 business days.",
+              "corrective_actions": [
+                "If an advisor fails to respond to a request within 5 business days, FedRAMP will send a follow-up email.",
+                "If an advisor fails to respond to the follow-up email within 5 business days, FedRAMP will remove their listing from the Marketplace.",
+                "Advisors removed from the Marketplace for failure to respond to FedRAMP will not be eligible for listing for at least 6 months unless there are extenuating circumstances."
+              ],
+              "force": "MUST",
+              "affects": ["Advisors"],
+              "terms": ["Advisor"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "PRE": {
+            "MKT-PRE-REQ": {
+              "name": "Preparation Phase Requirements",
+              "statement": "Providers MUST implement a minimum set of rules to be listed in the FedRAMP Marketplace during the Preparation Phase, including at least:",
+              "following_information": [
+                "CDS-CSO-PUB (Public Information) (Public Information",
+                "CDS-CSO-UTC (Use Trust Centers)"
+              ],
+              "related": ["CDS-CSO-PUB", "CDS-CSO-UTC"],
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Provider", "Trust Center"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "MKT-PRE-DCP": {
+              "name": "Demonstrating Continuous Progress",
+              "statement": "Providers MUST demonstrate continuous progress towards a FedRAMP Certification, documented in their Trust Center and updated at least quarterly; progress is measured by the provider against documented goals and milestones.",
+              "note": "This is an opportunity for a business to showcase its goals and progress, and should be seen as a marketing and customer experience challenge instead of a compliance challenge.",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Provider", "Trust Center"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "MKT-PRE-DLA": {
+              "name": "Deadline for Assessment",
+              "statement": "Providers MUST demonstrate that an assessment for a FedRAMP Certification Class B, C, or D has been scheduled within 2 years of initial listing in the Preparation Phase",
+              "corrective_actions": [
+                "If a provider fails to schedule an assessment for a FedRAMP Certification Class B, C, or D within 2 years of initial listing in the Preparation Phase, FedRAMP will remove their listing from the Marketplace until they provide evidence of a scheduled assessment."
+              ],
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Provider"],
               "updated": [
                 {
                   "date": "2026-05-04",
@@ -5187,330 +5510,6 @@
         },
         "20x": {},
         "rev5": {}
-      }
-    },
-    "MKT": {
-      "info": {
-        "name": "Marketplace Listing",
-        "short_name": "MKT",
-        "web_name": "marketplace-listing",
-        "purpose": "The Marketplace Listing rules define how FedRAMP decides which cloud service offerings, assessors, and advisors may be listed in the FedRAMP Marketplace. These rules help agencies and other customers rely on the Marketplace as a consistent source of eligible services and supporting organizations, while requiring listed organizations to supply accurate, accessible, and machine-readable information.",
-        "status": "placeholder",
-        "subsets": {
-          "FRP": {
-            "name": "FedRAMP Responsibilities",
-            "description": "These rules apply to FedRAMP activities related to the FedRAMP Marketplace.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["A", "B", "C", "D"],
-              "affects": ["FedRAMP"]
-            }
-          },
-          "CSO": {
-            "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers seeking a listing in the FedRAMP Marketplace.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["A", "B", "C", "D"],
-              "affects": ["Providers"]
-            }
-          },
-          "IAS": {
-            "name": "General Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services seeking a listing in the FedRAMP Marketplace.",
-            "applicability": {
-              "types": [],
-              "paths": [],
-              "classes": [],
-              "affects": ["Assessors"]
-            }
-          },
-          "CAS": {
-            "name": "General Advisor Responsibilities",
-            "description": "These rules apply to consulting and advisory services seeking a listing in the FedRAMP Marketplace.",
-            "applicability": {
-              "types": [],
-              "paths": [],
-              "classes": [],
-              "affects": ["Advisors"]
-            }
-          },
-          "PRE": {
-            "name": "Provider Responsibilities for Preparation Phase Listings",
-            "description": "These rules apply to providers seeking a Preparation Phase listing in the FedRAMP Marketplace.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": [],
-              "affects": ["Providers"]
-            }
-          }
-        },
-        "20x": {
-          "effective": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-07-04",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-05-04"
-            }
-          }
-        },
-        "rev5": {
-          "effective": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2027-01-01",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-06-01"
-            }
-          }
-        }
-      },
-      "data": {
-        "all": {
-          "FRP": {
-            "MKT-FRP-DSM": {
-              "name": "Decision Summaries",
-              "statement": "FedRAMP MUST include a summary with any Marketplace listing decision that explains why the decision was made, including an explanation of deficiencies if applicable.",
-              "force": "MUST",
-              "affects": ["FedRAMP"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "MKT-FRP-MJS": {
-              "name": "Marketplace JSON Schemas",
-              "statement": "FedRAMP MUST publish and maintain JSON schemas for required machine-readable Marketplace web information supplied by advisors and assessors.",
-              "reference": "FedRAMP JSON Schemas on GitHub",
-              "reference_url": "https://github.com/FedRAMP/schemas",
-              "force": "MUST",
-              "affects": ["FedRAMP"],
-              "terms": ["Advisor", "Assessor", "Machine-Readable"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "MKT-FRP-SOF": {
-              "name": "Scope of FedRAMP",
-              "statement": "FedRAMP MUST NOT list cloud service offerings in the Marketplace or perform any FedRAMP Certification activities unless it determines the cloud service offering is within the scope of FedRAMP.",
-              "reference": "Scope of FedRAMP",
-              "reference_url": "https://fedramp.gov/docs/authority/scope",
-              "force": "MUST NOT",
-              "affects": ["FedRAMP"],
-              "terms": ["Cloud Service Offering"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
-          "CSO": {
-            "MKT-CSO-AGU": {
-              "name": "Agency Use Cases",
-              "statement": "Providers MUST demonstrate that a cloud service offering is intended for one of the following use cases:",
-              "following_information": [
-                "Direct Use: The product will be used directly by agency customers for integration into a federal information system that falls within the scope of 44 USC § 3506 and will receive an agency Authorization to Operate.",
-                "Indirect Use: The product will be included as a third-party information resource in other cloud service offerings that are directly used by agency customers."
-              ],
-              "notes": [
-                "FedRAMP will not list products or services that are outside the explicit statutory scope of FedRAMP; See MKT-FRP-SOF (Scope of FedRAMP).",
-                "Services used by private companies to meet other compliance requirements (such as CMMC) that do not also meet one of the above use cases are outside the scope of FedRAMP."
-              ],
-              "related": ["MKT-FRP-SOF"],
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "Agency",
-                "Cloud Service Offering",
-                "Information Resource",
-                "Provider",
-                "Third-Party Information Resource"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "MKT-CSO-LRQ": {
-              "name": "Listing Requests for Providers",
-              "statement": "Providers MUST complete the Provider Listing Request Form at https://fedramp.gov/forms/provider-listing-request/ in full to request listing in the FedRAMP Marketplace.",
-              "reference": "FedRAMP Marketplace Provider Listing Request Form",
-              "reference_url": "https://fedramp.gov/forms",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
-          "IAS": {
-            "MKT-IAS-OFR": {
-              "name": "Only FedRAMP Recognized Assessors",
-              "statement": "Assessors MUST obtain and maintain FedRAMP Recognition to be listed in the FedRAMP Marketplace.",
-              "force": "MUST",
-              "affects": ["Assessors"],
-              "terms": ["Assessor", "FedRAMP Recognized"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "MKT-IAS-WEB": {
-              "name": "Website Requirements for Assessors",
-              "statement": "Assessors MUST have an appropriate web site that publicly supplies at least the following information in consistent machine-readable and human-readable formats:",
-              "following_information": [
-                "General description of the independent assessment service",
-                "Contact information",
-                "Types of independent services offered",
-                "Optional: Positive attestations from customers or customer references"
-              ],
-              "force": "MUST",
-              "affects": ["Assessors"],
-              "terms": ["Assessor", "Machine-Readable"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "MKT-IAS-LRQ": {
-              "name": "Listing Requests for Assessors",
-              "statement": "Assessors MUST complete the Assessor Listing Request Form at https://fedramp.gov/forms/assessor-listing-request/ to request listing in the FedRAMP Marketplace.",
-              "force": "MUST",
-              "affects": ["Assessors"],
-              "terms": ["Assessor"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
-          "CAS": {
-            "MKT-CAS-WEB": {
-              "name": "Website Requirements for Advisors",
-              "statement": "Advisors MUST have an appropriate web site that publicly supplies at least the following information in consistent machine-readable and human-readable formats:",
-              "following_information": [
-                "General description of the consulting or advisory service",
-                "Contact information",
-                "Types of consulting or advisory services offered",
-                "Optional: Positive attestations from customers or customer references"
-              ],
-              "force": "MUST",
-              "affects": ["Advisors"],
-              "terms": ["Advisor", "Machine-Readable"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "MKT-CAS-LRQ": {
-              "name": "Listing Requests for Advisors",
-              "statement": "Advisors MUST complete the Advisor Listing Request Form at https://fedramp.gov/forms/advisor-listing-request/ to request listing in the FedRAMP Marketplace.",
-              "force": "MUST",
-              "affects": ["Advisors"],
-              "terms": ["Advisor"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "MKT-CAS-RFR": {
-              "name": "Advisor Responses to FedRAMP",
-              "statement": "Advisors MUST reply to all requests from @fedramp.gov or @gsa.gov email addresses sent to the contact information provided in their advisor listing within 5 business days.",
-              "corrective_actions": [
-                "If an advisor fails to respond to a request within 5 business days, FedRAMP will send a follow-up email.",
-                "If an advisor fails to respond to the follow-up email within 5 business days, FedRAMP will remove their listing from the Marketplace.",
-                "Advisors removed from the Marketplace for failure to respond to FedRAMP will not be eligible for listing for at least 6 months unless there are extenuating circumstances."
-              ],
-              "force": "MUST",
-              "affects": ["Advisors"],
-              "terms": ["Advisor"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
-          "PRE": {
-            "MKT-PRE-REQ": {
-              "name": "Preparation Phase Requirements",
-              "statement": "Providers MUST implement a minimum set of rules to be listed in the FedRAMP Marketplace during the Preparation Phase, including at least:",
-              "following_information": [
-                "CDS-CSO-PUB (Public Information",
-                "CDS-CSO-UTC (Use Trust Centers)"
-              ],
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "MKT-PRE-DCP": {
-              "name": "Demonstrating Continuous Progress",
-              "statement": "Providers MUST demonstrate continuous progress towards a FedRAMP Certification, documented in their Trust Center and updated at least quarterly; progress is measured by the provider against documented goals and milestones.",
-              "note": "This is an opportunity for a business to showcase its goals and progress, and should be seen as a marketing and customer experience challenge instead of a compliance challenge.",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Ongoing Certification", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "MKT-PRE-DLA": {
-              "name": "Deadline for Assessment",
-              "statement": "Providers MUST demonstrate that an assessment for a FedRAMP Certification Class B, C, or D has been scheduled within 2 years of initial listing in the Preparation Phase",
-              "corrective_actions": [
-                "If a provider fails to schedule an assessment for a FedRAMP Certification Class B, C, or D within 2 years of initial listing in the Preparation Phase, FedRAMP will remove their listing from the Marketplace until they provide evidence of a scheduled assessment."
-              ],
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          }
-        }
       }
     },
     "REC": {

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -4105,7 +4105,7 @@
     },
     "IFR": {
       "info": {
-        "name": "Obtaining Initial FedRAMP Certification",
+        "name": "Initial FedRAMP Certification",
         "short_name": "IFR",
         "web_name": "initial-fedramp-certification",
         "purpose": "This ruleset explains how cloud service offerings obtain initial FedRAMP Certification across certification classes and paths.",
@@ -4805,7 +4805,7 @@
     },
     "OFR": {
       "info": {
-        "name": "Maintaining Ongoing FedRAMP Certification",
+        "name": "Ongoing FedRAMP Certification",
         "short_name": "OFR",
         "web_name": "ongoing-fedramp-certification",
         "purpose": "This ruleset explains how cloud service offerings maintain ongoing FedRAMP Certification across certification classes and paths.",

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -1958,23 +1958,24 @@
           "CSO": {
             "CDS-CSO-PUB": {
               "name": "Public Information",
-              "statement": "Providers MUST publicly share up-to-date information about the cloud service offering in both human-readable and machine-readable formats, including at least:",
+              "statement": "Providers MUST publicly share up-to-date information about the cloud service offering in both human-readable and machine-readable formats, including at least the following information that is available and applicable:",
               "following_information": [
                 "Direct link to the FedRAMP Marketplace for the offering",
                 "Service Model",
                 "Deployment Model",
                 "Business Category",
                 "UEI Number",
-                "Contact Information",
+                "Sales Contact Information",
+                "Security Contact Information",
+                "Product Website Link",
+                "Link to Product Logo",
                 "Overall Service Description",
                 "Detailed list of specific services and their security categories (see CDS-CSO-SVC (Service List))",
-                "Summary of customer responsibilities and secure configuration guidance (if applicable, see the FedRAMP Secure Configuration Guide process)",
-                "Process for accessing information in the trust center (if applicable)",
-                "Availability status and recent disruptions for the trust center (if applicable)",
-                "Customer support information for the trust center (if applicable)",
+                "Summary of customer responsibilities and secure configuration guidance",
+                "Link to Trust Center landing page that includes instructions on accessing information in the trust center",
                 "Next Ongoing Certification Report date (see CCM-OCR-NRD (Next Report Date))"
               ],
-              "note": "Generally, this information should be available on a public webpage.",
+              "note": "Generally, this information should be available on a public webpage or publicly shared in a FedRAMP-compatible trust center.",
               "related": ["CDS-CSO-SVC", "CCM-OCR-NRD"],
               "force": "MUST",
               "affects": ["Providers"],
@@ -2380,7 +2381,7 @@
             },
             "CDS-UTC-AAD": {
               "name": "Agency Access Denial",
-              "statement": "Providers MUST notify FedRAMP by email to info@fedramp.gov within 5 business days of denying an agency access request for FedRAMP Certification Data.",
+              "statement": "Providers MUST notify FedRAMP within 5 business days of denying an agency access request for FedRAMP Certification Data.",
               "force": "MUST",
               "affects": ["Providers"],
               "timeframe_type": "bizdays",
@@ -2402,7 +2403,7 @@
             },
             "CDS-UTC-AGA": {
               "name": "Agency Access",
-              "statement": "Providers SHOULD share the FedRAMP Certification package with agencies upon request.",
+              "statement": "Providers SHOULD supply access to the FedRAMP Certification package with agencies upon request.",
               "force": "SHOULD",
               "affects": ["Providers"],
               "artifacts": {
@@ -2420,9 +2421,6 @@
               ]
             }
           }
-        },
-        "20x": {
-          "CSX": {}
         },
         "rev5": {
           "CSF": {

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -2674,6 +2674,27 @@
             }
           },
           "CSO": {
+            "FRC-CSO-PKG": {
+              "name": "FedRAMP Certification Package",
+              "statement": "Providers MUST supply a complete FedRAMP Certification Package to FedRAMP for initial certification, aligned to the requirements for the target Certification Type, Class, and Path; the FedRAMP Certification Package MUST include at least the following information:",
+              "following_information": [
+                "A Certification Package Overview following the Certification Package Overview rules",
+                "A Security Decision Record following the Security Decision Record rules"
+              ],
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": [
+                "Certification Package",
+                "Initial Certification",
+                "Provider"
+              ],
+              "updated": [
+                {
+                  "date": "2026-07-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
             "FRC-CSO-CDS": {
               "name": "FedRAMP Certification Data Sharing",
               "statement": "Providers MUST follow and persistently address the FedRAMP Certification Data Sharing (CDS) rules, based on the applicability and effective date(s) in those rules.",
@@ -3460,20 +3481,6 @@
         },
         "rev5": {
           "CSF": {
-            "FRC-CSF-CDE": {
-              "name": "Class D Program Certification Exclusion",
-              "statement": "Providers seeking a FedRAMP Rev5 Class D Certification MUST use the FedRAMP Agency Certification path.",
-              "note": "FedRAMP will not perform FedRAMP Rev5 Class D Program Certifications.",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Agency", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
             "FRC-CSF-RDY": {
               "name": "FedRAMP Ready Conversion",
               "statement": "Providers with FedRAMP Rev5 Ready status MUST convert to a FedRAMP Certification before the furthest date of the expiration of their most recently yearly assessment or November 17, 2026; the legacy FedRAMP Ready status will be entirely removed on December 31, 2027.",

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -2605,37 +2605,17 @@
         "rev5": {}
       }
     },
-    "FRC": {
+    "FRA": {
       "info": {
-        "name": "FedRAMP Certification",
-        "short_name": "FRC",
-        "web_name": "fedramp-certification",
-        "purpose": "The FedRAMP Certification rules define how cloud service offerings obtain and maintain FedRAMP Certification across certification classes and paths. They give providers, assessors, agencies, and FedRAMP a common set of expectations for required rule sets, current evidence, independent verification and validation, and ongoing certification decisions.",
+        "name": "FedRAMP Assessments",
+        "short_name": "FRA",
+        "web_name": "fedramp-assessments",
+        "purpose": "This ruleset explains the expectations for FedRAMP assessments.",
         "status": "placeholder",
         "subsets": {
-          "FRP": {
-            "name": "FedRAMP Responsibilities",
-            "description": "These rules apply to FedRAMP.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["A", "B", "C", "D"],
-              "affects": ["FedRAMP"]
-            }
-          },
           "CSO": {
             "name": "General Provider Responsibilities",
             "description": "These rules apply to cloud service providers obtaining and maintaining any FedRAMP Certification.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["A", "B", "C", "D"],
-              "affects": ["Providers"]
-            }
-          },
-          "AFR": {
-            "name": "Addressing FedRAMP Rules",
-            "description": "These rules apply to all cloud service providers obtaining and maintaining any FedRAMP Certification.",
             "applicability": {
               "types": ["20x", "Rev5"],
               "paths": ["Program", "Agency"],
@@ -2652,36 +2632,6 @@
               "classes": ["A", "B", "C", "D"],
               "affects": ["Assessors"]
             }
-          },
-          "CLA": {
-            "name": "FedRAMP Class A Certification Rules",
-            "description": "These rules apply to providers seeking FedRAMP Class A Certifications.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["A"],
-              "affects": ["Providers"]
-            }
-          },
-          "APP": {
-            "name": "Applying for FedRAMP Certification",
-            "description": "These rules apply to cloud service providers who have met all other relevant rules and are ready to apply for any FedRAMP Certification.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["A", "B", "C", "D"],
-              "affects": ["Providers"]
-            }
-          },
-          "APS": {
-            "name": "Applying for FedRAMP Certification with an Agency Sponsor",
-            "description": "These rules apply to cloud service providers with an Agency Sponsor who have met all other relevant rules and are ready to apply for any FedRAMP Certification.",
-            "applicability": {
-              "types": ["Rev5"],
-              "paths": ["Agency"],
-              "classes": ["B", "C", "D"],
-              "affects": ["Providers"]
-            }
           }
         },
         "20x": {
@@ -2695,16 +2645,6 @@
             }
           },
           "subsets": {
-            "CSX": {
-              "name": "20x-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
-              "applicability": {
-                "types": ["20x"],
-                "paths": ["Program"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Providers"]
-              }
-            },
             "IAX": {
               "name": "20x-Specific Independent Assessor Responsibilities",
               "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications.",
@@ -2728,16 +2668,6 @@
             }
           },
           "subsets": {
-            "CSF": {
-              "name": "Rev5-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
-              "applicability": {
-                "types": ["Rev5"],
-                "paths": ["Program", "Agency"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Providers"]
-              }
-            },
             "IAF": {
               "name": "Rev5-Specific Independent Assessor Responsibilities",
               "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications.",
@@ -2753,127 +2683,8 @@
       },
       "data": {
         "all": {
-          "FRP": {
-            "FRC-FRP-MCM": {
-              "name": "Minimum Continuous Monitoring",
-              "statement": "FedRAMP MUST perform a minimum level of continuous monitoring for cloud service offerings with FedRAMP Program Certification, including at least reviewing Ongoing Certification Reports.",
-              "force": "MUST",
-              "affects": ["FedRAMP"],
-              "terms": ["Cloud Service Offering", "Ongoing Certification"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-FRP-ECR": {
-              "name": "Exemptions from Certification Rules",
-              "statement": "FedRAMP MAY approve exemptions from some FedRAMP Certification rules in rare circumstances by supplying an explicit waiver, based on a prioritization and risk assessment completed by FedRAMP.",
-              "notes": [
-                "FedRAMP will determine when such exemptions are appropriate.",
-                "Exemptions will typically be part of a public prioritization process and criteria will be published publicly.",
-                "Do not ask FedRAMP for an exemption unless the publicly published criteria is met."
-              ],
-              "force": "MAY",
-              "affects": ["FedRAMP"],
-              "terms": [],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
           "CSO": {
-            "FRC-CSO-PKG": {
-              "name": "FedRAMP Certification Package",
-              "statement": "Providers MUST supply a complete FedRAMP Certification Package to FedRAMP for initial certification, aligned to the requirements for the target Certification Type, Class, and Path; the FedRAMP Certification Package MUST include at least the following information:",
-              "following_information": [
-                "A Certification Package Overview following the Certification Package Overview rules",
-                "A Security Decision Record following the Security Decision Record rules"
-              ],
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "Certification Package",
-                "Initial Certification",
-                "Provider"
-              ],
-              "updated": [
-                {
-                  "date": "2026-07-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-IVV": {
-              "name": "Independent Verification and Validation",
-              "varies_by_class": {
-                "a": {
-                  "statement": "Providers with Class A Certifications MAY persistently complete an independent verification and validation assessment at least once per year; these assessments MAY be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MAY be included in their FedRAMP Certification Data without inappropriate modification.",
-                  "force": "MAY",
-                  "timeframe_type": "years",
-                  "timeframe_num": 1
-                },
-                "b": {
-                  "statement": "Providers with Class B Certifications MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
-                  "force": "MUST",
-                  "timeframe_type": "years",
-                  "timeframe_num": 1
-                },
-                "c": {
-                  "statement": "Providers with Class C Certifications MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
-                  "force": "MUST",
-                  "timeframe_type": "years",
-                  "timeframe_num": 1
-                },
-                "d": {
-                  "statement": "Providers with Class D Certifications MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
-                  "force": "MUST",
-                  "timeframe_type": "years",
-                  "timeframe_num": 1
-                }
-              },
-              "notes": [
-                "The first such completed assessment is typically called an \"initial assessment\" while following assessments are called \"annual assessments.\"",
-                "The specific requirements for independent verification and validation assessments are documented by the FedRAMP Certification Class and Type.",
-                "The option for assessment by FedRAMP directly is limited to cloud services that are explicitly prioritized by FedRAMP, in consultation with the FedRAMP Board and the federal Chief Information Officers Council.",
-                "FedRAMP Recognized independent assessors are listed on the FedRAMP Marketplace."
-              ],
-              "affects": ["Providers"],
-              "terms": [
-                "Assessor",
-                "Certification Data",
-                "FedRAMP Recognized",
-                "Persistently",
-                "Provider",
-                "Validation",
-                "Verification"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-POP": {
-              "name": "Pick One Program Certification Type",
-              "statement": "Providers MUST NOT seek both FedRAMP Rev5 Program Certification and FedRAMP 20x Program Certification for the same cloud service offering; pick one type.",
-              "note": "This rule does not prevent a provider from seeking and maintaining a FedRAMP Rev5 Agency Certification and a FedRAMP 20x Program Certification for the same cloud service offering, however, doing so is strongly discouraged due to the increased complexity and risk of confusion for all parties.",
-              "force": "MUST NOT",
-              "affects": ["Providers"],
-              "terms": ["Agency", "Cloud Service Offering", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-STE": {
+            "FRA-CSO-STE": {
               "name": "Supply Technical Evidence",
               "statement": "Providers SHOULD supply all necessary accessors with technical explanations, demonstrations, and other relevant supporting information about the technical capabilities they employ to address FedRAMP rules; this SHOULD be supplied as necessary to ensure the assessor can effectively complete verification and validation.",
               "force": "SHOULD",
@@ -2886,7 +2697,7 @@
                 }
               ]
             },
-            "FRC-CSO-RAA": {
+            "FRA-CSO-RAA": {
               "name": "Receiving Assessor Advice",
               "statement": "Providers MAY ask for and accept advice from their assessor during assessment regarding techniques and procedures that will improve their security posture or the effectiveness, clarity, and accuracy of their verification, validation and reporting procedures, UNLESS doing so is likely to compromise the objectivity and integrity of the assessment.",
               "force": "MAY",
@@ -2906,260 +2717,8 @@
               ]
             }
           },
-          "AFR": {
-            "FRC-AFR-CDS": {
-              "name": "FedRAMP Certification Data Sharing",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Certification Data Sharing (CDS) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "FedRAMP Certification Data Sharing",
-              "reference_url_web_name": "certification-data-sharing",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "controls": [
-                "ac-3",
-                "ac-4",
-                "au-2",
-                "au-3",
-                "au-6",
-                "ca-2",
-                "ir-4",
-                "ra-5",
-                "sc-8"
-              ],
-              "terms": ["Certification Data", "Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-AFR-CCM": {
-              "name": "Collaborative Continuous Monitoring",
-              "statement": "Providers MUST follow and persistently address the Collaborative Continuous Monitoring (CCM) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Collaborative Continuous Monitoring",
-              "reference_url_web_name": "collaborative-continuous-monitoring",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-AFR-FSI": {
-              "name": "FedRAMP Security Inbox",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Security Inbox (FSI) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "FedRAMP Security Inbox",
-              "reference_url_web_name": "fedramp-security-inbox",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["FedRAMP Security Inbox", "Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-AFR-ICP": {
-              "name": "Incident Communications Procedures",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Incident Communications Procedures (ICP) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Incident Communications Procedures",
-              "reference_url_web_name": "incident-communications-procedures",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Incident", "Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-AFR-MAS": {
-              "name": "Minimum Assessment Scope",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Minimum Assessment Scope (MAS) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Minimum Assessment Scope",
-              "reference_url_web_name": "minimum-assessment-scope",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "controls": [
-                "ac-1",
-                "ac-21",
-                "at-1",
-                "au-1",
-                "ca-1",
-                "cm-1",
-                "cp-1",
-                "cp-2.1",
-                "cp-2.8",
-                "cp-4.1",
-                "ia-1",
-                "ir-1",
-                "ma-1",
-                "mp-1",
-                "pe-1",
-                "pl-1",
-                "pl-2",
-                "pl-4",
-                "pl-4.1",
-                "ps-1",
-                "ra-1",
-                "ra-9",
-                "sa-1",
-                "sc-1",
-                "si-1",
-                "sr-1",
-                "sr-2",
-                "sr-3",
-                "sr-11"
-              ],
-              "terms": ["Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-AFR-SCN": {
-              "name": "Significant Change Notifications",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Significant Change Notifications (SCN) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Significant Change Notifications",
-              "reference_url_web_name": "significant-change-notifications",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "controls": [
-                "ca-7.4",
-                "cm-3.4",
-                "cm-4",
-                "cm-7.1",
-                "au-5",
-                "ca-5",
-                "ca-7",
-                "ra-5",
-                "ra-5.2",
-                "sa-22",
-                "si-2",
-                "si-2.2",
-                "si-3",
-                "si-5",
-                "si-7.7",
-                "si-10",
-                "si-11"
-              ],
-              "terms": ["Persistently", "Provider", "Significant Change"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-AFR-UCM": {
-              "name": "Using Cryptographic Modules",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Using Cryptographic Modules (UCM) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Using Cryptographic Modules",
-              "reference_url_web_name": "using-cryptographic-modules",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-AFR-VDR": {
-              "name": "Vulnerability Detection and Response",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Vulnerability Detection and Response (VDR) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Vulnerability Detection and Response",
-              "reference_url_web_name": "vulnerability-detection-and-response",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "controls": [
-                "ca-2",
-                "ca-7",
-                "ca-7.6",
-                "ir-1",
-                "ir-4",
-                "ir-4.1",
-                "ir-5",
-                "ir-5.1",
-                "ir-6",
-                "ir-6.1",
-                "ir-6.2",
-                "pm-3",
-                "pm-5",
-                "pm-31",
-                "ra-2",
-                "ra-2.1",
-                "ra-3",
-                "ra-3.3",
-                "ra-5",
-                "ra-5.2",
-                "ra-5.3",
-                "ra-5.4",
-                "ra-5.5",
-                "ra-5.6",
-                "ra-5.7",
-                "ra-5.11",
-                "ra-9",
-                "ra-10",
-                "si-2",
-                "si-2.1",
-                "si-2.2",
-                "si-2.4",
-                "si-2.5",
-                "si-3",
-                "si-3.1",
-                "si-3.2",
-                "si-4",
-                "si-4.2",
-                "si-4.3",
-                "si-4.7",
-                "ca-7.4",
-                "ra-7"
-              ],
-              "terms": [
-                "Persistently",
-                "Provider",
-                "Vulnerability",
-                "Vulnerability Detection",
-                "Vulnerability Response"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-AFR-SCG": {
-              "name": "Secure Configuration Guide",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Secure Configuration Guide (SCG) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Secure Configuration Guide",
-              "reference_url_web_name": "secure-configuration-guide",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-06-03",
-                  "comment": "Renamed to \"FRC-AFR-SCG\"."
-                },
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
           "IAS": {
-            "FRC-IAS-VVP": {
+            "FRA-IAS-VVP": {
               "name": "Verify and Validate Processes",
               "statement": "Assessors MUST verify and validate the implementation of processes derived from FedRAMP requirements, including rules, controls and Key Security Indicators, to determine whether or not the provider has accurately documented their process and security goals for the cloud service offering.",
               "force": "MUST",
@@ -3178,7 +2737,7 @@
                 }
               ]
             },
-            "FRC-IAS-OUC": {
+            "FRA-IAS-OUC": {
               "name": "Outcome Consistency",
               "statement": "Assessors MUST verify and validate whether or not the underlying processes are consistently creating the desired security outcome documented by the provider.",
               "force": "MUST",
@@ -3191,7 +2750,7 @@
                 }
               ]
             },
-            "FRC-IAS-PAD": {
+            "FRA-IAS-PAD": {
               "name": "Procedure Adherence",
               "statement": "Assessors MUST assess whether or not procedures are consistently followed, including evaluating the processes in place to ensure this occurs, without relying solely on the existence of procedure documents.",
               "note": "This includes evaluating tests or plans for activities that may occur in the future but have not yet occurred.",
@@ -3205,7 +2764,7 @@
                 }
               ]
             },
-            "FRC-IAS-MME": {
+            "FRA-IAS-MME": {
               "name": "Mixed Methods Evaluation",
               "statement": "Assessors MUST perform verification and validation using a combination of quantitative and expert qualitative assessment as appropriate AND document which is applied to which aspect of the assessment.",
               "force": "MUST",
@@ -3218,7 +2777,7 @@
                 }
               ]
             },
-            "FRC-IAS-SUM": {
+            "FRA-IAS-SUM": {
               "name": "Assessment Summary",
               "statement": "Assessors MUST deliver a high-level summary of their assessment process and findings for each FedRAMP requirement, including rules, controls, and Key Security Indicators; this summary will be included in the FedRAMP Certification Data for the cloud service offering.",
               "force": "MUST",
@@ -3235,7 +2794,7 @@
                 }
               ]
             },
-            "FRC-IAS-OSA": {
+            "FRA-IAS-OSA": {
               "name": "Overall Summary of Assessment",
               "statement": "Assessors MUST supply an overall summary of the verification and validation assessment results, including any resulting failures or areas of dispute, to the provider and all necessary assessors.",
               "note": "FedRAMP will make the final FedRAMP Certification decision based on the assessor's findings and other relevant information.",
@@ -3255,7 +2814,7 @@
                 }
               ]
             },
-            "FRC-IAS-EPX": {
+            "FRA-IAS-EPX": {
               "name": "Engage Provider Experts",
               "statement": "Assessors SHOULD engage provider experts in discussion to understand the decisions made by the provider and inform expert qualitative assessment, and SHOULD perform independent research to test such information as part of the expert qualitative assessment process.",
               "force": "SHOULD",
@@ -3268,7 +2827,7 @@
                 }
               ]
             },
-            "FRC-IAS-SHA": {
+            "FRA-IAS-SHA": {
               "name": "Sharing Advice",
               "statement": "Assessors MAY share advice with providers they are assessing about techniques and procedures that will improve the provider's security posture or the effectiveness, clarity, and accuracy of their verification, validation and reporting procedures, UNLESS doing so is likely to compromise the objectivity and integrity of the assessment.",
               "force": "MAY",
@@ -3287,250 +2846,11 @@
                 }
               ]
             }
-          },
-          "CLA": {
-            "FRC-CLA-ASF": {
-              "name": "Approved Alternative Security Frameworks",
-              "statement": "Providers seeking a FedRAMP Class A Certification MUST have completed a certification or equivalent process, including an independent assessment, from one of the following alternative security frameworks:",
-              "following_information": [
-                "FedRAMP Ready",
-                "SOC 2 Type II",
-                "GovRAMP"
-              ],
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CLA-EAM": {
-              "name": "External Assessment Materials",
-              "statement": "Providers seeking a FedRAMP Class A Certification MUST supply the full materials from the alternative security assessment to all necessary parties as part of the FedRAMP Certification Package.",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "All Necessary Parties",
-                "Certification Package",
-                "Provider"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CLA-AFR": {
-              "name": "Address FedRAMP Rules",
-              "statement": "Providers seeking a Class A FedRAMP Certification MUST address the following FedRAMP rules and supply the appropriate artifacts or information mapping in the FedRAMP Certification Package:",
-              "following_information": [
-                "FedRAMP Certification: FRC-CSO-POP (Pick One Program Certification Type)",
-                "Minimum Assessment Scope: MAS-CSO-IIR (Identify Information Resources)",
-                "Certification Data Sharing: CDS-CSO-PUB (Public Information)",
-                "Certification Data Sharing: CDS-CSO-UTC (Use Trust Centers)",
-                "Certification Data Sharing: CDS-UTC-PGD (Public Guidance for Certification Data)",
-                "Certification Data Sharing: CDS-UTC-AAD (Agency Access Denial)",
-                "FedRAMP Security Inbox: FSI-CSO-INB (Maintain a FedRAMP Security Inbox)",
-                "FedRAMP Security Inbox: FSI-CSO-RCV (Receive Email Without Disruption)",
-                "FedRAMP Security Inbox: FSI-CSO-CRA (Complete Required Actions)",
-                "Incident Communications Procedures: ICP-CSO-EFR (Evaluate FedRAMP Reportability)",
-                "Vulnerability Detection and Response: VDR-CSO-DET (Vulnerability Detection)",
-                "Continuous Collaborative Monitoring: CCM-OCR-AVL (Report Availability)",
-                "Continuous Collaborative Monitoring: CCM-OCR-NRD (Next Report Date)"
-              ],
-              "note": "If the alternative security framework has existing rules that align with these FedRAMP rules then a mapping to the alternative security framework content may be supplied instead of generating new artifacts.",
-              "related": [
-                "FRC-CSO-POP",
-                "MAS-CSO-IIR",
-                "CDS-CSO-PUB",
-                "CDS-CSO-UTC",
-                "CDS-UTC-PGD",
-                "CDS-UTC-AAD",
-                "FSI-CSO-INB",
-                "FSI-CSO-RCV",
-                "FSI-CSO-CRA",
-                "ICP-CSO-EFR",
-                "VDR-CSO-DET",
-                "CCM-OCR-AVL",
-                "CCM-OCR-NRD"
-              ],
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "Agency",
-                "Artifacts",
-                "Certification Data",
-                "Certification Package",
-                "FedRAMP Security Inbox",
-                "Incident",
-                "Information Resource",
-                "Initial Incident Report (IIR)",
-                "Ongoing Certification Report (OCR)",
-                "Provider",
-                "Trust Center",
-                "Vulnerability",
-                "Vulnerability Detection",
-                "Vulnerability Response"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CLA-IVV": {
-              "name": "Optional Independent Verification and Validation",
-              "statement": "Providers seeking a FedRAMP Class A Certification MAY have the FedRAMP Certification Package independently verified and validated by a FedRAMP Recognized assessor before submission to FedRAMP.",
-              "force": "MAY",
-              "affects": ["Providers"],
-              "terms": [
-                "Assessor",
-                "Certification Package",
-                "FedRAMP Recognized",
-                "Provider",
-                "Validation",
-                "Verification"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
-          "APP": {
-            "FRC-APP-MLF": {
-              "name": "Marketplace Listing First",
-              "statement": "Providers MUST be listed in the FedRAMP Marketplace before applying for FedRAMP Certification.",
-              "note": "See FedRAMP's Marketplace Listing rules for information about being listed in the Marketplace in the Preparation Phase prior to receiving a formal FedRAMP Certification.",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-APP-AFC": {
-              "name": "Applying for FedRAMP Certification",
-              "statement": "Providers MUST complete the FedRAMP Certification Application Form at https://fedramp.gov/forms/provider-listing-request/ in full to request an initial assessment by FedRAMP.",
-              "reference": "FedRAMP Certification Application Form",
-              "reference_url": "https://fedramp.gov/forms",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-APP-FCP": {
-              "name": "Fresh FedRAMP Certification Package",
-              "statement": "Providers MUST supply a fresh initial FedRAMP Certification Package that shows the current status of the cloud service offering as verified and validated by the provider within the previous 7 days.",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "Certification Package",
-                "Cloud Service Offering",
-                "Provider",
-                "Validation",
-                "Verification"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-APP-FIA": {
-              "name": "Fresh Independent Assessment",
-              "statement": "Providers MUST supply a fresh initial independent verification and validation assessment that was completed by a FedRAMP Recognized Independent Assessment Service within the previous 3 months.",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "FedRAMP Recognized",
-                "Provider",
-                "Validation",
-                "Verification"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
-          "APS": {
-            "FRC-APS-ATO": {
-              "name": "Agency Authorization to Operate",
-              "statement": "Providers seeking a FedRAMP Rev5 Agency Certification MUST have completed the Authorization to Operate (ATO) process with their agency sponsor for the cloud service offering, concluding with a formal signed ATO letter that the agency has sent over official government channels to FedRAMP.",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Agency", "Cloud Service Offering", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
           }
         },
         "20x": {
-          "CSX": {
-            "FRC-CSX-SUM": {
-              "name": "Implementation Summaries",
-              "statement": "Providers MUST maintain simple high-level summaries of at least the following for each Key Security Indicator:",
-              "following_information": [
-                "Goals for how it will be implemented and validated, including clear pass/fail criteria and traceability",
-                "The consolidated _information resources_ that will be validated (this should include consolidated summaries such as \"all employees with privileged access that are members of the Admin group\")",
-                "The machine-based processes for _validation_ and the _persistent_ cycle on which they will be performed (or an explanation of why this doesn't apply)",
-                "The non-machine-based processes for _validation_ and the _persistent_ cycle on which they will be performed (or an explanation of why this doesn't apply)",
-                "Current implementation status",
-                "Any clarifications or responses to the assessment summary"
-              ],
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": [
-                "Machine-Based (Information Resources)",
-                "Provider",
-                "Validation"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSX-MAS": {
-              "name": "Application within MAS",
-              "statement": "Providers SHOULD apply ALL Key Security Indicators to ALL aspects of their cloud service offering that are within the FedRAMP Minimum Assessment Scope.",
-              "force": "SHOULD",
-              "affects": ["Providers"],
-              "terms": ["Cloud Service Offering", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
           "IAX": {
-            "FRC-IAX-UNP": {
+            "FRA-IAX-UNP": {
               "name": "Underlying Processes",
               "statement": "Assessors MUST verify and validate the underlying processes (both machine-based and non-machine-based) that providers use to validate Key Security Indicators; this should include at least:",
               "following_information": [
@@ -3556,7 +2876,7 @@
                 }
               ]
             },
-            "FRC-IAX-STE": {
+            "FRA-IAX-STE": {
               "name": "Static Evidence",
               "statement": "Assessors MUST NOT rely on screenshots, configuration dumps, or other static output as evidence EXCEPT when evaluating the accuracy and reliability of a process that generates such artifacts.",
               "force": "MUST NOT",
@@ -3569,72 +2889,9 @@
                 }
               ]
             }
-          },
-          "CLA": {
-            "FRC-CLA-KSM": {
-              "name": "Key Security Indicator Mapping",
-              "statement": "Providers seeking a FedRAMP 20x Certification Class A by leveraging an alternative security framework MUST supply a temporary mapping from the alternative security assessment to the following FedRAMP Key Security Indicators:",
-              "following_information": [
-                "KSI-CMT-LMC",
-                "KSI-CNA-RNT",
-                "KSI-CED-RAT",
-                "KSI-IAM-AAM",
-                "KSI-INR-RIR",
-                "KSI-SVC-SNT"
-              ],
-              "notes": [
-                "The mapping must be available in both machine-readable and human-readable formats.",
-                "If a mapping is not clear, the provider should supply new information indicating that the Key Security Indicator has not been independently audited."
-              ],
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Machine-Readable", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
           }
         },
-        "rev5": {
-          "CSF": {
-            "FRC-CSF-RDY": {
-              "name": "FedRAMP Ready Conversion",
-              "statement": "Providers with FedRAMP Rev5 Ready status MUST convert to a FedRAMP Certification before the furthest date of the expiration of their most recently yearly assessment or November 17, 2026; the legacy FedRAMP Ready status will be entirely removed on December 31, 2027.",
-              "note": "Cloud services that do not wish to convert or do not meet conversion criteria will be renamed Legacy FedRAMP Ready and otherwise retired from FedRAMP Ready.",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          },
-          "CLA": {
-            "FRC-CLA-CAC": {
-              "name": "Rev5 Class A Certification",
-              "statement": "Providers seeking a FedRAMP Rev5 Class A Certification by leveraging an alternative security framework that is based on the SP 800-53 Revision 5 MUST supply all Security Decision Record materials required for FedRAMP Rev5 Class B Certification.",
-              "notes": [
-                "The only approved alternative security frameworks based on the SP 800-53 Revision 5 are FedRAMP Ready and GovRAMP.",
-                "An independent assessment is not required for FedRAMP Rev5 Class A Certification."
-              ],
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            }
-          }
-        }
+        "rev5": {}
       }
     },
     "FSI": {
@@ -4846,6 +4103,541 @@
         }
       }
     },
+    "IFR": {
+      "info": {
+        "name": "Obtaining Initial FedRAMP Certification",
+        "short_name": "IFR",
+        "web_name": "fedramp-certification",
+        "purpose": "This ruleset explains how cloud service offerings obtain initial FedRAMP Certification across certification classes and paths.",
+        "status": "placeholder",
+        "subsets": {
+          "FRP": {
+            "name": "FedRAMP Responsibilities",
+            "description": "These rules apply to FedRAMP.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["FedRAMP"]
+            }
+          },
+          "CSO": {
+            "name": "General Provider Responsibilities",
+            "description": "These rules apply to cloud service providers obtaining and maintaining any FedRAMP Certification.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
+          },
+          "IAS": {
+            "name": "General Independent Assessor Responsibilities",
+            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Assessors"]
+            }
+          },
+          "CLA": {
+            "name": "FedRAMP Class A Certification Rules",
+            "description": "These rules apply to providers seeking FedRAMP Class A Certifications.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A"],
+              "affects": ["Providers"]
+            }
+          },
+          "APP": {
+            "name": "Applying for FedRAMP Certification",
+            "description": "These rules apply to cloud service providers who have met all other relevant rules and are ready to apply for any FedRAMP Certification.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
+          },
+          "APS": {
+            "name": "Applying for FedRAMP Certification with an Agency Sponsor",
+            "description": "These rules apply to cloud service providers with an Agency Sponsor who have met all other relevant rules and are ready to apply for any FedRAMP Certification.",
+            "applicability": {
+              "types": ["Rev5"],
+              "paths": ["Agency"],
+              "classes": ["B", "C", "D"],
+              "affects": ["Providers"]
+            }
+          }
+        },
+        "20x": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2026-07-04",
+              "maintain": "2027-05-04",
+              "grace_ends": "2027-05-04"
+            }
+          },
+          "subsets": {
+            "CSX": {
+              "name": "20x-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
+            },
+            "IAX": {
+              "name": "20x-Specific Independent Assessor Responsibilities",
+              "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Assessors"]
+              }
+            }
+          }
+        },
+        "rev5": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2027-01-01",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-01-01"
+            }
+          },
+          "subsets": {
+            "CSF": {
+              "name": "Rev5-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
+            },
+            "IAF": {
+              "name": "Rev5-Specific Independent Assessor Responsibilities",
+              "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Assessors"]
+              }
+            }
+          }
+        }
+      },
+      "data": {
+        "all": {
+          "FRP": {
+            "IFR-FRP-ECR": {
+              "name": "Exemptions from Certification Rules",
+              "statement": "FedRAMP MAY approve exemptions from some FedRAMP Certification rules in rare circumstances by supplying an explicit waiver, based on a prioritization and risk assessment completed by FedRAMP.",
+              "notes": [
+                "FedRAMP will determine when such exemptions are appropriate.",
+                "Exemptions will typically be part of a public prioritization process and criteria will be published publicly.",
+                "Do not ask FedRAMP for an exemption unless the publicly published criteria is met."
+              ],
+              "force": "MAY",
+              "affects": ["FedRAMP"],
+              "terms": [],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "CSO": {
+            "IFR-CSO-PKG": {
+              "name": "FedRAMP Certification Package",
+              "varies_by_class": {
+                "a": {
+                  "statement": "Providers seeking a Class A Certification MUST supply a complete FedRAMP Certification Package to FedRAMP for initial certification, aligned to the requirements for the target Certification Type, Class, and Path; the FedRAMP Certification Package MUST include at least the following information:",
+                  "following_information": [
+                    "A Certification Package Overview",
+                    "An External Framework Mapping"
+                  ],
+                  "force": "MUST"
+                },
+                "b": {
+                  "statement": "Providers seeking a Class B Certification MUST supply a complete FedRAMP Certification Package to FedRAMP for initial certification, aligned to the requirements for the target Certification Type, Class, and Path; the FedRAMP Certification Package MUST include at least the following information:",
+                  "following_information": [
+                    "A Certification Package Overview",
+                    "A Security Decision Record",
+                    "A real or example Ongoing Certification Report following CCM-OCR-AVL (Report Availability)"
+                  ],
+                  "force": "MUST"
+                },
+                "c": {
+                  "statement": "Providers seeking a Class C Certification MUST supply a complete FedRAMP Certification Package to FedRAMP for initial certification, aligned to the requirements for the target Certification Type, Class, and Path; the FedRAMP Certification Package MUST include at least the following information:",
+                  "following_information": [
+                    "A Certification Package Overview",
+                    "A Security Decision Record",
+                    "A real or example Ongoing Certification Report following CCM-OCR-AVL (Report Availability)"
+                  ],
+                  "force": "MUST"
+                },
+                "d": {
+                  "statement": "Providers seeking a Class D Certification MUST supply a complete FedRAMP Certification Package to FedRAMP for initial certification, aligned to the requirements for the target Certification Type, Class, and Path; the FedRAMP Certification Package MUST include at least the following information:",
+                  "following_information": [
+                    "A Certification Package Overview",
+                    "A Security Decision Record",
+                    "A real or example Ongoing Certification Report following CCM-OCR-AVL (Report Availability)"
+                  ],
+                  "force": "MUST"
+                }
+              },
+              "related": ["CCM-OCR-AVL"],
+              "affects": ["Providers"],
+              "terms": [
+                "Certification Package",
+                "Initial Certification",
+                "Provider"
+              ],
+              "updated": [
+                {
+                  "date": "2026-07-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "IFR-CSO-POP": {
+              "name": "Pick One Program Certification Type",
+              "statement": "Providers MUST NOT seek both FedRAMP Rev5 Program Certification and FedRAMP 20x Program Certification for the same cloud service offering; pick one type.",
+              "note": "This rule does not prevent a provider from seeking and maintaining a FedRAMP Rev5 Agency Certification and a FedRAMP 20x Program Certification for the same cloud service offering, however, doing so is strongly discouraged due to the increased complexity and risk of confusion for all parties.",
+              "force": "MUST NOT",
+              "affects": ["Providers"],
+              "terms": ["Agency", "Cloud Service Offering", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "CLA": {
+            "IFR-CLA-ASF": {
+              "name": "Approved Alternative Security Frameworks",
+              "statement": "Providers seeking a FedRAMP Class A Certification MUST have completed a certification or equivalent process, including an independent assessment, from one of the following alternative security frameworks:",
+              "following_information": [
+                "FedRAMP Ready",
+                "SOC 2 Type II",
+                "GovRAMP"
+              ],
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "IFR-CLA-EAM": {
+              "name": "External Assessment Materials",
+              "statement": "Providers seeking a FedRAMP Class A Certification MUST supply the full materials from the alternative security assessment to all necessary parties as part of the FedRAMP Certification Package.",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": [
+                "All Necessary Parties",
+                "Certification Package",
+                "Provider"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "IFR-CLA-AFR": {
+              "name": "Address FedRAMP Rules",
+              "statement": "Providers seeking a Class A FedRAMP Certification MUST address the following FedRAMP rules and supply the appropriate artifacts or information mapping in the FedRAMP Certification Package:",
+              "following_information": [
+                "FedRAMP Certification: IFR-CSO-POP (Pick One Program Certification Type)",
+                "Minimum Assessment Scope: MAS-CSO-IIR (Identify Information Resources)",
+                "Certification Data Sharing: CDS-CSO-PUB (Public Information)",
+                "Certification Data Sharing: CDS-CSO-UTC (Use Trust Centers)",
+                "Certification Data Sharing: CDS-UTC-PGD (Public Guidance for Certification Data)",
+                "Certification Data Sharing: CDS-UTC-AAD (Agency Access Denial)",
+                "FedRAMP Security Inbox: FSI-CSO-INB (Maintain a FedRAMP Security Inbox)",
+                "FedRAMP Security Inbox: FSI-CSO-RCV (Receive Email Without Disruption)",
+                "FedRAMP Security Inbox: FSI-CSO-CRA (Complete Required Actions)",
+                "Incident Communications Procedures: ICP-CSO-EFR (Evaluate FedRAMP Reportability)",
+                "Vulnerability Detection and Response: VDR-CSO-DET (Vulnerability Detection)",
+                "Continuous Collaborative Monitoring: CCM-OCR-AVL (Report Availability)",
+                "Continuous Collaborative Monitoring: CCM-OCR-NRD (Next Report Date)"
+              ],
+              "note": "If the alternative security framework has existing rules that align with these FedRAMP rules then a mapping to the alternative security framework content may be supplied instead of generating new artifacts.",
+              "related": [
+                "IFR-CSO-POP",
+                "MAS-CSO-IIR",
+                "CDS-CSO-PUB",
+                "CDS-CSO-UTC",
+                "CDS-UTC-PGD",
+                "CDS-UTC-AAD",
+                "FSI-CSO-INB",
+                "FSI-CSO-RCV",
+                "FSI-CSO-CRA",
+                "ICP-CSO-EFR",
+                "VDR-CSO-DET",
+                "CCM-OCR-AVL",
+                "CCM-OCR-NRD"
+              ],
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": [
+                "Agency",
+                "Artifacts",
+                "Certification Data",
+                "Certification Package",
+                "FedRAMP Security Inbox",
+                "Incident",
+                "Information Resource",
+                "Initial Incident Report (IIR)",
+                "Ongoing Certification Report (OCR)",
+                "Provider",
+                "Trust Center",
+                "Vulnerability",
+                "Vulnerability Detection",
+                "Vulnerability Response"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "IFR-CLA-IVV": {
+              "name": "Optional Independent Verification and Validation",
+              "statement": "Providers seeking a FedRAMP Class A Certification MAY have the FedRAMP Certification Package independently verified and validated by a FedRAMP Recognized assessor before submission to FedRAMP.",
+              "force": "MAY",
+              "affects": ["Providers"],
+              "terms": [
+                "Assessor",
+                "Certification Package",
+                "FedRAMP Recognized",
+                "Provider",
+                "Validation",
+                "Verification"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "APP": {
+            "IFR-APP-MLF": {
+              "name": "Marketplace Listing First",
+              "statement": "Providers MUST be listed in the FedRAMP Marketplace before applying for FedRAMP Certification.",
+              "note": "See FedRAMP's Marketplace Listing rules for information about being listed in the Marketplace in the Preparation Phase prior to receiving a formal FedRAMP Certification.",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "IFR-APP-AFC": {
+              "name": "Applying for FedRAMP Certification",
+              "statement": "Providers MUST complete the FedRAMP Certification Application Form at https://fedramp.gov/forms/provider-listing-request/ in full to request an initial assessment by FedRAMP.",
+              "reference": "FedRAMP Certification Application Form",
+              "reference_url": "https://fedramp.gov/forms",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "IFR-APP-FCP": {
+              "name": "Fresh FedRAMP Certification Package",
+              "statement": "Providers MUST supply a fresh initial FedRAMP Certification Package that shows the current status of the cloud service offering as verified and validated by the provider within the previous 7 days.",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": [
+                "Certification Package",
+                "Cloud Service Offering",
+                "Provider",
+                "Validation",
+                "Verification"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "IFR-APP-FIA": {
+              "name": "Fresh Independent Assessment",
+              "statement": "Providers MUST supply a fresh initial independent verification and validation assessment that was completed by a FedRAMP Recognized Independent Assessment Service within the previous 3 months.",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": [
+                "FedRAMP Recognized",
+                "Provider",
+                "Validation",
+                "Verification"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "APS": {
+            "IFR-APS-ATO": {
+              "name": "Agency Authorization to Operate",
+              "statement": "Providers seeking a FedRAMP Rev5 Agency Certification MUST have completed the Authorization to Operate (ATO) process with their agency sponsor for the cloud service offering, concluding with a formal signed ATO letter that the agency has sent over official government channels to FedRAMP.",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Agency", "Cloud Service Offering", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          }
+        },
+        "20x": {
+          "CSX": {
+            "IFR-CSX-SUM": {
+              "name": "Initial Implementation Summaries",
+              "statement": "Providers MUST supply simple high-level summaries of at least the following for each Key Security Indicator:",
+              "following_information": [
+                "Goals for how it will be implemented and validated, including clear pass/fail criteria and traceability",
+                "The consolidated _information resources_ that will be validated (this should include consolidated summaries such as \"all employees with privileged access that are members of the Admin group\")",
+                "The machine-based processes for _validation_ and the _persistent_ cycle on which they will be performed (or an explanation of why this doesn't apply)",
+                "The non-machine-based processes for _validation_ and the _persistent_ cycle on which they will be performed (or an explanation of why this doesn't apply)",
+                "Current implementation status",
+                "Any clarifications or responses to the assessment summary"
+              ],
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": [
+                "Machine-Based (Information Resources)",
+                "Provider",
+                "Validation"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "IFR-CSX-MAS": {
+              "name": "Application within MAS",
+              "statement": "Providers SHOULD apply ALL Key Security Indicators to ALL aspects of their cloud service offering that are within the FedRAMP Minimum Assessment Scope.",
+              "force": "SHOULD",
+              "affects": ["Providers"],
+              "terms": ["Cloud Service Offering", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "CLA": {
+            "IFR-CLA-KSM": {
+              "name": "Key Security Indicator Mapping",
+              "statement": "Providers seeking a FedRAMP 20x Certification Class A by leveraging an alternative security framework MUST supply a temporary mapping from the alternative security assessment to the following FedRAMP Key Security Indicators:",
+              "following_information": [
+                "KSI-CMT-LMC",
+                "KSI-CNA-RNT",
+                "KSI-CED-RAT",
+                "KSI-IAM-AAM",
+                "KSI-INR-RIR",
+                "KSI-SVC-SNT"
+              ],
+              "notes": [
+                "The mapping must be available in both machine-readable and human-readable formats.",
+                "If a mapping is not clear, the provider should supply new information indicating that the Key Security Indicator has not been independently audited."
+              ],
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Machine-Readable", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          }
+        },
+        "rev5": {
+          "CSF": {
+            "IFR-CSF-RDY": {
+              "name": "FedRAMP Ready Conversion",
+              "statement": "Providers with FedRAMP Rev5 Ready status MUST convert to a FedRAMP Certification before the furthest date of the expiration of their most recently yearly assessment or November 17, 2026; the legacy FedRAMP Ready status will be entirely removed on December 31, 2027.",
+              "note": "Cloud services that do not wish to convert or do not meet conversion criteria will be renamed Legacy FedRAMP Ready and otherwise retired from FedRAMP Ready.",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "CLA": {
+            "IFR-CLA-CAC": {
+              "name": "Rev5 Class A Certification",
+              "statement": "Providers seeking a FedRAMP Rev5 Class A Certification by leveraging an alternative security framework that is based on the SP 800-53 Revision 5 MUST supply all Security Decision Record materials required for FedRAMP Rev5 Class B Certification.",
+              "notes": [
+                "The only approved alternative security frameworks based on the SP 800-53 Revision 5 are FedRAMP Ready and GovRAMP.",
+                "An independent assessment is not required for FedRAMP Rev5 Class A Certification."
+              ],
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
     "MAS": {
       "info": {
         "name": "Minimum Assessment Scope",
@@ -5009,6 +4801,415 @@
             }
           }
         }
+      }
+    },
+    "MFR": {
+      "info": {
+        "name": "Maintaining FedRAMP Certification",
+        "short_name": "MFR",
+        "web_name": "fedramp-certification",
+        "purpose": "This ruleset explains how cloud service offerings maintain ongoing FedRAMP Certification across certification classes and paths.",
+        "status": "placeholder",
+        "subsets": {
+          "FRP": {
+            "name": "FedRAMP Responsibilities",
+            "description": "These rules apply to FedRAMP.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["FedRAMP"]
+            }
+          },
+          "CSO": {
+            "name": "General Provider Responsibilities",
+            "description": "These rules apply to cloud service providers obtaining and maintaining any FedRAMP Certification.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
+          },
+          "AFR": {
+            "name": "Addressing FedRAMP Rules",
+            "description": "These rules apply to all cloud service providers obtaining and maintaining any FedRAMP Certification.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
+          }
+        },
+        "20x": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2026-07-04",
+              "maintain": "2027-05-04",
+              "grace_ends": "2027-05-04"
+            }
+          },
+          "subsets": {
+            "CSX": {
+              "name": "20x-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
+            }
+          }
+        },
+        "rev5": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2027-01-01",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-01-01"
+            }
+          },
+          "subsets": {
+            "CSF": {
+              "name": "Rev5-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
+            }
+          }
+        }
+      },
+      "data": {
+        "all": {
+          "FRP": {
+            "MFR-FRP-MCM": {
+              "name": "Minimum Continuous Monitoring",
+              "statement": "FedRAMP MUST perform a minimum level of continuous monitoring for cloud service offerings with FedRAMP Program Certification, including at least reviewing Ongoing Certification Reports.",
+              "force": "MUST",
+              "affects": ["FedRAMP"],
+              "terms": ["Cloud Service Offering", "Ongoing Certification"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "CSO": {
+            "MFR-CSO-IVV": {
+              "name": "Independent Verification and Validation",
+              "varies_by_class": {
+                "a": {
+                  "statement": "Providers with Class A Certifications MAY persistently complete an independent verification and validation assessment at least once per year; these assessments MAY be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MAY be included in their FedRAMP Certification Data without inappropriate modification.",
+                  "force": "MAY",
+                  "timeframe_type": "years",
+                  "timeframe_num": 1
+                },
+                "b": {
+                  "statement": "Providers with Class B Certifications MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
+                  "force": "MUST",
+                  "timeframe_type": "years",
+                  "timeframe_num": 1
+                },
+                "c": {
+                  "statement": "Providers with Class C Certifications MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
+                  "force": "MUST",
+                  "timeframe_type": "years",
+                  "timeframe_num": 1
+                },
+                "d": {
+                  "statement": "Providers with Class D Certifications MUST persistently complete an independent verification and validation assessment at least once per year; these assessments MUST be performed by a FedRAMP Recognized independent assessor OR by FedRAMP directly; the results of these assessments MUST be included in their FedRAMP Certification Data without inappropriate modification.",
+                  "force": "MUST",
+                  "timeframe_type": "years",
+                  "timeframe_num": 1
+                }
+              },
+              "notes": [
+                "The first such completed assessment is typically called an \"initial assessment\" while following assessments are called \"annual assessments.\"",
+                "The specific requirements for independent verification and validation assessments are documented by the FedRAMP Certification Class and Type.",
+                "The option for assessment by FedRAMP directly is limited to cloud services that are explicitly prioritized by FedRAMP, in consultation with the FedRAMP Board and the federal Chief Information Officers Council.",
+                "FedRAMP Recognized independent assessors are listed on the FedRAMP Marketplace."
+              ],
+              "affects": ["Providers"],
+              "terms": [
+                "Assessor",
+                "Certification Data",
+                "FedRAMP Recognized",
+                "Persistently",
+                "Provider",
+                "Validation",
+                "Verification"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "AFR": {
+            "MFR-AFR-CDS": {
+              "name": "FedRAMP Certification Data Sharing",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Certification Data Sharing (CDS) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "FedRAMP Certification Data Sharing",
+              "reference_url_web_name": "certification-data-sharing",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "controls": [
+                "ac-3",
+                "ac-4",
+                "au-2",
+                "au-3",
+                "au-6",
+                "ca-2",
+                "ir-4",
+                "ra-5",
+                "sc-8"
+              ],
+              "terms": ["Certification Data", "Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "MFR-AFR-CCM": {
+              "name": "Collaborative Continuous Monitoring",
+              "statement": "Providers MUST follow and persistently address the Collaborative Continuous Monitoring (CCM) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Collaborative Continuous Monitoring",
+              "reference_url_web_name": "collaborative-continuous-monitoring",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "MFR-AFR-FSI": {
+              "name": "FedRAMP Security Inbox",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Security Inbox (FSI) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "FedRAMP Security Inbox",
+              "reference_url_web_name": "fedramp-security-inbox",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["FedRAMP Security Inbox", "Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "MFR-AFR-ICP": {
+              "name": "Incident Communications Procedures",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Incident Communications Procedures (ICP) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Incident Communications Procedures",
+              "reference_url_web_name": "incident-communications-procedures",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Incident", "Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "MFR-AFR-MAS": {
+              "name": "Minimum Assessment Scope",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Minimum Assessment Scope (MAS) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Minimum Assessment Scope",
+              "reference_url_web_name": "minimum-assessment-scope",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "controls": [
+                "ac-1",
+                "ac-21",
+                "at-1",
+                "au-1",
+                "ca-1",
+                "cm-1",
+                "cp-1",
+                "cp-2.1",
+                "cp-2.8",
+                "cp-4.1",
+                "ia-1",
+                "ir-1",
+                "ma-1",
+                "mp-1",
+                "pe-1",
+                "pl-1",
+                "pl-2",
+                "pl-4",
+                "pl-4.1",
+                "ps-1",
+                "ra-1",
+                "ra-9",
+                "sa-1",
+                "sc-1",
+                "si-1",
+                "sr-1",
+                "sr-2",
+                "sr-3",
+                "sr-11"
+              ],
+              "terms": ["Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "MFR-AFR-SCN": {
+              "name": "Significant Change Notifications",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Significant Change Notifications (SCN) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Significant Change Notifications",
+              "reference_url_web_name": "significant-change-notifications",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "controls": [
+                "ca-7.4",
+                "cm-3.4",
+                "cm-4",
+                "cm-7.1",
+                "au-5",
+                "ca-5",
+                "ca-7",
+                "ra-5",
+                "ra-5.2",
+                "sa-22",
+                "si-2",
+                "si-2.2",
+                "si-3",
+                "si-5",
+                "si-7.7",
+                "si-10",
+                "si-11"
+              ],
+              "terms": ["Persistently", "Provider", "Significant Change"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "MFR-AFR-UCM": {
+              "name": "Using Cryptographic Modules",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Using Cryptographic Modules (UCM) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Using Cryptographic Modules",
+              "reference_url_web_name": "using-cryptographic-modules",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "MFR-AFR-VDR": {
+              "name": "Vulnerability Detection and Response",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Vulnerability Detection and Response (VDR) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Vulnerability Detection and Response",
+              "reference_url_web_name": "vulnerability-detection-and-response",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "controls": [
+                "ca-2",
+                "ca-7",
+                "ca-7.6",
+                "ir-1",
+                "ir-4",
+                "ir-4.1",
+                "ir-5",
+                "ir-5.1",
+                "ir-6",
+                "ir-6.1",
+                "ir-6.2",
+                "pm-3",
+                "pm-5",
+                "pm-31",
+                "ra-2",
+                "ra-2.1",
+                "ra-3",
+                "ra-3.3",
+                "ra-5",
+                "ra-5.2",
+                "ra-5.3",
+                "ra-5.4",
+                "ra-5.5",
+                "ra-5.6",
+                "ra-5.7",
+                "ra-5.11",
+                "ra-9",
+                "ra-10",
+                "si-2",
+                "si-2.1",
+                "si-2.2",
+                "si-2.4",
+                "si-2.5",
+                "si-3",
+                "si-3.1",
+                "si-3.2",
+                "si-4",
+                "si-4.2",
+                "si-4.3",
+                "si-4.7",
+                "ca-7.4",
+                "ra-7"
+              ],
+              "terms": [
+                "Persistently",
+                "Provider",
+                "Vulnerability",
+                "Vulnerability Detection",
+                "Vulnerability Response"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "MFR-AFR-SCG": {
+              "name": "Secure Configuration Guide",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Secure Configuration Guide (SCG) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Secure Configuration Guide",
+              "reference_url_web_name": "secure-configuration-guide",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          }
+        },
+        "20x": {},
+        "rev5": {}
       }
     },
     "MKT": {

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -2356,29 +2356,6 @@
             }
           },
           "UTC": {
-            "CDS-UTC-PGD": {
-              "name": "Public Guidance for Certification Data",
-              "statement": "Providers MUST publicly provide plain-language policies and guidance for all necessary parties that explains how they can obtain and manage access to FedRAMP Certification Data stored in the trust center.",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "artifacts": {
-                "all": [
-                  "URL or explanation of the supplied materials, including how to access and use them."
-                ]
-              },
-              "terms": [
-                "All Necessary Parties",
-                "Certification Data",
-                "Provider",
-                "Trust Center"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
             "CDS-UTC-AAD": {
               "name": "Agency Access Denial",
               "statement": "Providers MUST notify FedRAMP within 5 business days of denying an agency access request for FedRAMP Certification Data.",
@@ -5488,7 +5465,10 @@
             "MKT-PRE-REQ": {
               "name": "Preparation Phase Requirements",
               "statement": "Providers MUST implement a minimum set of rules to be listed in the FedRAMP Marketplace during the Preparation Phase, including at least:",
-              "following_information": ["CDS: rules", "CCM: rules"],
+              "following_information": [
+                "CDS-CSO-PUB (Public Information",
+                "CDS-CSO-UTC (Use Trust Centers)"
+              ],
               "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Provider"],
@@ -5501,7 +5481,7 @@
             },
             "MKT-PRE-DCP": {
               "name": "Demonstrating Continuous Progress",
-              "statement": "Providers MUST demonstrate continuous progress towards FedRAMP Certification, documented in their quarterly Ongoing Certification Reports; progress is measured by the provider against documented goals and milestones.",
+              "statement": "Providers MUST demonstrate continuous progress towards a FedRAMP Certification, documented in their Trust Center and updated at least quarterly; progress is measured by the provider against documented goals and milestones.",
               "note": "This is an opportunity for a business to showcase its goals and progress, and should be seen as a marketing and customer experience challenge instead of a compliance challenge.",
               "force": "MUST",
               "affects": ["Providers"],

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -2,7 +2,7 @@
   "info": {
     "title": "FedRAMP Consolidated Rules for 2026 Public Preview",
     "description": "This datafile contains the Consolidated Rules for FedRAMP in structured machine-readable text. It includes definitions, requirements, recommendations, and key security indicators.",
-    "version": "2026.06.03.01-preview",
+    "version": "2026.06.4.01-preview",
     "last_updated": "2026-06-03",
     "default_artifacts": {
       "FRR": [
@@ -2502,6 +2502,109 @@
         }
       }
     },
+    "CPO": {
+      "info": {
+        "name": "Certification Package Overview",
+        "short_name": "CPO",
+        "web_name": "certification-package-overview",
+        "purpose": "The Certification Package Overview rules outline the expectations for a simple overview of the cloud service offering that must be included within a FedRAMP Certification Package.",
+        "status": "empty",
+        "subsets": {
+          "CSO": {
+            "name": "General Provider Responsibilities",
+            "description": "These rules apply to providers for FedRAMP Certifications of any type.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
+          },
+          "IAS": {
+            "name": "General Independent Assessor Responsibilities",
+            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["B", "C", "D"],
+              "affects": ["Assessors"]
+            }
+          }
+        },
+        "20x": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2026-07-04",
+              "maintain": "2027-01-01",
+              "grace_ends": "2027-05-04"
+            }
+          },
+          "subsets": {
+            "CSX": {
+              "name": "20x-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
+            },
+            "IAX": {
+              "name": "20x-Specific Independent Assessor Responsibilities",
+              "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications.",
+              "applicability": {
+                "types": ["20x"],
+                "paths": ["Program"],
+                "classes": ["B", "C", "D"],
+                "affects": ["Assessors"]
+              }
+            }
+          }
+        },
+        "rev5": {
+          "effective": {
+            "is": "required",
+            "current_status": "Consolidated Rules for 2026",
+            "date": {
+              "obtain": "2027-01-01",
+              "maintain": "2027-08-01",
+              "grace_ends": "2028-02-01"
+            },
+            "signup_url": "ADDME"
+          },
+          "subsets": {
+            "CSF": {
+              "name": "Rev5-Specific Provider Responsibilities",
+              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Providers"]
+              }
+            },
+            "IAF": {
+              "name": "Rev5-Specific Independent Assessor Responsibilities",
+              "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications.",
+              "applicability": {
+                "types": ["Rev5"],
+                "paths": ["Program", "Agency"],
+                "classes": ["A", "B", "C", "D"],
+                "affects": ["Assessors"]
+              }
+            }
+          }
+        }
+      },
+      "data": {
+        "all": {},
+        "20x": {},
+        "rev5": {}
+      }
+    },
     "FRC": {
       "info": {
         "name": "FedRAMP Certification",
@@ -2523,6 +2626,16 @@
           "CSO": {
             "name": "General Provider Responsibilities",
             "description": "These rules apply to cloud service providers obtaining and maintaining any FedRAMP Certification.",
+            "applicability": {
+              "types": ["20x", "Rev5"],
+              "paths": ["Program", "Agency"],
+              "classes": ["A", "B", "C", "D"],
+              "affects": ["Providers"]
+            }
+          },
+          "AFR": {
+            "name": "Addressing FedRAMP Rules",
+            "description": "These rules apply to all cloud service providers obtaining and maintaining any FedRAMP Certification.",
             "applicability": {
               "types": ["20x", "Rev5"],
               "paths": ["Program", "Agency"],
@@ -2695,252 +2808,6 @@
                 }
               ]
             },
-            "FRC-CSO-CDS": {
-              "name": "FedRAMP Certification Data Sharing",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Certification Data Sharing (CDS) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "FedRAMP Certification Data Sharing",
-              "reference_url_web_name": "certification-data-sharing",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "controls": [
-                "ac-3",
-                "ac-4",
-                "au-2",
-                "au-3",
-                "au-6",
-                "ca-2",
-                "ir-4",
-                "ra-5",
-                "sc-8"
-              ],
-              "terms": ["Certification Data", "Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-CCM": {
-              "name": "Collaborative Continuous Monitoring",
-              "statement": "Providers MUST follow and persistently address the Collaborative Continuous Monitoring (CCM) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Collaborative Continuous Monitoring",
-              "reference_url_web_name": "collaborative-continuous-monitoring",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-FSI": {
-              "name": "FedRAMP Security Inbox",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Security Inbox (FSI) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "FedRAMP Security Inbox",
-              "reference_url_web_name": "fedramp-security-inbox",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["FedRAMP Security Inbox", "Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-ICP": {
-              "name": "Incident Communications Procedures",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Incident Communications Procedures (ICP) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Incident Communications Procedures",
-              "reference_url_web_name": "incident-communications-procedures",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Incident", "Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-MAS": {
-              "name": "Minimum Assessment Scope",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Minimum Assessment Scope (MAS) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Minimum Assessment Scope",
-              "reference_url_web_name": "minimum-assessment-scope",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "controls": [
-                "ac-1",
-                "ac-21",
-                "at-1",
-                "au-1",
-                "ca-1",
-                "cm-1",
-                "cp-1",
-                "cp-2.1",
-                "cp-2.8",
-                "cp-4.1",
-                "ia-1",
-                "ir-1",
-                "ma-1",
-                "mp-1",
-                "pe-1",
-                "pl-1",
-                "pl-2",
-                "pl-4",
-                "pl-4.1",
-                "ps-1",
-                "ra-1",
-                "ra-9",
-                "sa-1",
-                "sc-1",
-                "si-1",
-                "sr-1",
-                "sr-2",
-                "sr-3",
-                "sr-11"
-              ],
-              "terms": ["Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-SCG": {
-              "name": "Secure Configuration Guide",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Secure Configuration Guide (SCG) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Secure Configuration Guide",
-              "reference_url_web_name": "secure-configuration-guide",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-SCN": {
-              "name": "Significant Change Notifications",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Significant Change Notifications (SCN) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Significant Change Notifications",
-              "reference_url_web_name": "significant-change-notifications",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "controls": [
-                "ca-7.4",
-                "cm-3.4",
-                "cm-4",
-                "cm-7.1",
-                "au-5",
-                "ca-5",
-                "ca-7",
-                "ra-5",
-                "ra-5.2",
-                "sa-22",
-                "si-2",
-                "si-2.2",
-                "si-3",
-                "si-5",
-                "si-7.7",
-                "si-10",
-                "si-11"
-              ],
-              "terms": ["Persistently", "Provider", "Significant Change"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-UCM": {
-              "name": "Using Cryptographic Modules",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Using Cryptographic Modules (UCM) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Using Cryptographic Modules",
-              "reference_url_web_name": "using-cryptographic-modules",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "terms": ["Persistently", "Provider"],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
-            "FRC-CSO-VDR": {
-              "name": "Vulnerability Detection and Response",
-              "statement": "Providers MUST follow and persistently address the FedRAMP Vulnerability Detection and Response (VDR) rules, based on the applicability and effective date(s) in those rules.",
-              "reference": "Vulnerability Detection and Response",
-              "reference_url_web_name": "vulnerability-detection-and-response",
-              "force": "MUST",
-              "affects": ["Providers"],
-              "controls": [
-                "ca-2",
-                "ca-7",
-                "ca-7.6",
-                "ir-1",
-                "ir-4",
-                "ir-4.1",
-                "ir-5",
-                "ir-5.1",
-                "ir-6",
-                "ir-6.1",
-                "ir-6.2",
-                "pm-3",
-                "pm-5",
-                "pm-31",
-                "ra-2",
-                "ra-2.1",
-                "ra-3",
-                "ra-3.3",
-                "ra-5",
-                "ra-5.2",
-                "ra-5.3",
-                "ra-5.4",
-                "ra-5.5",
-                "ra-5.6",
-                "ra-5.7",
-                "ra-5.11",
-                "ra-9",
-                "ra-10",
-                "si-2",
-                "si-2.1",
-                "si-2.2",
-                "si-2.4",
-                "si-2.5",
-                "si-3",
-                "si-3.1",
-                "si-3.2",
-                "si-4",
-                "si-4.2",
-                "si-4.3",
-                "si-4.7",
-                "ca-7.4",
-                "ra-7"
-              ],
-              "terms": [
-                "Persistently",
-                "Provider",
-                "Vulnerability",
-                "Vulnerability Detection",
-                "Vulnerability Response"
-              ],
-              "updated": [
-                {
-                  "date": "2026-05-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
-                }
-              ]
-            },
             "FRC-CSO-IVV": {
               "name": "Independent Verification and Validation",
               "varies_by_class": {
@@ -3032,6 +2899,258 @@
                 "Verification"
               ],
               "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            }
+          },
+          "AFR": {
+            "FRC-AFR-CDS": {
+              "name": "FedRAMP Certification Data Sharing",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Certification Data Sharing (CDS) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "FedRAMP Certification Data Sharing",
+              "reference_url_web_name": "certification-data-sharing",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "controls": [
+                "ac-3",
+                "ac-4",
+                "au-2",
+                "au-3",
+                "au-6",
+                "ca-2",
+                "ir-4",
+                "ra-5",
+                "sc-8"
+              ],
+              "terms": ["Certification Data", "Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-AFR-CCM": {
+              "name": "Collaborative Continuous Monitoring",
+              "statement": "Providers MUST follow and persistently address the Collaborative Continuous Monitoring (CCM) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Collaborative Continuous Monitoring",
+              "reference_url_web_name": "collaborative-continuous-monitoring",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-AFR-FSI": {
+              "name": "FedRAMP Security Inbox",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Security Inbox (FSI) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "FedRAMP Security Inbox",
+              "reference_url_web_name": "fedramp-security-inbox",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["FedRAMP Security Inbox", "Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-AFR-ICP": {
+              "name": "Incident Communications Procedures",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Incident Communications Procedures (ICP) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Incident Communications Procedures",
+              "reference_url_web_name": "incident-communications-procedures",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Incident", "Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-AFR-MAS": {
+              "name": "Minimum Assessment Scope",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Minimum Assessment Scope (MAS) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Minimum Assessment Scope",
+              "reference_url_web_name": "minimum-assessment-scope",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "controls": [
+                "ac-1",
+                "ac-21",
+                "at-1",
+                "au-1",
+                "ca-1",
+                "cm-1",
+                "cp-1",
+                "cp-2.1",
+                "cp-2.8",
+                "cp-4.1",
+                "ia-1",
+                "ir-1",
+                "ma-1",
+                "mp-1",
+                "pe-1",
+                "pl-1",
+                "pl-2",
+                "pl-4",
+                "pl-4.1",
+                "ps-1",
+                "ra-1",
+                "ra-9",
+                "sa-1",
+                "sc-1",
+                "si-1",
+                "sr-1",
+                "sr-2",
+                "sr-3",
+                "sr-11"
+              ],
+              "terms": ["Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-AFR-SCN": {
+              "name": "Significant Change Notifications",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Significant Change Notifications (SCN) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Significant Change Notifications",
+              "reference_url_web_name": "significant-change-notifications",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "controls": [
+                "ca-7.4",
+                "cm-3.4",
+                "cm-4",
+                "cm-7.1",
+                "au-5",
+                "ca-5",
+                "ca-7",
+                "ra-5",
+                "ra-5.2",
+                "sa-22",
+                "si-2",
+                "si-2.2",
+                "si-3",
+                "si-5",
+                "si-7.7",
+                "si-10",
+                "si-11"
+              ],
+              "terms": ["Persistently", "Provider", "Significant Change"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-AFR-UCM": {
+              "name": "Using Cryptographic Modules",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Using Cryptographic Modules (UCM) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Using Cryptographic Modules",
+              "reference_url_web_name": "using-cryptographic-modules",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-AFR-VDR": {
+              "name": "Vulnerability Detection and Response",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Vulnerability Detection and Response (VDR) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Vulnerability Detection and Response",
+              "reference_url_web_name": "vulnerability-detection-and-response",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "controls": [
+                "ca-2",
+                "ca-7",
+                "ca-7.6",
+                "ir-1",
+                "ir-4",
+                "ir-4.1",
+                "ir-5",
+                "ir-5.1",
+                "ir-6",
+                "ir-6.1",
+                "ir-6.2",
+                "pm-3",
+                "pm-5",
+                "pm-31",
+                "ra-2",
+                "ra-2.1",
+                "ra-3",
+                "ra-3.3",
+                "ra-5",
+                "ra-5.2",
+                "ra-5.3",
+                "ra-5.4",
+                "ra-5.5",
+                "ra-5.6",
+                "ra-5.7",
+                "ra-5.11",
+                "ra-9",
+                "ra-10",
+                "si-2",
+                "si-2.1",
+                "si-2.2",
+                "si-2.4",
+                "si-2.5",
+                "si-3",
+                "si-3.1",
+                "si-3.2",
+                "si-4",
+                "si-4.2",
+                "si-4.3",
+                "si-4.7",
+                "ca-7.4",
+                "ra-7"
+              ],
+              "terms": [
+                "Persistently",
+                "Provider",
+                "Vulnerability",
+                "Vulnerability Detection",
+                "Vulnerability Response"
+              ],
+              "updated": [
+                {
+                  "date": "2026-05-04",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-AFR-SCG": {
+              "name": "Secure Configuration Guide",
+              "statement": "Providers MUST follow and persistently address the FedRAMP Secure Configuration Guide (SCG) rules, based on the applicability and effective date(s) in those rules.",
+              "reference": "Secure Configuration Guide",
+              "reference_url_web_name": "secure-configuration-guide",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": ["Persistently", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-06-03",
+                  "comment": "Renamed to \"FRC-AFR-SCG\"."
+                },
                 {
                   "date": "2026-05-04",
                   "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
@@ -3821,212 +3940,6 @@
             }
           }
         }
-      }
-    },
-    "IAP": {
-      "info": {
-        "name": "Independent Assessment Plan",
-        "short_name": "IAP",
-        "web_name": "independent-assessment-plan",
-        "purpose": "The Independent Assessment Plan rules explain how independent assessment services should approach the verification, validation, and attestation of a cloud service provider's own Security Decision Record on behalf of FedRAMP.",
-        "status": "empty",
-        "subsets": {
-          "CSO": {
-            "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Certifications of any type.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["A", "B", "C", "D"],
-              "affects": ["Providers"]
-            }
-          },
-          "IAS": {
-            "name": "General Independent Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["B", "C", "D"],
-              "affects": ["Assessors"]
-            }
-          }
-        },
-        "20x": {
-          "effective": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-07-04",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-05-04"
-            }
-          },
-          "subsets": {
-            "CSX": {
-              "name": "20x-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
-              "applicability": {
-                "types": ["20x"],
-                "paths": ["Program"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Providers"]
-              }
-            },
-            "IAX": {
-              "name": "20x-Specific Independent Assessor Responsibilities",
-              "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications.",
-              "applicability": {
-                "types": ["20x"],
-                "paths": ["Program"],
-                "classes": ["B", "C", "D"],
-                "affects": ["Assessors"]
-              }
-            }
-          }
-        },
-        "rev5": {
-          "effective": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2027-01-01",
-              "maintain": "2027-08-01",
-              "grace_ends": "2028-02-01"
-            },
-            "signup_url": "ADDME"
-          },
-          "subsets": {
-            "CSF": {
-              "name": "Rev5-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
-              "applicability": {
-                "types": ["Rev5"],
-                "paths": ["Program", "Agency"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Providers"]
-              }
-            },
-            "IAF": {
-              "name": "Rev5-Specific Independent Assessor Responsibilities",
-              "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications.",
-              "applicability": {
-                "types": ["Rev5"],
-                "paths": ["Program", "Agency"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Assessors"]
-              }
-            }
-          }
-        }
-      },
-      "data": {
-        "all": {},
-        "20x": {},
-        "rev5": {}
-      }
-    },
-    "IAR": {
-      "info": {
-        "name": "Independent Assessment Report",
-        "short_name": "IAR",
-        "web_name": "independent-assessment-report",
-        "purpose": "The Independent Assessment Report rules explain the minimum expectations for independent assessor attestations after the completion of an independent assessment for FedRAMP Certification.",
-        "status": "empty",
-        "subsets": {
-          "CSO": {
-            "name": "General Provider Responsibilities",
-            "description": "These rules apply to providers for FedRAMP Certifications of any type.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["A", "B", "C", "D"],
-              "affects": ["Providers"]
-            }
-          },
-          "IAS": {
-            "name": "General Independent Assessor Responsibilities",
-            "description": "These rules apply to independent assessment services supporting all FedRAMP Certification types.",
-            "applicability": {
-              "types": ["20x", "Rev5"],
-              "paths": ["Program", "Agency"],
-              "classes": ["B", "C", "D"],
-              "affects": ["Assessors"]
-            }
-          }
-        },
-        "20x": {
-          "effective": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-07-04",
-              "maintain": "2027-01-01",
-              "grace_ends": "2027-05-04"
-            }
-          },
-          "subsets": {
-            "CSX": {
-              "name": "20x-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP 20x Certifications.",
-              "applicability": {
-                "types": ["20x"],
-                "paths": ["Program"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Providers"]
-              }
-            },
-            "IAX": {
-              "name": "20x-Specific Independent Assessor Responsibilities",
-              "description": "These rules apply to independent assessment services supporting FedRAMP 20x Certifications.",
-              "applicability": {
-                "types": ["20x"],
-                "paths": ["Program"],
-                "classes": ["B", "C", "D"],
-                "affects": ["Assessors"]
-              }
-            }
-          }
-        },
-        "rev5": {
-          "effective": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2027-01-01",
-              "maintain": "2027-08-01",
-              "grace_ends": "2028-02-01"
-            },
-            "signup_url": "ADDME"
-          },
-          "subsets": {
-            "CSF": {
-              "name": "Rev5-Specific Provider Responsibilities",
-              "description": "These rules apply to providers for FedRAMP Rev5 Certifications.",
-              "applicability": {
-                "types": ["Rev5"],
-                "paths": ["Program", "Agency"],
-                "classes": ["A", "B", "C", "D"],
-                "affects": ["Providers"]
-              }
-            },
-            "IAF": {
-              "name": "Rev5-Specific Independent Assessor Responsibilities",
-              "description": "These rules apply to independent assessment services supporting FedRAMP Rev5 Certifications.",
-              "applicability": {
-                "types": ["Rev5"],
-                "paths": ["Program", "Agency"],
-                "classes": ["B", "C", "D"],
-                "affects": ["Assessors"]
-              }
-            }
-          }
-        }
-      },
-      "data": {
-        "all": {},
-        "20x": {},
-        "rev5": {}
       }
     },
     "ICP": {

--- a/schemas/fedramp-consolidated-rules.schema.json
+++ b/schemas/fedramp-consolidated-rules.schema.json
@@ -140,6 +140,7 @@
         "CSF",
         "CSX",
         "CSL",
+        "AFR",
         "IAF",
         "IAS",
         "IAX",


### PR DESCRIPTION
## Rules Content Changes

- Structural: the former `FRC` FedRAMP Certification placeholder was split across `IFR`, `FRA`, `OFR`, and empty `CPO` rulesets; unchanged former `FRC` requirements were reissued as `IFR-FRP-ECR`, `IFR-CSO-POP`, `IFR-CLA-ASF`, `IFR-CLA-EAM`, `IFR-CLA-IVV`, `IFR-APP-MLF`, `IFR-APP-AFC`, `IFR-APP-FCP`, `IFR-APP-FIA`, `IFR-APS-ATO`, `IFR-CSX-MAS`, `IFR-CLA-KSM`, `IFR-CSF-RDY`, `IFR-CLA-CAC`, `FRA-CSO-STE`, `FRA-CSO-RAA`, `FRA-IAS-VVP`, `FRA-IAS-OUC`, `FRA-IAS-PAD`, `FRA-IAS-MME`, `FRA-IAS-SUM`, `FRA-IAS-OSA`, `FRA-IAS-EPX`, `FRA-IAS-SHA`, `FRA-IAX-UNP`, `FRA-IAX-STE`, `OFR-FRP-MCM`, `OFR-AFR-CDS`, `OFR-AFR-CCM`, `OFR-AFR-FSI`, `OFR-AFR-ICP`, `OFR-AFR-MAS`, `OFR-AFR-SCG`, `OFR-AFR-SCN`, `OFR-AFR-UCM`, `OFR-AFR-VDR`, and `OFR-CSO-IVV`.
- `IFR-CSO-PKG` adds a class-specific FedRAMP Certification Package requirement: Class A packages require a Certification Package Overview and External Framework Mapping, while Classes B, C, and D require a Certification Package Overview, Security Decision Record, and real or example OCR evidence related to `CCM-OCR-AVL`.
- `IFR-CLA-AFR` replaces `FRC-CLA-AFR`, updates the related certification rule reference from `FRC-CSO-POP` to `IFR-CSO-POP`, and removes `CDS-UTC-PGD` from the Class A FedRAMP rules that must be addressed.
- `IFR-CSX-SUM` replaces `FRC-CSX-SUM`, renaming “Implementation Summaries” to “Initial Implementation Summaries” and changing the obligation from maintaining summaries to supplying summaries for each Key Security Indicator.
- `FRC-CSF-CDE` was removed, eliminating the explicit Rev5 Class D Program Certification Exclusion rule that required Rev5 Class D providers to use the Agency Certification path.
- `CDS-CSO-PUB` narrows the public information obligation to information that is available and applicable, splits contact information into sales and security contacts, adds product website and logo links, simplifies secure configuration guidance, and replaces several trust-center operational items with a trust-center landing page instruction.
- `CDS-UTC-PGD` was removed, eliminating the standalone Public Guidance for Certification Data requirement.
- `CDS-UTC-AAD` keeps the 5-business-day agency access denial notification requirement but removes the email address from the statement text while retaining the structured notification metadata.
- `CDS-UTC-AGA` changes the agency access recommendation from sharing the FedRAMP Certification package to supplying access to it upon agency request.
- `MKT-PRE-REQ` replaces broad “CDS: rules” and “CCM: rules” preparation-phase prerequisites with explicit references to `CDS-CSO-PUB` and `CDS-CSO-UTC`, adding related-rule metadata and the Trust Center term.
- `MKT-PRE-DCP` moves continuous-progress evidence from quarterly Ongoing Certification Reports to Trust Center updates at least quarterly, replacing the Ongoing Certification term with Trust Center.
- FRD definitions and KSI indicators are unchanged.

## Schema And Structure Changes

- fedramp-consolidated-rules.json updates dataset metadata from `2026.06.03.01-preview` / `2026-06-03` to `2026.06.04.01-preview` / `2026-06-04`.
- Structural: FRR top-level process keys remove `FRC`, `IAP`, and `IAR`, and add `CPO`, `FRA`, `IFR`, and `OFR`; this is a rule taxonomy reorganization rather than a schema-shape breaking change.
- Structural: `CPO` is introduced as an empty Certification Package Overview ruleset with common `CSO` and `IAS` subsets plus framework-specific effective metadata.
- Structural: `FRA`, `IFR`, and `OFR` are introduced as placeholder rulesets with framework-specific effective metadata and redistributed assessment, initial certification, and ongoing certification requirements.
- schemas/fedramp-consolidated-rules.schema.json adds `AFR` to the allowed FRR subset key enum so the new `OFR.data.all.AFR` subset validates.
- Structural: the empty `CDS.data.20x.CSX` bucket was removed from the rules JSON.