### PR TITLE
Pwx 619

### DIFF
--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -51,8 +51,8 @@
           "alts": ["accepted vulnerability", "accepted vulnerabilities"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -64,8 +64,8 @@
           "alts": ["adaptive", "adaptive change", "adaptive changes"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -77,8 +77,8 @@
           "do_not_link": true,
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -92,8 +92,8 @@
           "reference_url": "https://www.govinfo.gov/app/details/USCODE-2023-title44/USCODE-2023-title44-chap35-subchapI-sec3502",
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -104,8 +104,8 @@
           "alts": ["all affected parties"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -116,8 +116,8 @@
           "alts": ["all necessary assessors"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -128,8 +128,8 @@
           "alts": ["all necessary parties"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -140,8 +140,8 @@
           "alts": ["artifact", "artifacts"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -154,8 +154,8 @@
           "do_not_link": true,
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -166,8 +166,8 @@
           "alts": ["Certification Class", "Certification Classes"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -178,8 +178,8 @@
           "alts": ["certification class change", "certification class changes"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -191,8 +191,8 @@
           "alts": ["certification data"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -206,8 +206,8 @@
           "reference_url": "https://fedramp.gov/docs/authority/law/#b-additional-definitions",
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -218,8 +218,8 @@
           "alts": ["Certification Path", "Certification Paths"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -230,8 +230,8 @@
           "alts": ["Certification Profile", "Certification Profiles"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -242,8 +242,8 @@
           "alts": ["Certification Type", "Certification Types"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -254,8 +254,8 @@
           "alts": ["cloud service offering", "cloud service offerings"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -269,8 +269,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -281,8 +281,8 @@
           "alts": ["deterministic telemetry"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -293,8 +293,8 @@
           "alts": ["disruptive customer effect", "disruptive customer effects"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -304,8 +304,8 @@
           "alts": ["drift", "drifts", "drifting"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -323,8 +323,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -335,8 +335,8 @@
           "alts": ["federal customer data"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -353,8 +353,8 @@
           "reference_url": "https://www.fedramp.gov/docs/authority/law/#sec-3608-federal-risk-and-authorization-management-program",
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -375,8 +375,8 @@
           "reference_url": "https://www.fedramp.gov/docs/authority/law/#sec-3608-federal-risk-and-authorization-management-program",
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -389,8 +389,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -400,8 +400,8 @@
           "alts": ["FedRAMP Practice", "FedRAMP Practices"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -411,8 +411,8 @@
           "alts": ["FedRAMP Recognized", "FedRAMP Recognition"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -426,8 +426,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -437,8 +437,8 @@
           "alts": ["security inbox", "security inboxes", "FSI"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -454,8 +454,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -470,8 +470,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -481,8 +481,8 @@
           "alts": ["handle", "handles", "handled", "handling"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -495,8 +495,8 @@
           "reference_url": "https://www.govinfo.gov/app/details/USCODE-2024-title44/USCODE-2024-title44-chap35-subchapII-sec3552",
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -510,8 +510,8 @@
           "reference_url": "https://www.govinfo.gov/app/details/USCODE-2023-title44/USCODE-2023-title44-chap35-subchapI-sec3502",
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -522,8 +522,8 @@
           "alts": ["initial certification", "initial certifications"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -534,8 +534,8 @@
           "alts": ["initial FedRAMP assessment", "IFRA"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -551,8 +551,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -575,8 +575,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -594,8 +594,8 @@
           "reference_url": "https://www.cisa.gov/news-events/directives/bod-26-04-prioritizing-security-updates-based-risk",
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -605,8 +605,8 @@
           "alts": ["likely", "likelihood"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -628,8 +628,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -641,8 +641,8 @@
           "alts": ["machine-based", "machine based"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -652,8 +652,8 @@
           "alts": ["machine-generated"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -665,8 +665,8 @@
           "reference_url": "https://www.govinfo.gov/app/details/USCODE-2023-title44/USCODE-2023-title44-chap35-subchapI-sec3502",
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -677,8 +677,8 @@
           "alts": ["minimal customer effect", "minimal customer effects"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -689,8 +689,8 @@
           "alts": ["narrow customer effect", "narrow customer effects"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -701,8 +701,8 @@
           "alts": ["ongoing certification", "ongoing certifications"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -712,8 +712,8 @@
           "alts": ["ongoing certification report", "OCR", "OCRs"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -729,8 +729,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -741,8 +741,8 @@
           "alts": ["overdue vulnerability", "overdue vulnerabilities"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -757,8 +757,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -769,8 +769,8 @@
           "alts": ["persistent FedRAMP assessment", "PFRA"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -781,8 +781,8 @@
           "alts": ["persistently", "persistent"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -797,8 +797,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -810,8 +810,8 @@
           "alts": ["privileged account", "privileged accounts"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -822,8 +822,8 @@
           "alts": ["promptly", "prompt"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -841,8 +841,8 @@
           "do_not_link": true,
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -853,8 +853,8 @@
           "alts": ["quarterly review", "quarterly reviews"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -864,8 +864,8 @@
           "alts": ["regularly", "regular"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -880,8 +880,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -892,8 +892,8 @@
           "alts": ["responsibly"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -908,8 +908,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -926,8 +926,8 @@
           "reference_url": "https://csrc.nist.gov/pubs/fips/199/final",
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -941,8 +941,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -955,8 +955,8 @@
           "reference_url": "https://csrc.nist.gov/pubs/sp/800/37/r2/final",
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -970,8 +970,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -986,8 +986,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -1003,8 +1003,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -1015,8 +1015,8 @@
           "alts": ["trust center", "trust centers"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -1029,8 +1029,8 @@
           "reference_url": "https://www.iso.org/standard/27001",
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -1043,8 +1043,8 @@
           "reference_url": "https://www.iso.org/standard/27001",
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -1057,8 +1057,8 @@
           "reference_url": "https://www.govinfo.gov/app/details/USCODE-2024-title6/USCODE-2024-title6-chap1-subchapXVIII-sec650",
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -1076,8 +1076,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -1095,8 +1095,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         }
@@ -1159,8 +1159,8 @@
               "terms": ["Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1178,8 +1178,8 @@
               "terms": ["FedRAMP Security Inbox", "Incident", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1190,8 +1190,8 @@
               "affects": ["FedRAMP"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1216,8 +1216,8 @@
               "terms": ["Likely"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1228,8 +1228,8 @@
               "affects": ["FedRAMP"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1252,8 +1252,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1264,8 +1264,8 @@
               "affects": ["FedRAMP"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1277,8 +1277,8 @@
               "terms": ["Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -1301,8 +1301,8 @@
               "terms": ["FedRAMP Security Inbox", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1330,8 +1330,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1349,8 +1349,8 @@
               "terms": ["FedRAMP Security Inbox", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1363,8 +1363,8 @@
               "terms": ["Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1377,8 +1377,8 @@
               "terms": ["Certification Class", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1397,8 +1397,8 @@
               "terms": ["Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1411,8 +1411,8 @@
               "terms": ["Certification Class", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1424,8 +1424,8 @@
               "terms": ["FedRAMP Security Inbox", "Promptly", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -1498,8 +1498,8 @@
               "terms": ["Agency"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1522,8 +1522,8 @@
               "terms": ["Agency"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1539,8 +1539,8 @@
               "terms": ["Agency", "Artifacts", "Machine-Readable"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1564,8 +1564,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1590,8 +1590,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1617,8 +1617,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1630,8 +1630,8 @@
               "terms": ["Agency"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1645,8 +1645,8 @@
               "terms": ["Agency"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1659,8 +1659,8 @@
               "terms": ["Agency"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -1681,8 +1681,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1694,8 +1694,8 @@
               "terms": ["Agency", "Certification Package"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1707,8 +1707,8 @@
               "terms": ["Agency", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1724,8 +1724,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1753,8 +1753,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1773,8 +1773,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1791,8 +1791,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1820,8 +1820,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1838,8 +1838,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1855,8 +1855,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -1870,8 +1870,8 @@
               "terms": ["Agency"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -1969,8 +1969,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -1990,8 +1990,8 @@
               "terms": ["Agency", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2009,8 +2009,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2029,8 +2029,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -2074,8 +2074,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2093,8 +2093,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2116,8 +2116,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2139,8 +2139,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2159,8 +2159,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2178,8 +2178,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2199,8 +2199,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -2264,8 +2264,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2284,8 +2284,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2297,8 +2297,8 @@
               "terms": ["Certification Data", "Provider", "Quarterly Review"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2315,8 +2315,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2335,8 +2335,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2348,8 +2348,8 @@
               "terms": ["Agency", "Provider", "Quarterly Review"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2365,8 +2365,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2385,8 +2385,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2405,8 +2405,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2424,8 +2424,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -2567,8 +2567,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2591,8 +2591,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2609,8 +2609,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2631,8 +2631,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2670,8 +2670,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2689,8 +2689,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2702,8 +2702,8 @@
               "terms": ["Certification Data", "Machine-Readable", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2740,8 +2740,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2770,8 +2770,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2794,8 +2794,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2847,8 +2847,8 @@
               "terms": ["Agency", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2871,8 +2871,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -2891,8 +2891,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2907,8 +2907,8 @@
               "terms": ["Certification Data", "Trust Center"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2925,8 +2925,8 @@
               "terms": ["Agency", "Certification Data", "Trust Center"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2943,8 +2943,8 @@
               "terms": ["Certification Data", "Trust Center"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2960,8 +2960,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -2982,8 +2982,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -3006,8 +3006,8 @@
               "terms": ["Agency", "Certification Data", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -3025,8 +3025,8 @@
               "terms": ["Agency", "Certification Package", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -3054,8 +3054,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -3130,8 +3130,8 @@
               "terms": ["Federal Customer Data", "Provider", "Validation"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -3179,8 +3179,8 @@
               "terms": ["Federal Customer Data", "Provider", "Validation"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -3197,8 +3197,8 @@
               "terms": ["Agency", "Provider", "Validation"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -3331,8 +3331,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -3350,8 +3350,8 @@
               "terms": ["Certification Package", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -3395,8 +3395,8 @@
               "terms": ["Certification Package", "Persistently", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -3446,8 +3446,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -3591,8 +3591,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -3644,8 +3644,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-07-04",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -3658,8 +3658,8 @@
               "terms": ["Machine-Readable", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -3671,8 +3671,8 @@
               "terms": ["Assessor", "Certification Package", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -3685,8 +3685,8 @@
               "terms": ["Agency", "Cloud Service Offering", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -3705,8 +3705,8 @@
               "terms": ["Provider", "Security Category"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -3723,8 +3723,8 @@
               "terms": ["All Necessary Parties", "Provider", "Verification"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -3805,8 +3805,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -3825,8 +3825,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -3852,8 +3852,8 @@
               "terms": ["Agency", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -3867,8 +3867,8 @@
               "terms": ["Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -3886,8 +3886,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -3927,8 +3927,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -3944,8 +3944,8 @@
               "terms": ["Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -3963,8 +3963,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -3978,8 +3978,8 @@
               "terms": ["Agency", "Cloud Service Offering", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -3997,8 +3997,8 @@
               "terms": ["Certification Class", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -4019,8 +4019,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -4033,8 +4033,8 @@
               "terms": ["Agency", "All Necessary Parties", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -4050,8 +4050,8 @@
               "terms": ["Cloud Service Offering", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -4071,8 +4071,8 @@
               "terms": ["Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -4218,8 +4218,8 @@
               "terms": ["Incident", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -4245,8 +4245,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -4266,8 +4266,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -4528,8 +4528,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -4777,8 +4777,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -4997,8 +4997,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5035,8 +5035,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5054,8 +5054,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -5197,8 +5197,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5217,8 +5217,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5238,8 +5238,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5261,8 +5261,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5275,8 +5275,8 @@
               "terms": ["Provider", "Validation", "Verification"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5294,8 +5294,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5313,8 +5313,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5332,8 +5332,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -5352,8 +5352,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5365,8 +5365,8 @@
               "terms": ["Assessor", "FedRAMP Practices", "Validation"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5384,8 +5384,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5405,8 +5405,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5426,8 +5426,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5439,8 +5439,8 @@
               "terms": ["Assessor", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5458,8 +5458,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -5503,8 +5503,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -5761,8 +5761,8 @@
               "terms": ["FedRAMP Independent Assessment", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5776,8 +5776,8 @@
               "terms": ["FedRAMP Independent Assessment", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5789,8 +5789,8 @@
               "terms": ["FedRAMP Independent Assessment", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5802,8 +5802,8 @@
               "terms": ["FedRAMP Independent Assessment", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -5895,8 +5895,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5923,8 +5923,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5957,8 +5957,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -5983,8 +5983,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6004,8 +6004,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -6117,8 +6117,8 @@
               "terms": ["Cloud Service Offering"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -6136,8 +6136,8 @@
               "terms": ["Certification Data", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6152,8 +6152,8 @@
               "terms": ["Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -6167,8 +6167,8 @@
               "terms": ["Assessor", "FedRAMP Recognized"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6196,8 +6196,8 @@
               "terms": ["Assessor"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6209,8 +6209,8 @@
               "terms": ["Assessor"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -6240,8 +6240,8 @@
               "terms": ["Advisor", "Machine-Readable"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6253,8 +6253,8 @@
               "terms": ["Advisor"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6271,8 +6271,8 @@
               "terms": ["Advisor"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -6301,8 +6301,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6315,8 +6315,8 @@
               "terms": ["Provider", "Trust Center"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6331,8 +6331,8 @@
               "terms": ["Certification Class", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -6395,8 +6395,8 @@
               "terms": ["Assessor", "FedRAMP Recognized"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6413,8 +6413,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6426,8 +6426,8 @@
               "terms": ["Assessor", "FedRAMP Recognized"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -6442,8 +6442,8 @@
               "terms": ["Assessor", "FedRAMP Recognized"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6462,8 +6462,8 @@
               "terms": ["Assessor", "FedRAMP Recognized"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6477,8 +6477,8 @@
               "terms": ["Assessor", "FedRAMP Recognized"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6495,8 +6495,8 @@
               "terms": ["Assessor", "FedRAMP Recognized"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6513,8 +6513,8 @@
               "terms": ["Assessor", "FedRAMP Recognized"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6527,8 +6527,8 @@
               "terms": ["Assessor", "FedRAMP Recognized"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6543,8 +6543,8 @@
               "terms": ["Assessor"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6566,8 +6566,8 @@
               "terms": ["Assessor"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6589,8 +6589,8 @@
               "terms": ["Assessor"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6616,8 +6616,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6629,8 +6629,8 @@
               "terms": ["Assessor"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6642,8 +6642,8 @@
               "terms": ["Assessor"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6664,8 +6664,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -6747,8 +6747,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6767,8 +6767,8 @@
               "terms": ["Certification Package", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6786,8 +6786,8 @@
               "terms": ["Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6809,8 +6809,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -6834,8 +6834,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6853,8 +6853,8 @@
               "terms": ["Machine-Readable", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6872,8 +6872,8 @@
               "terms": ["Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6891,8 +6891,8 @@
               "terms": ["Machine-Readable", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -6914,8 +6914,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -7027,8 +7027,8 @@
               "terms": ["Provider", "Significant Change"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -7062,8 +7062,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7086,8 +7086,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7124,8 +7124,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7142,8 +7142,8 @@
               "terms": ["Certification Data", "Provider", "Significant Change"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7165,8 +7165,8 @@
               "terms": ["Provider", "Significant Change"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7179,8 +7179,8 @@
               "terms": ["Provider", "Significant Change"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7199,8 +7199,8 @@
               "terms": ["Agency", "Certification Package", "Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7220,8 +7220,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -7280,8 +7280,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -7337,8 +7337,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -7371,8 +7371,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7402,8 +7402,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7433,8 +7433,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7472,8 +7472,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7497,8 +7497,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7540,8 +7540,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -7655,8 +7655,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7673,8 +7673,8 @@
               "terms": ["Provider", "Security Decision Record (SDR)"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -7706,8 +7706,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7748,8 +7748,8 @@
               "terms": ["Provider", "Security Decision Record (SDR)"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -7782,8 +7782,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7795,8 +7795,8 @@
               "terms": ["Provider"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -7893,8 +7893,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7922,8 +7922,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7940,8 +7940,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7959,8 +7959,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7977,8 +7977,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -7995,8 +7995,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -8013,8 +8013,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -8032,8 +8032,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -8051,8 +8051,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -8072,8 +8072,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -8117,8 +8117,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -8162,8 +8162,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -8484,8 +8484,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -8497,8 +8497,8 @@
               "terms": ["Provider", "Vulnerability"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -8516,8 +8516,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -8560,8 +8560,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -8601,8 +8601,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -8648,8 +8648,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -8760,8 +8760,8 @@
               "terms": ["Agency", "Provider", "Vulnerability"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -8778,8 +8778,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -8801,8 +8801,8 @@
               "terms": ["Agency", "Provider", "Vulnerability"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -8821,8 +8821,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -8840,8 +8840,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -8861,8 +8861,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -8888,8 +8888,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -8914,8 +8914,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -8945,8 +8945,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -8958,8 +8958,8 @@
               "terms": ["Provider", "Vulnerability"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -8978,8 +8978,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -8997,8 +8997,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -9027,8 +9027,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -9052,8 +9052,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -9098,8 +9098,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -9140,8 +9140,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -9159,8 +9159,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -9178,8 +9178,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -9191,8 +9191,8 @@
               "terms": ["Likely", "Provider", "Responsibly", "Vulnerability"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -9219,8 +9219,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -9234,8 +9234,8 @@
               "terms": ["Accepted Vulnerability", "Provider", "Vulnerability"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -9305,8 +9305,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -9342,8 +9342,8 @@
               "terms": ["Provider", "Vulnerability", "Vulnerability Detection"],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -9381,8 +9381,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             },
@@ -9420,8 +9420,8 @@
               ],
               "updated": [
                 {
-                  "date": "2026-06-30",
-                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
                 }
               ]
             }
@@ -9458,8 +9458,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Incident", "Persistently", "Vulnerability Response"]
@@ -9487,8 +9487,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Cloud Service Offering"]
@@ -9507,8 +9507,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": [
@@ -9522,8 +9522,8 @@
           "controls": ["cm-3", "cm-3.2", "cm-3.4", "cm-5", "cm-7.1", "cm-9"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Persistently"]
@@ -9534,8 +9534,8 @@
           "controls": ["cm-3", "cm-3.2", "cm-4.2", "si-2"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Persistently", "Validation"]
@@ -9555,8 +9555,8 @@
           "controls": ["cm-2", "si-3"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -9565,8 +9565,8 @@
           "controls": ["ca-2.1", "ca-7.1"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "varies_by_class": {
@@ -9589,8 +9589,8 @@
           "controls": ["ac-17.3", "cm-2", "pl-10"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": [
@@ -9621,8 +9621,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": [
@@ -9637,8 +9637,8 @@
           "controls": [],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": [
@@ -9653,8 +9653,8 @@
           "controls": ["ac-17.3", "ca-9", "cm-7.1", "sc-7.5", "si-8"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": [
@@ -9669,8 +9669,8 @@
           "controls": ["sc-5", "si-8", "si-8.2"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": [
@@ -9694,8 +9694,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Persistently"]
@@ -9725,8 +9725,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -9750,8 +9750,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -9796,8 +9796,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Persistently"]
@@ -9847,8 +9847,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Persistently"]
@@ -9867,8 +9867,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Persistently"]
@@ -9887,8 +9887,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Vulnerability Response"]
@@ -9908,8 +9908,8 @@
           "controls": ["ir-3", "ir-4", "ir-4.1", "ir-8"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Incident", "Persistently"]
@@ -9931,8 +9931,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Incident", "Persistently", "Vulnerability Response"]
@@ -9943,8 +9943,8 @@
           "controls": ["ir-3", "ir-4", "ir-4.1", "ir-5", "ir-8"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Incident", "Persistently", "Vulnerability"]
@@ -9963,8 +9963,8 @@
           "controls": ["si-11"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "varies_by_class": {
@@ -9983,8 +9983,8 @@
           "controls": ["ca-7", "cm-2", "cm-6", "si-7.7"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": [
@@ -10010,8 +10010,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Information Resource", "Persistently"]
@@ -10041,8 +10041,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Persistently"]
@@ -10061,8 +10061,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Persistently"]
@@ -10090,8 +10090,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Information Resource"]
@@ -10102,8 +10102,8 @@
           "controls": [],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Persistently", "Provider"]
@@ -10124,8 +10124,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Persistently", "Provider"]
@@ -10149,8 +10149,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Persistently"]
@@ -10161,8 +10161,8 @@
           "controls": ["ra-5.11"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Persistently", "Provider", "Vulnerability"]
@@ -10182,8 +10182,8 @@
           "controls": ["cm-2.3", "cp-6", "cp-9", "cp-10", "cp-10.2", "si-12"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": [
@@ -10215,8 +10215,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Persistently"]
@@ -10227,8 +10227,8 @@
           "controls": ["cp-2.3", "cp-10"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Persistently", "Provider"]
@@ -10250,8 +10250,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Incident", "Persistently"]
@@ -10284,8 +10284,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Persistently"]
@@ -10307,8 +10307,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Information Resource", "Vulnerability"]
@@ -10340,8 +10340,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": [
@@ -10357,8 +10357,8 @@
           "controls": ["ac-17.2", "ia-5.2", "ia-5.6", "sc-12", "sc-17"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Persistently", "Regularly"]
@@ -10379,8 +10379,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": ["Information Resource", "Persistently"]
@@ -10390,8 +10390,8 @@
           "controls": ["sc-4"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "varies_by_class": {
@@ -10414,8 +10414,8 @@
           "controls": ["si-12.3", "si-18.4"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "varies_by_class": {
@@ -10447,8 +10447,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ]
         },
@@ -10457,8 +10457,8 @@
           "controls": ["sc-23", "si-7.1"],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "varies_by_class": {
@@ -10490,8 +10490,8 @@
           ],
           "updated": [
             {
-              "date": "2026-07-04",
-              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+              "date": "2026-06-23",
+              "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
             }
           ],
           "terms": [

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -1208,9 +1208,10 @@
               "timeframe_num": 10,
               "notification": [
                 {
-                  "party": "publicly",
+                  "party": "Everyone",
                   "method": "web",
-                  "target": "fedramp.gov"
+                  "target": "https://www.fedramp.gov/notices",
+                  "name": "FedRAMP Public Notices"
                 }
               ],
               "terms": ["Likely"],
@@ -1308,7 +1309,7 @@
             },
             "AFC-CSO-NOC": {
               "name": "Notification of Changes",
-              "statement": "Providers MUST immediately notify FedRAMP of any changes in addressing for their FedRAMP Security Inbox by emailing info@fedramp.gov with the name and FedRAMP ID of the cloud service offering and the updated email address.",
+              "statement": "Providers MUST immediately notify FedRAMP of any changes to the email address for their FedRAMP Security Inbox.",
               "force": "MUST",
               "affects": ["Providers"],
               "artifacts": {
@@ -1319,15 +1320,12 @@
               "notification": [
                 {
                   "party": "FedRAMP",
-                  "method": "email",
-                  "target": "info@fedramp.gov"
+                  "method": "form",
+                  "target": "https://help.fedramp.gov/hc/en-us/requests/new?ticket_form_id=51829466938011",
+                  "name": "[CSP] Notification of Changes"
                 }
               ],
-              "terms": [
-                "Cloud Service Offering",
-                "FedRAMP Security Inbox",
-                "Provider"
-              ],
+              "terms": ["FedRAMP Security Inbox", "Provider"],
               "updated": [
                 {
                   "date": "2026-06-23",
@@ -1505,18 +1503,19 @@
             },
             "AGU-AGC-NAL": {
               "name": "Notify FedRAMP After Authorization",
-              "statement": "Agencies MUST supply FedRAMP the following information upon authorizing the use of a cloud service within the scope of FedRAMP:",
+              "statement": "Agencies MUST notify FedRAMP upon authorizing the use of a cloud service within the scope of FedRAMP, supplying at least the following information:",
               "following_information": [
                 "A copy of the Authorization to Operate letter",
-                "All other supplementary information outlined at https://help.fedramp.gov/ato"
+                "All other supplementary information outlined in the Submit an ATO Letter form on the FedRAMP Help Center"
               ],
               "force": "MUST",
               "affects": ["Agencies"],
               "notification": [
                 {
                   "party": "FedRAMP",
-                  "method": "email",
-                  "target": "ato-letter@fedramp.gov"
+                  "method": "form",
+                  "target": "https://help.fedramp.gov/hc/en-us/requests/new?ticket_form_id=51447926193691",
+                  "name": "Submit an ATO Letter"
                 }
               ],
               "terms": ["Agency"],
@@ -1546,15 +1545,16 @@
             },
             "AGU-AGC-NAI": {
               "name": "Notify Additional Information Requests",
-              "statement": "Agencies MUST notify FedRAMP after requesting any additional information or materials from a FedRAMP Certified cloud service offering beyond those FedRAMP requires.",
+              "statement": "Agencies MUST notify FedRAMP after requesting any additional information or materials from a FedRAMP Certified cloud service offering beyond those required by FedRAMP.",
               "note": "Agencies are expected to notify FedRAMP under OMB Memorandum M-24-15 section IV (a).",
               "force": "MUST",
               "affects": ["Agencies"],
               "notification": [
                 {
                   "party": "FedRAMP",
-                  "method": "email",
-                  "target": "info@fedramp.gov"
+                  "method": "form",
+                  "target": "https://help.fedramp.gov/hc/en-us/requests/new?ticket_form_id=51822364715035",
+                  "name": "[For Agencies] Additional Information, Security Requirements, or Certification Change, or After Request Form"
                 }
               ],
               "terms": [
@@ -1579,7 +1579,8 @@
                 {
                   "party": "FedRAMP",
                   "method": "email",
-                  "target": "info@fedramp.gov"
+                  "target": "info@fedramp.gov",
+                  "name": "info@fedramp.gov"
                 }
               ],
               "terms": [
@@ -1605,7 +1606,8 @@
                 {
                   "party": "FedRAMP",
                   "method": "email",
-                  "target": "info@fedramp.gov"
+                  "target": "info@fedramp.gov",
+                  "name": "info@fedramp.gov"
                 }
               ],
               "terms": [
@@ -1738,8 +1740,9 @@
               "notification": [
                 {
                   "party": "FedRAMP",
-                  "method": "email",
-                  "target": "info@fedramp.gov"
+                  "method": "form",
+                  "target": "https://help.fedramp.gov/hc/en-us/requests/new?ticket_form_id=51821301979547",
+                  "name": "Report Concerns on Ongoing Certifications"
                 }
               ],
               "terms": [
@@ -1798,14 +1801,15 @@
             },
             "AGU-USE-NPC": {
               "name": "Notify Provider of Concerns",
-              "statement": "Agencies SHOULD formally notify the Provider if information presented in an Ongoing Certification Report, Quarterly Review, or other FedRAMP Certification Data causes significant concerns for the authorizing official that would likely result in rescission of their Authorization to Operate.",
+              "statement": "Agencies SHOULD formally notify the cloud service provider if information presented in an Ongoing Certification Report, Quarterly Review, or other FedRAMP Certification Data causes significant concerns for the authorizing official that would likely result in rescission of their Authorization to Operate.",
               "force": "SHOULD",
               "affects": ["Agencies"],
               "notification": [
                 {
                   "party": "Provider",
-                  "method": "email",
-                  "target": "Provider security contact"
+                  "method": "varies",
+                  "target": "varies by provider",
+                  "name": "The provider's security contact email or form."
                 }
               ],
               "terms": [
@@ -1982,8 +1986,9 @@
               "notification": [
                 {
                   "party": "FedRAMP",
-                  "method": "email",
-                  "target": "info@fedramp.gov"
+                  "method": "form",
+                  "target": "https://help.fedramp.gov/hc/en-us/requests/new?ticket_form_id=51822364715035",
+                  "name": "[For Agencies] Additional Information, Security Requirements, or Certification Change, or After Request Form"
                 }
               ],
               "terms": ["Agency", "Provider"],
@@ -2003,8 +2008,9 @@
               "notification": [
                 {
                   "party": "FedRAMP",
-                  "method": "email",
-                  "target": "info@fedramp.gov"
+                  "method": "form",
+                  "target": "https://help.fedramp.gov/hc/en-us/requests/new?ticket_form_id=51822364715035",
+                  "name": "[For Agencies] Additional Information, Security Requirements, or Certification Change, or After Request Form"
                 }
               ],
               "terms": [
@@ -2603,8 +2609,11 @@
             },
             "CDS-CSO-FID": {
               "name": "Always Include FedRAMP ID",
-              "statement": "Providers MUST always include the FedRAMP ID of the related cloud service offering in all FedRAMP Certification Data, including all reports, notifications, and other communication that results from FedRAMP Rules.",
-              "note": "Many providers have multiple cloud service offerings or use internal names that don't align to public materials; using the FedRAMP ID ensures we can easily align the communication with a specific cloud service offering.",
+              "statement": "Providers MUST always include the FedRAMP ID of the related cloud service offering in all FedRAMP Certification Data once assigned, including all reports, notifications, and other communication that results from FedRAMP Rules.",
+              "notes": [
+                "The FedRAMP ID is supplied by FedRAMP after a cloud service offering is registered to be listed on the FedRAMP Marketplace - providers will need to use a placeholder until the FedRAMP ID is assigned.",
+                "Many providers have multiple cloud service offerings or use internal names that don't align to public materials; using the FedRAMP ID ensures we can easily align the communication with a specific cloud service offering."
+              ],
               "force": "MUST",
               "affects": ["Providers"],
               "terms": [
@@ -3004,8 +3013,9 @@
               "notification": [
                 {
                   "party": "FedRAMP",
-                  "method": "email",
-                  "target": "info@fedramp.gov"
+                  "method": "form",
+                  "target": "https://help.fedramp.gov/hc/en-us/requests/new?ticket_form_id=51829826617243",
+                  "name": "[CSP] Agency Access Denial"
                 }
               ],
               "terms": ["Agency", "Certification Data", "Provider"],
@@ -3046,9 +3056,16 @@
               "affects": ["Providers"],
               "notification": [
                 {
-                  "party": "All Necessary Parties",
-                  "method": "update",
-                  "target": "FedRAMP Certification Data"
+                  "party": "FedRAMP",
+                  "method": "email",
+                  "target": "info@fedramp.gov",
+                  "name": "info@fedramp.gov"
+                },
+                {
+                  "party": "Agency Customers",
+                  "method": "varies",
+                  "target": "varies by agency",
+                  "name": "Agency Security Contact"
                 }
               ],
               "terms": [
@@ -3301,7 +3318,7 @@
                 "Minimum Assessment Scope: MAS-CSO-FLO (Information Flows and Security Categories)",
                 "Minimum Assessment Scope: MAS-CSO-TPR (Third-Party Information Resources)",
                 "Using Cryptographic Modules: CMU-CSO-CMD (Cryptographic Module Documentation)",
-                "FedRAMP Assessment: Whatever rule is created to replace the SAR ;)"
+                "Independent Verification and Validation: IVV-CSO-ICP (Inclusion in Certification Package)"
               ],
               "notes": [
                 "For FedRAMP Rev5, the Certification Package Overview replaces the historically required System Security Plan (not including appendices).",
@@ -3315,7 +3332,8 @@
                 "MAS-CSO-FLO",
                 "MAS-CSO-TPR",
                 "CMU-CSO-CMD",
-                "CDS-CSO-IRP"
+                "CDS-CSO-IRP",
+                "IVV-CSO-ICP"
               ],
               "force": "MUST",
               "affects": ["Providers"],
@@ -3331,7 +3349,9 @@
                 "Initial Incident Report (IIR)",
                 "Provider",
                 "Security Category",
-                "Third-Party Information Resource"
+                "Third-Party Information Resource",
+                "Validation",
+                "Verification"
               ],
               "updated": [
                 {
@@ -4615,17 +4635,20 @@
                 {
                   "party": "FedRAMP",
                   "method": "email",
-                  "target": "fedramp_security@fedramp.gov"
+                  "target": "fedramp_security@fedramp.gov",
+                  "name": "FedRAMP Security Team"
                 },
                 {
                   "party": "Agency Customers",
-                  "method": "update",
-                  "target": "incident contact procedures documented in contract agreement"
+                  "method": "varies",
+                  "target": "varies by agency",
+                  "name": "Follow agency-specific incident reporting procedures"
                 },
                 {
                   "party": "All Necessary Parties",
                   "method": "update",
-                  "target": "trust center"
+                  "target": "trust center",
+                  "name": "Provider's Trust Center or USDA Connect"
                 }
               ],
               "terms": [
@@ -4864,17 +4887,20 @@
                 {
                   "party": "FedRAMP",
                   "method": "email",
-                  "target": "fedramp_security@fedramp.gov"
+                  "target": "fedramp_security@fedramp.gov",
+                  "name": "FedRAMP Security Team"
                 },
                 {
                   "party": "Agency Customers",
-                  "method": "update",
-                  "target": "incident contact procedures documented in contract agreement"
+                  "method": "varies",
+                  "target": "varies by agency",
+                  "name": "Follow agency-specific incident reporting procedures"
                 },
                 {
                   "party": "All Necessary Parties",
                   "method": "update",
-                  "target": "trust center"
+                  "target": "trust center",
+                  "name": "Provider's Trust Center or USDA Connect"
                 }
               ],
               "terms": [
@@ -5085,17 +5111,20 @@
                 {
                   "party": "FedRAMP",
                   "method": "email",
-                  "target": "fedramp_security@fedramp.gov"
+                  "target": "fedramp_security@fedramp.gov",
+                  "name": "FedRAMP Security Team"
                 },
                 {
                   "party": "Agency Customers",
-                  "method": "update",
-                  "target": "incident contact procedures documented in contract agreement"
+                  "method": "varies",
+                  "target": "varies by agency",
+                  "name": "Follow agency-specific incident reporting procedures"
                 },
                 {
                   "party": "All Necessary Parties",
                   "method": "update",
-                  "target": "trust center"
+                  "target": "trust center",
+                  "name": "Provider's Trust Center or USDA Connect"
                 }
               ],
               "terms": [
@@ -6126,6 +6155,19 @@
         "purpose": "The Marketplace Listing rules define how FedRAMP decides which cloud service offerings, assessors, and advisors may be listed in the FedRAMP Marketplace. These rules help agencies and other customers rely on the Marketplace as a consistent source of eligible services and supporting organizations, while requiring listed organizations to supply accurate, accessible, and machine-readable information.",
         "status": "stable",
         "tag": "other",
+        "effective": {
+          "is": "required",
+          "current_status": "Consolidated Rules for 2026",
+          "date": {
+            "obtain": "2026-07-04",
+            "maintain": "2026-07-04",
+            "optional_adoption": "2026-07-04",
+            "grace": {
+              "default": "2026-07-04",
+              "until_next_assessment": false
+            }
+          }
+        },
         "subsets": {
           "FRP": {
             "name": "FedRAMP Responsibilities",
@@ -6177,36 +6219,6 @@
               "affects": ["Providers"]
             }
           }
-        },
-        "20x": {
-          "effective": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2026-07-04",
-              "maintain": "2027-01-01",
-              "optional_adoption": "2026-07-04",
-              "grace": {
-                "default": "2027-01-01",
-                "until_next_assessment": true
-              }
-            }
-          }
-        },
-        "rev5": {
-          "effective": {
-            "is": "required",
-            "current_status": "Consolidated Rules for 2026",
-            "date": {
-              "obtain": "2027-01-01",
-              "maintain": "2027-01-01",
-              "optional_adoption": "2026-07-04",
-              "grace": {
-                "default": "2027-06-01",
-                "until_next_assessment": false
-              }
-            }
-          }
         }
       },
       "data": {
@@ -6248,12 +6260,18 @@
             },
             "MKT-CSO-PML": {
               "name": "Provider Marketplace Listing Requests",
-              "statement": "Providers MUST use the FedRAMP Marketplace Providing Listing Request Form to request a listing in the FedRAMP Marketplace.",
+              "statement": "Providers MUST notify FedRAMP using the FedRAMP Marketplace Providing Listing Request Form to request a listing in the FedRAMP Marketplace.",
               "note": "FedRAMP does not accept applications for a FedRAMP Marketplace Listing via email!",
-              "reference": "FedRAMP Marketplace Provider Listing Request Form",
-              "reference_url": "https://fedramp.gov/forms/to-be-added",
               "force": "MUST",
               "affects": ["Providers"],
+              "notification": [
+                {
+                  "party": "FedRAMP",
+                  "method": "form",
+                  "target": "https://help.fedramp.gov/hc/en-us/requests/new?ticket_form_id=50939227168027",
+                  "name": "FedRAMP Marketplace Provider Listing Request Form"
+                }
+              ],
               "terms": ["Provider"],
               "updated": [
                 {
@@ -6663,9 +6681,9 @@
               "notification": [
                 {
                   "party": "FedRAMP",
-                  "method": "web",
-                  "target": "FedRAMP Foreign Ownership, Control, or Influence Declaration Form",
-                  "url": "https://help.fedramp.gov/forms/assessors/foci-declaration"
+                  "method": "form",
+                  "target": "https://help.fedramp.gov/forms/assessors/foci-declaration",
+                  "name": "FedRAMP Foreign Ownership, Control, or Influence Declaration Form"
                 }
               ],
               "terms": ["Assessor"],
@@ -6686,9 +6704,9 @@
               "notification": [
                 {
                   "party": "FedRAMP",
-                  "method": "web",
-                  "target": "FedRAMP Foreign Ownership, Control, or Influence Declaration Form",
-                  "url": "https://help.fedramp.gov/forms/assessors/foci-declaration"
+                  "method": "form",
+                  "target": "https://help.fedramp.gov/forms/assessors/foci-declaration",
+                  "name": "FedRAMP Foreign Ownership, Control, or Influence Declaration Form"
                 }
               ],
               "terms": ["Assessor"],
@@ -6834,7 +6852,7 @@
               ],
               "notes": [
                 "These rules refer to this guidance as a Secure Configuration Guide but cloud service providers may make this guidance available in various appropriate forms that provide the best customer experience.",
-                "This guidance should explain how top-level administrative accounts are named and referred to in the cloud service offering."
+                "This guidance should explain how top-level administrative accounts and privileged accounts are named and referred to in the cloud service offering."
               ],
               "force": "MUST",
               "affects": ["Providers"],
@@ -7173,8 +7191,8 @@
             },
             "SCN-CSO-MAR": {
               "name": "Maintain Audit Records",
-              "statement": "Providers MUST maintain auditable records of the significant change evaluation activities required by SCN-CSO-EVA (Evaluate Changes) and make them available to FedRAMP.",
-              "note": "These audit records must be available to FedRAMP on request; these records do not need to be included in the FedRAMP Certification package by default.",
+              "statement": "Providers MUST maintain auditable records of the significant change evaluation activities required by SCN-CSO-EVA (Evaluate Changes) and make them available to FedRAMP as requested.",
+              "note": "These audit records must be available to FedRAMP on request; these records do not need to be included in the FedRAMP Certification package by default and do not need to be emailed to FedRAMP continuously.",
               "related": ["SCN-CSO-EVA"],
               "force": "MUST",
               "affects": ["Providers"],
@@ -7371,7 +7389,8 @@
                 {
                   "party": "All Necessary Parties",
                   "method": "update",
-                  "target": "FedRAMP Certification Data"
+                  "target": "FedRAMP Certification Data",
+                  "name": "FedRAMP Certification Data"
                 }
               ],
               "terms": [
@@ -7464,7 +7483,8 @@
                 {
                   "party": "All Necessary Parties",
                   "method": "update",
-                  "target": "FedRAMP Certification Data"
+                  "target": "FedRAMP Certification Data",
+                  "name": "FedRAMP Certification Data"
                 }
               ],
               "terms": [
@@ -7496,7 +7516,8 @@
                 {
                   "party": "All Necessary Parties",
                   "method": "update",
-                  "target": "FedRAMP Certification Data"
+                  "target": "FedRAMP Certification Data",
+                  "name": "FedRAMP Certification Data"
                 }
               ],
               "terms": [
@@ -7527,7 +7548,8 @@
                 {
                   "party": "All Necessary Parties",
                   "method": "update",
-                  "target": "FedRAMP Certification Data"
+                  "target": "FedRAMP Certification Data",
+                  "name": "FedRAMP Certification Data"
                 }
               ],
               "terms": [
@@ -7563,7 +7585,8 @@
                 {
                   "party": "All Necessary Parties",
                   "method": "update",
-                  "target": "FedRAMP Certification Data"
+                  "target": "FedRAMP Certification Data",
+                  "name": "FedRAMP Certification Data"
                 }
               ],
               "terms": [
@@ -7892,7 +7915,7 @@
             },
             "SDR-CSF-ODP": {
               "name": "Organization-Defined Parameters",
-              "statement": "Providers MUST define all required organization-defined parameters tied all Rev5 Controls, following FedRAMP Rules if applicable, UNLESS the parameter is assigned by FedRAMP.",
+              "statement": "Providers MUST define all required organization-defined parameters tied to all Rev5 Controls, following FedRAMP Rules if applicable, UNLESS the parameter is assigned by FedRAMP.",
               "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Provider"],
@@ -8890,8 +8913,9 @@
               "notification": [
                 {
                   "party": "FedRAMP",
-                  "method": "email",
-                  "target": "info@fedramp.gov"
+                  "method": "form",
+                  "target": "https://help.fedramp.gov/hc/en-us/requests/new?ticket_form_id=51822364715035",
+                  "name": "[For Agencies] Additional Information, Security Requirements, or Certification Change, or After Request Form"
                 }
               ],
               "terms": ["Agency", "Provider", "Vulnerability"],
@@ -8950,8 +8974,9 @@
               "notification": [
                 {
                   "party": "FedRAMP",
-                  "method": "email",
-                  "target": "info@fedramp.gov"
+                  "method": "form",
+                  "target": "https://help.fedramp.gov/hc/en-us/requests/new?ticket_form_id=51822364715035",
+                  "name": "[For Agencies] Additional Information, Security Requirements, or Certification Change, or After Request Form"
                 }
               ],
               "terms": [

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -3821,8 +3821,32 @@
             },
             "FRC-APP-FIA": {
               "name": "Fresh Independent Assessment",
-              "statement": "Providers MUST supply a fresh initial FedRAMP independent assessment that was completed by a FedRAMP Recognized Independent Assessment Service within the previous 3 months.",
-              "force": "MUST",
+              "varies_by_class": {
+                "a": {
+                  "statement": "Providers seeking Class A Certification MAY supply a fresh initial FedRAMP independent assessment that was completed by a FedRAMP Recognized Independent Assessment Service within the previous 3 months.",
+                  "force": "MAY",
+                  "timeframe_type": "months",
+                  "timeframe_num": 3
+                },
+                "b": {
+                  "statement": "Providers seeking Class B Certification MUST supply a fresh initial FedRAMP independent assessment that was completed by a FedRAMP Recognized Independent Assessment Service within the previous 3 months.",
+                  "force": "MUST",
+                  "timeframe_type": "months",
+                  "timeframe_num": 3
+                },
+                "c": {
+                  "statement": "Providers seeking Class C Certification MUST supply a fresh initial FedRAMP independent assessment that was completed by a FedRAMP Recognized Independent Assessment Service within the previous 3 months.",
+                  "force": "MUST",
+                  "timeframe_type": "months",
+                  "timeframe_num": 3
+                },
+                "d": {
+                  "statement": "Providers seeking Class D Certification MUST supply a fresh initial FedRAMP independent assessment that was completed by a FedRAMP Recognized Independent Assessment Service within the previous 3 months.",
+                  "force": "MUST",
+                  "timeframe_type": "months",
+                  "timeframe_num": 3
+                }
+              },
               "affects": ["Providers"],
               "terms": [
                 "FedRAMP Independent Assessment",

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -931,6 +931,21 @@
             }
           ]
         },
+        "FRD-SDR": {
+          "term": "Security Decision Record (SDR)",
+          "definition": "A persistently maintained, verified, and validated record of the security decisions made by a provider over the lifecycle of a cloud service offering. The Security Decision Record replaces the traditional System Security Plan and documents how applicable FedRAMP Practices are addressed, including implementation rationale, resulting customer risk, assessment findings, and supporting artifacts.",
+          "alts": [
+            "security decision record",
+            "security decision records",
+            "SDR"
+          ],
+          "updated": [
+            {
+              "date": "2026-07-04",
+              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+            }
+          ]
+        },
         "FRD-SGC": {
           "term": "Significant Change",
           "definition": "Has the meaning given in NIST SP 800-37 Rev. 2 which is \"a change that is likely to substantively affect the security or privacy posture of a system.\"",
@@ -3969,13 +3984,52 @@
             }
           },
           "CCL": {
-            "FRC-CCL-PLC": {
-              "name": "Placeholder on Changing Certification Class",
-              "statement": "Providers MUST do things properly in order to change their FedRAMP Certification Class.",
-              "note": "This is a placeholder rule that must be updated!",
+            "FRC-CCL-UCC": {
+              "name": "Upgrading Certification Class",
+              "statement": "Providers MUST apply for a new FedRAMP Certification to upgrade their Certification Class; all applicable requirements MUST be met in advance.",
+              "notes": [
+                "Upgrade paths include moving from A to B, C, or D; B to C or D; and C to D.",
+                "The preferred path is to incrementally update the implementation and assurance commitments within the current Certification Class until the provider has met all requirements for the target Certification Class, then apply for the new Certification Class."
+              ],
               "force": "MUST",
               "affects": ["Providers"],
               "terms": ["Certification Class", "Provider"],
+              "updated": [
+                {
+                  "date": "2026-06-30",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-CCL-DCC": {
+              "name": "Downgrading Certification Class",
+              "statement": "Providers MUST apply for a new FedRAMP Certification to downgrade their Certification Class.",
+              "notes": [
+                "Downgrade paths include moving from D to C, B, or A; C to B or A; or B to A.",
+                "FRC-CCL-DNP (Downgrade Notification Period) applies - please DO NOT downgrade Certification Class with providing advance notification to all necessary parties!"
+              ],
+              "related": ["FRC-CCL-DNP"],
+              "force": "MUST",
+              "affects": ["Providers"],
+              "terms": [
+                "All Necessary Parties",
+                "Certification Class",
+                "Provider"
+              ],
+              "updated": [
+                {
+                  "date": "2026-06-30",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "FRC-CCL-DNP": {
+              "name": "Downgrade Notification Period",
+              "statement": "Providers SHOULD notify all necessary parties at least 120 days in advance of an intended downgrade or cancellation of FedRAMP Certification.",
+              "note": "Downgrading or canceling FedRAMP Certification will have severe negative consequences for the provider and their agency customers and should only be done after careful consideration and planning... but if it must be done, notify all necessary parties as soon as possible.",
+              "force": "SHOULD",
+              "affects": ["Providers"],
+              "terms": ["Agency", "All Necessary Parties", "Provider"],
               "updated": [
                 {
                   "date": "2026-06-30",
@@ -5321,7 +5375,12 @@
               "note": "FedRAMP does not require a separate Security Assessment Plan or Security Assessment Report for FedRAMP 20x or FedRAMP Rev5 Certifications; this information is expected to be included in the Security Decision Record by the cloud service provider.",
               "force": "MUST",
               "affects": ["Assessors"],
-              "terms": ["Assessor", "Cloud Service Offering", "Provider"],
+              "terms": [
+                "Assessor",
+                "Cloud Service Offering",
+                "Provider",
+                "Security Decision Record (SDR)"
+              ],
               "updated": [
                 {
                   "date": "2026-06-30",
@@ -7586,7 +7645,13 @@
                 "name": "FedRAMP Security Decision Record Schema",
                 "url": "https://fedramp.gov/schemas/fedramp-security-decision-record-schema-v2026.06.06.01.json"
               },
-              "terms": ["Artifacts", "Provider", "Validation", "Verification"],
+              "terms": [
+                "Artifacts",
+                "Provider",
+                "Security Decision Record (SDR)",
+                "Validation",
+                "Verification"
+              ],
               "updated": [
                 {
                   "date": "2026-06-30",
@@ -7604,7 +7669,7 @@
               ],
               "force": "MUST",
               "affects": ["Providers"],
-              "terms": ["Provider"],
+              "terms": ["Provider", "Security Decision Record (SDR)"],
               "updated": [
                 {
                   "date": "2026-06-30",
@@ -7679,7 +7744,7 @@
                 "name": "FedRAMP Security Decision Record Schema",
                 "url": "https://fedramp.gov/schemas/fedramp-security-decision-record-schema-v2026.06.06.01.json"
               },
-              "terms": ["Provider"],
+              "terms": ["Provider", "Security Decision Record (SDR)"],
               "updated": [
                 {
                   "date": "2026-06-30",
@@ -10157,7 +10222,7 @@
         },
         "KSI-RPL-RRO": {
           "name": "Reviewing Recovery Objectives",
-          "statement": "The desired Recovery Time Objectives (RTO) and Recovery Point Objectives (RPO) are persistently reviewed for alignment with the provider's business needs and capabilities.",
+          "statement": "The desired Recovery Time Objectives (RTO) and Recovery Point Objectives (RPO) are defined and persistently reviewed for alignment with the provider's business needs and capabilities.",
           "controls": ["cp-2.3", "cp-10"],
           "updated": [
             {

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -2,8 +2,8 @@
   "info": {
     "title": "FedRAMP Consolidated Rules for 2026 Public Preview",
     "description": "This datafile contains the Consolidated Rules for FedRAMP in structured machine-readable text. It includes definitions, requirements, recommendations, and key security indicators.",
-    "version": "2026.06.15.01-preview",
-    "last_updated": "2026-06-15",
+    "version": "2026.06.19.01-preview",
+    "last_updated": "2026-06-19",
     "default_artifacts": {
       "FRR": [
         "Explanation of how the rule is followed, or an explanation of the reason and resulting risk to customers for not following the rule.",
@@ -2123,7 +2123,7 @@
             },
             "CCM-OCR-AFS": {
               "name": "Anonymized Feedback Summary",
-              "statement": "Providers MUST supply an anonymized and desensitized summary of the feedback, questions, and answers about each Ongoing Certification Report as an addendum to the Ongoing Certification Report.",
+              "statement": "Providers MUST supply an anonymized and desensitized summary of the feedback, questions, and answers about each Ongoing Certification Report as an addendum to the Ongoing Certification Report OR in the next Ongoing Certification Report.",
               "note": "This is intended to encourage sharing of information and decrease the burden on the cloud service provider - providing this summary will reduce duplicate questions from agencies and ensure FedRAMP has access to this information. It is generally in the provider's interest to update this addendum frequently throughout the quarter.",
               "force": "MUST",
               "affects": ["Providers"],
@@ -2777,8 +2777,8 @@
             },
             "CDS-CSO-HAD": {
               "name": "Historical FedRAMP Certification Data",
-              "statement": "Providers MUST supply historical versions of FedRAMP Certification Data for three years to all necessary parties UNLESS otherwise specified by applicable FedRAMP rules; deltas between versions MAY be consolidated quarterly.",
-              "note": "Consolidating changes quarterly means that the historical status at the end of each quarter or at the time of the Ongoing Certification Report or Quarterly Review is sufficient, instead of maintaining separate versions with every single change that took place throughout the quarter.",
+              "statement": "Providers MUST supply snapshots of FedRAMP Certification Data aligned to Ongoing Certification Reports to all necessary parties; these snapshots MUST be available for the duration of FedRAMP Certification.",
+              "note": "Historical snapshots do not need to be reconstructed for periods before the provider's first Ongoing Certification Report, but should be maintained for all subsequent Ongoing Certification Reports.",
               "force": "MUST",
               "affects": ["Providers"],
               "artifacts": {
@@ -2790,8 +2790,7 @@
                 "FedRAMP Certification Report",
                 "Ongoing Certification",
                 "Ongoing Certification Report (OCR)",
-                "Provider",
-                "Quarterly Review"
+                "Provider"
               ],
               "updated": [
                 {
@@ -3070,7 +3069,7 @@
         "short_name": "CMU",
         "web_name": "cryptographic-module-use",
         "purpose": "The Cryptographic Module Use rules clarify how providers should select and use cryptographic modules. These rules allow risk-based decisions for some services while still encouraging validated cryptographic modules whenever they are technically feasible and reasonable.",
-        "status": "placeholder",
+        "status": "stable",
         "tag": "boundary",
         "subsets": {
           "CSO": {
@@ -3213,7 +3212,7 @@
         "short_name": "CPO",
         "web_name": "certification-package-overview",
         "purpose": "The Certification Package Overview rules outline the expectations for a simple overview of the cloud service offering that must be included within a FedRAMP Certification Package. This overview replaces the historically required base System Security Plan for FedRAMP Rev5 and is intended to provide a clear, concise, and consistent summary of the offering and the information included in the package to help customers understand the offering at a high level.",
-        "status": "placeholder",
+        "status": "stable",
         "tag": "materials",
         "subsets": {
           "CSO": {
@@ -3462,7 +3461,7 @@
         "short_name": "FRC",
         "web_name": "fedramp-certification",
         "purpose": "This ruleset explains how cloud service offerings obtain and maintain FedRAMP Certification across certification classes and paths.",
-        "status": "placeholder",
+        "status": "stable",
         "tag": "other",
         "subsets": {
           "CSO": {
@@ -3740,6 +3739,7 @@
                 "Certification Data Sharing: CDS-CSO-PUB (Public Information)",
                 "Certification Data Sharing: CDS-CSO-UTC (Use Trust Centers)",
                 "Certification Data Sharing: CDS-UTC-AAD (Agency Access Denial)",
+                "Certification Data Sharing: CDS-CSO-AVR (Availability Reporting)",
                 "Addressing FedRAMP Communication: AFC-CSO-INB (Maintain a FedRAMP Security Inbox)",
                 "Addressing FedRAMP Communication: AFC-CSO-RCV (Receive Email Without Disruption)",
                 "Addressing FedRAMP Communication: AFC-CSO-CRA (Complete Required Actions)",
@@ -3781,7 +3781,8 @@
                 "KSI-IAM-AAM",
                 "KSI-INR-RIR",
                 "KSI-SVC-SIN",
-                "KSI-IAM-APM"
+                "KSI-IAM-APM",
+                "CDS-CSO-AVR"
               ],
               "force": "MUST",
               "affects": ["Providers"],
@@ -4085,7 +4086,7 @@
         "short_name": "IEC",
         "web_name": "incident-evaluation-and-communication",
         "purpose": "The Incident Evaluation and Communication rules explain how providers must communicate incident information to FedRAMP and government customers when they are affected by an incident or likely to be affected by an incident.",
-        "status": "placeholder",
+        "status": "stable",
         "tag": "assurance",
         "subsets": {
           "FRP": {
@@ -5068,7 +5069,7 @@
         "short_name": "IVV",
         "web_name": "independent-verification-and-validation",
         "purpose": "This ruleset explains the expectations for independent verification and validation assessments.",
-        "status": "placeholder",
+        "status": "stable",
         "tag": "assurance",
         "subsets": {
           "CSO": {
@@ -6018,7 +6019,7 @@
         "short_name": "MKT",
         "web_name": "marketplace-listing",
         "purpose": "The Marketplace Listing rules define how FedRAMP decides which cloud service offerings, assessors, and advisors may be listed in the FedRAMP Marketplace. These rules help agencies and other customers rely on the Marketplace as a consistent source of eligible services and supporting organizations, while requiring listed organizations to supply accurate, accessible, and machine-readable information.",
-        "status": "placeholder",
+        "status": "stable",
         "tag": "other",
         "subsets": {
           "FRP": {
@@ -6345,7 +6346,7 @@
         "short_name": "REC",
         "web_name": "fedramp-recognition",
         "purpose": "The FedRAMP Recognition of Independent Assessment Services rules explain the requirements for assessors to obtain and maintain FedRAMP Recognition in order to support the FedRAMP Certification process.",
-        "status": "placeholder",
+        "status": "stable",
         "tag": "other",
         "effective": {
           "is": "required",
@@ -7554,7 +7555,7 @@
         "short_name": "SDR",
         "web_name": "security-decision-record",
         "purpose": "The Security Decision Record replaced a traditional System Security Plan with a persistently maintained, verified, and validated record of the security decisions made by the cloud service provider over the lifecycle of their cloud service offering.",
-        "status": "empty",
+        "status": "stable",
         "tag": "materials",
         "subsets": {
           "CSO": {

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -1946,8 +1946,7 @@
                 "default": "2027-10-01",
                 "until_next_assessment": false
               }
-            },
-            "signup_url": "ADDME"
+            }
           }
         }
       },
@@ -2001,6 +2000,13 @@
               "note": "This is a statutory requirement in 44 USC § 3613 (e) related to the Presumption of Adequacy for a FedRAMP Certification.",
               "force": "MUST NOT",
               "affects": ["Agencies"],
+              "notification": [
+                {
+                  "party": "FedRAMP",
+                  "method": "email",
+                  "target": "info@fedramp.gov"
+                }
+              ],
               "terms": [
                 "Agency",
                 "Certification Data",
@@ -2500,8 +2506,7 @@
                 "default": "2028-02-01",
                 "until_next_assessment": false
               }
-            },
-            "signup_url": "ADDME"
+            }
           },
           "subsets": {
             "CSF": {
@@ -3265,8 +3270,7 @@
                 "default": "2027-01-01",
                 "until_next_assessment": true
               }
-            },
-            "signup_url": "ADDME"
+            }
           },
           "subsets": {
             "CSF": {
@@ -3728,9 +3732,9 @@
                 }
               ]
             },
-            "FRC-CLA-AFR": {
-              "name": "Address FedRAMP Rules for Class A",
-              "statement": "Providers seeking a Class A FedRAMP Certification of any Type MUST address all rules in this FedRAMP Class A Certification subset (FRC-CLA) AND the following additional FedRAMP rules; the appropriate artifacts or information mapping for all rules MUST be supplied in the FedRAMP Certification Package.",
+            "FRC-CLA-MFR": {
+              "name": "Mandatory FedRAMP Rules for Class A",
+              "statement": "Providers seeking a Class A FedRAMP Certification MUST address all rules in this FedRAMP Class A Certification subset (FRC-CLA) AND the following additional FedRAMP Class Arules; the appropriate artifacts or information mapping for all rules MUST be supplied in the FedRAMP Certification Package.",
               "following_information": [
                 "FedRAMP Certification: FRC-CSO-PKG (FedRAMP Certification Package)",
                 "FedRAMP Certification: FRC-CSO-JSN (FedRAMP JSON Schemas)",
@@ -3744,9 +3748,12 @@
                 "Addressing FedRAMP Communication: AFC-CSO-RCV (Receive Email Without Disruption)",
                 "Addressing FedRAMP Communication: AFC-CSO-CRA (Complete Required Actions)",
                 "Incident Evaluation and Communication: IEC-CSO-EFR (Evaluate FedRAMP Reportability)",
+                "Incident Evaluation and Communication: IEC-CSO-FIR (Final Incident Report)",
                 "Vulnerability Detection and Response: VDR-CSO-DET (Vulnerability Detection)",
                 "Collaborative Continuous Monitoring: CCM-OCR-AVL (Report Availability)",
                 "Collaborative Continuous Monitoring: CCM-OCR-NRD (Next Report Date)",
+                "Independent Verification and Validation: IVV-CSX-AIA (Annual Independent Assessments for 20x)",
+                "Independent Verification and Validation: IVV-CSF-AIA (Annual Independent Assessments for Rev5)",
                 "Key Security Indicators: KSI-CMT-LMC (Logging Changes)",
                 "Key Security Indicators: KSI-CNA-RNT (Restricting Network Traffic)",
                 "Key Security Indicators: KSI-CED-RAT (Reviewing All Training)",
@@ -3770,9 +3777,12 @@
                 "AFC-CSO-RCV",
                 "AFC-CSO-CRA",
                 "IEC-CSO-EFR",
+                "IEC-CSO-FIR",
                 "VDR-CSO-DET",
                 "CCM-OCR-AVL",
                 "CCM-OCR-NRD",
+                "IVV-CSX-AIA",
+                "IVV-CSF-AIA",
                 "FRC-CSO-PKG",
                 "FRC-CSO-JSN",
                 "KSI-CMT-LMC",
@@ -3793,15 +3803,116 @@
                 "Certification Package",
                 "Certification Type",
                 "FedRAMP Security Inbox",
+                "Final Incident Report (FIR)",
                 "Incident",
                 "Information Resource",
                 "Initial Incident Report (IIR)",
                 "Ongoing Certification Report (OCR)",
                 "Provider",
                 "Trust Center",
+                "Validation",
+                "Verification",
                 "Vulnerability",
                 "Vulnerability Detection",
                 "Vulnerability Response"
+              ],
+              "updated": [
+                {
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
+                }
+              ]
+            },
+            "FRC-CLA-RFR": {
+              "name": "Recommended FedRAMP Rules for Class A",
+              "statement": "Providers seeking a Class A FedRAMP Certification SHOULD address the following additional recommended FedRAMP Class A rules (if applicable):",
+              "following_information": [
+                "Certification Data Sharing: CDS-CSO-AVR (Availability Reporting)",
+                "Certification Package Overview: CPO-CSF-CPM (Certification Package Maintenance for Rev5)",
+                "Certification Package Overview: CPO-CSX-CPM (Certification Package Maintenance for 20x)",
+                "Incident Evaluation and Communication: IEC-CSO-IIR (Initial Incident Report)",
+                "Incident Evaluation and Communication: IEC-CSO-OIR (Ongoing Incident Reports)",
+                "Vulnerability Detection and Response: VDR-TFR-MVX (Persistent Machine Verification and Validation for 20x)",
+                "Vulnerability Detection and Response: VDR-TFR-PCD (Persistently Complete Detection)",
+                "Vulnerability Detection and Response: VDR-TFR-PDD (Persistent Drift Detection)",
+                "Vulnerability Detection and Response: VDR-TFR-PSD (Persistent Sample Detection)",
+                "Vulnerability Detection and Response: VDR-TFR-PVR (Mitigation and Remediation Expectations)",
+                "Vulnerability Evaluation and Reporting: VER-TFR-EVU (Evaluate Vulnerabilities Quickly)"
+              ],
+              "related": [
+                "CDS-CSO-AVR",
+                "CPO-CSF-CPM",
+                "CPO-CSX-CPM",
+                "IEC-CSO-IIR",
+                "IEC-CSO-OIR",
+                "VDR-TFR-MVX",
+                "VDR-TFR-PCD",
+                "VDR-TFR-PDD",
+                "VDR-TFR-PSD",
+                "VDR-TFR-PVR",
+                "VER-TFR-EVU"
+              ],
+              "force": "SHOULD",
+              "affects": ["Providers"],
+              "terms": [
+                "Certification Data",
+                "Certification Package",
+                "Drift",
+                "Incident",
+                "Initial Incident Report (IIR)",
+                "Ongoing Incident Report (OIR)",
+                "Persistently",
+                "Provider",
+                "Validation",
+                "Verification",
+                "Vulnerability",
+                "Vulnerability Detection",
+                "Vulnerability Response"
+              ],
+              "updated": [
+                {
+                  "date": "2026-06-23",
+                  "comment": "Official launch of the FedRAMP Consolidated Rules for 2026."
+                }
+              ]
+            },
+            "FRC-CLA-OFR": {
+              "name": "Address Optional FedRAMP Rules for Class A",
+              "statement": "Providers seeking a Class A FedRAMP Certification MAY address the following additional optional FedRAMP Class A rules (if applicable):",
+              "following_information": [
+                "Collaborative Continuous Monitoring: CCM-QTR-MTG (Quarterly Review Meeting)",
+                "Certification Data Sharing: CDS-CSO-PSM (Per-Service Certification Materials)",
+                "Cryptographic Module Use: CMU-CSO-UVM (Using Validated Cryptographic Modules)",
+                "FedRAMP Certification: FRC-APP-FIA (Fresh Independent Assessment)",
+                "Independent Verification and Validation: IVV-CSO-FIA (FedRAMP Independent Assessments)",
+                "Security Decision Record: SDR-CSX-KMT (Key Security Indicator Metrics)",
+                "Vulnerability Evaluation and Reporting: VER-TFR-IRI (Internet-Reachable Incidents)",
+                "Vulnerability Evaluation and Reporting: VER-TFR-MRH (Historical Activity)",
+                "Vulnerability Evaluation and Reporting: VER-TFR-NRI (Non-Internet-Reachable Incidents)"
+              ],
+              "related": [
+                "CCM-QTR-MTG",
+                "CDS-CSO-PSM",
+                "CMU-CSO-UVM",
+                "FRC-APP-FIA",
+                "IVV-CSO-FIA",
+                "SDR-CSX-KMT",
+                "VER-TFR-IRI",
+                "VER-TFR-MRH",
+                "VER-TFR-NRI"
+              ],
+              "force": "MAY",
+              "affects": ["Providers"],
+              "terms": [
+                "Certification Data",
+                "FedRAMP Independent Assessment",
+                "Incident",
+                "Provider",
+                "Quarterly Review",
+                "Security Decision Record (SDR)",
+                "Validation",
+                "Verification",
+                "Vulnerability"
               ],
               "updated": [
                 {
@@ -4063,7 +4174,7 @@
               "name": "FedRAMP Ready Conversion",
               "statement": "Providers with FedRAMP Rev5 Ready status MUST convert to a FedRAMP Certification before the furthest date of the expiration of their most recently yearly assessment or November 17, 2026; the legacy FedRAMP Ready status will be entirely removed on December 31, 2027.",
               "notes": [
-                "The simplest conversion in most cases would be to a FedRAMP Rev5 Class A Certification.",
+                "The simplest conversion in most cases would be to a FedRAMP 20x Class A Certification.",
                 "Cloud services that do not wish to convert or do not meet conversion criteria will be renamed Legacy FedRAMP Ready and otherwise retired from FedRAMP Ready."
               ],
               "force": "MUST",
@@ -4198,8 +4309,7 @@
                 "default": "2027-06-01",
                 "until_next_assessment": false
               }
-            },
-            "signup_url": "ADDME"
+            }
           }
         }
       },
@@ -5515,10 +5625,6 @@
             "IVV-CSF-AIA": {
               "name": "Annual Independent Assessments for Rev5",
               "varies_by_class": {
-                "a": {
-                  "statement": "Providers MUST NOT obtain a FedRAMP Rev5 Class A Certification.",
-                  "force": "MUST NOT"
-                },
                 "b": {
                   "statement": "Providers with Rev5 Class B Certifications MUST include the following Rev5 Controls in a FedRAMP independent assessment at least once per year:",
                   "following_information": [
@@ -5858,8 +5964,7 @@
                 "default": "2027-01-01",
                 "until_next_assessment": true
               }
-            },
-            "signup_url": "ADDME"
+            }
           }
         }
       },
@@ -7010,8 +7115,7 @@
                 "default": "2027-06-01",
                 "until_next_assessment": false
               }
-            },
-            "signup_url": "ADDME"
+            }
           }
         }
       },
@@ -7608,8 +7712,7 @@
                 "default": "2027-08-01",
                 "until_next_assessment": true
               }
-            },
-            "signup_url": "ADDME"
+            }
           },
           "subsets": {
             "CSF": {
@@ -7861,8 +7964,7 @@
                 "default": "2028-01-01",
                 "until_next_assessment": false
               }
-            },
-            "signup_url": "ADDME"
+            }
           }
         }
       },
@@ -8613,12 +8715,6 @@
             "VDR-TFR-MVF": {
               "name": "Persistent Machine Verification and Validation for Rev5",
               "varies_by_class": {
-                "a": {
-                  "statement": "Providers of FedRAMP Rev5 Class A offerings SHOULD verify and validate the status of machine-based information resources at least once every month.",
-                  "force": "SHOULD",
-                  "timeframe_type": "months",
-                  "timeframe_num": 1
-                },
                 "b": {
                   "statement": "Providers of FedRAMP Rev5 Class B offerings SHOULD verify and validate the status of machine-based information resources at least once every month.",
                   "force": "SHOULD",
@@ -8851,6 +8947,13 @@
               "note": "This is related to the Presumption of Adequacy directed by 44 USC § 3613 (e).",
               "force": "SHOULD NOT",
               "affects": ["Agencies"],
+              "notification": [
+                {
+                  "party": "FedRAMP",
+                  "method": "email",
+                  "target": "info@fedramp.gov"
+                }
+              ],
               "terms": [
                 "Agency",
                 "FedRAMP Certified",

--- a/fedramp-consolidated-rules.json
+++ b/fedramp-consolidated-rules.json
@@ -340,6 +340,24 @@
             }
           ]
         },
+        "FRD-FCR": {
+          "term": "FedRAMP Certification Report",
+          "definition": "A report that is produced by FedRAMP documenting the results of a FedRAMP Certification assessment. This report is typically produced after the initial FedRAMP Certification assessment on the Program Certification Path and updated as necessary during ongoing FedRAMP Certification, but may be produced at any time by FedRAMP as part of ongoing FedRAMP Certification activities for any cloud service offering (such as corrective action). Cloud service offerings must include these reports in their FedRAMP Certification Package.",
+          "tag": "Certification",
+          "alts": [
+            "FedRAMP Certification Report",
+            "FedRAMP certification report",
+            "certification report"
+          ],
+          "reference": "FedRAMP Certification Act (44 USC § 3608)",
+          "reference_url": "https://www.fedramp.gov/docs/authority/law/#sec-3608-federal-risk-and-authorization-management-program",
+          "updated": [
+            {
+              "date": "2026-07-04",
+              "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+            }
+          ]
+        },
         "FRD-FCT": {
           "term": "FedRAMP Certified",
           "definition": "The status of a cloud service offering that has received FedRAMP Certification and meets the legal requirement to be FedRAMP authorized.",
@@ -1712,6 +1730,7 @@
               "terms": [
                 "Agency",
                 "Certification Data",
+                "FedRAMP Certification Report",
                 "Likely",
                 "Ongoing Certification",
                 "Ongoing Certification Report (OCR)",
@@ -1733,6 +1752,7 @@
               "terms": [
                 "Agency",
                 "Cloud Service Offering",
+                "FedRAMP Certification Report",
                 "Ongoing Certification",
                 "Ongoing Certification Report (OCR)"
               ],
@@ -1776,6 +1796,7 @@
               "terms": [
                 "Agency",
                 "Certification Data",
+                "FedRAMP Certification Report",
                 "Likely",
                 "Ongoing Certification",
                 "Ongoing Certification Report (OCR)",
@@ -1927,6 +1948,7 @@
               "terms": [
                 "Agency",
                 "Cloud Service Offering",
+                "FedRAMP Certification Report",
                 "Ongoing Certification",
                 "Ongoing Certification Report (OCR)"
               ],
@@ -2026,6 +2048,7 @@
                 "All Necessary Parties",
                 "Certification Data",
                 "Cloud Service Offering",
+                "FedRAMP Certification Report",
                 "FedRAMP Reportable Incident",
                 "Incident",
                 "Ongoing Certification",
@@ -2048,6 +2071,7 @@
               "affects": ["Providers"],
               "terms": [
                 "Certification Data",
+                "FedRAMP Certification Report",
                 "Ongoing Certification",
                 "Ongoing Certification Report (OCR)",
                 "Provider"
@@ -2070,6 +2094,7 @@
               },
               "terms": [
                 "All Necessary Parties",
+                "FedRAMP Certification Report",
                 "Ongoing Certification",
                 "Ongoing Certification Report (OCR)",
                 "Provider"
@@ -2092,6 +2117,7 @@
               },
               "terms": [
                 "Agency",
+                "FedRAMP Certification Report",
                 "Ongoing Certification",
                 "Ongoing Certification Report (OCR)",
                 "Provider"
@@ -2110,6 +2136,7 @@
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
+                "FedRAMP Certification Report",
                 "Likely",
                 "Ongoing Certification",
                 "Ongoing Certification Report (OCR)",
@@ -2148,6 +2175,7 @@
               "affects": ["Providers"],
               "terms": [
                 "Cloud Service Offering",
+                "FedRAMP Certification Report",
                 "Likely",
                 "Ongoing Certification",
                 "Ongoing Certification Report (OCR)",
@@ -2283,6 +2311,7 @@
               "force": "SHOULD",
               "affects": ["Providers"],
               "terms": [
+                "FedRAMP Certification Report",
                 "Ongoing Certification",
                 "Ongoing Certification Report (OCR)",
                 "Provider",
@@ -2513,6 +2542,7 @@
               },
               "terms": [
                 "Cloud Service Offering",
+                "FedRAMP Certification Report",
                 "FedRAMP Recognized",
                 "Ongoing Certification",
                 "Ongoing Certification Report (OCR)",
@@ -2559,6 +2589,28 @@
               "affects": ["Providers"],
               "terms": [
                 "Certification Data",
+                "Cloud Service Offering",
+                "Provider"
+              ],
+              "updated": [
+                {
+                  "date": "2026-06-30",
+                  "comment": "Initial reset for the Consolidated Rules for 2026 Public Preview."
+                }
+              ]
+            },
+            "CDS-CSO-FRC": {
+              "name": "FedRAMP Certification Information",
+              "statement": "Providers MUST include FedRAMP Certification Reports with their FedRAMP Certification Data without inappropriate modifications, and make such reports available within 2 weeks of receiving the materials from FedRAMP.",
+              "note": "FedRAMP provides Certification Reports for all cloud service offerings following the Program Certification path as part of the initial and ongoing FedRAMP Certification process, and may provide Certification Reports for cloud service offerings following the Agency Certification path.",
+              "force": "MUST",
+              "affects": ["Providers"],
+              "timeframe_type": "weeks",
+              "timeframe_num": 2,
+              "terms": [
+                "Agency",
+                "Certification Data",
+                "Certification Path",
                 "Cloud Service Offering",
                 "Provider"
               ],
@@ -2720,6 +2772,7 @@
               "terms": [
                 "All Necessary Parties",
                 "Certification Data",
+                "FedRAMP Certification Report",
                 "Ongoing Certification",
                 "Ongoing Certification Report (OCR)",
                 "Provider",
@@ -3627,7 +3680,7 @@
           "CLA": {
             "FRC-CLA-ASF": {
               "name": "Approved Alternative Security Frameworks",
-              "statement": "Providers seeking a FedRAMP Class A Certification MUST have completed a certification or equivalent process, including an independent assessment if applicable, from one of the following alternative security frameworks:",
+              "statement": "Providers seeking a FedRAMP Class A Certification MUST have completed a certification or equivalent process, including an independent assessment if applicable, from one of the following alternative security frameworks within the past 12 months:",
               "following_information": [
                 "FedRAMP Rev5 (including FedRAMP Ready) at any historical Impact Level",
                 "SOC 2 Type II",
@@ -3645,14 +3698,15 @@
             },
             "FRC-CLA-EAM": {
               "name": "External Assessment Materials",
-              "statement": "Providers seeking a FedRAMP Class A Certification MUST supply the full materials from the alternative security assessment to all necessary parties as part of the FedRAMP Certification Package.",
+              "statement": "Providers seeking a FedRAMP Class A Certification MUST supply the following materials from their alternative security framework assessment to all necessary parties:",
+              "following_information": [
+                "SOC 2 Type II: Complete report, bridge or gap letter (if applicable), verified audit engagement documentation, estimated schedule for upcoming report, supplemental compliance evidence (if applicable)",
+                "FedRAMP Ready: Readiness Assessment Report, Security Assessment Plan, and any other materials required by FedRAMP.",
+                "GovRAMP: Readiness Assessment Report, Security Assessment Plan, and any other materials required by GovRAMP."
+              ],
               "force": "MUST",
               "affects": ["Providers"],
-              "terms": [
-                "All Necessary Parties",
-                "Certification Package",
-                "Provider"
-              ],
+              "terms": ["All Necessary Parties", "Provider", "Verification"],
               "updated": [
                 {
                   "date": "2026-06-30",
@@ -3682,6 +3736,7 @@
                 "Key Security Indicators: KSI-CNA-RNT (Restricting Network Traffic)",
                 "Key Security Indicators: KSI-CED-RAT (Reviewing All Training)",
                 "Key Security Indicators: KSI-IAM-AAM (Automating Account Management)",
+                "Key Security Indicators: KSI-IAM-APM (Adopting Passwordless Methods)",
                 "Key Security Indicators: KSI-INR-RIR (Reviewing Incident Response Procedures)",
                 "Key Security Indicators: KSI-SVC-SIN (Securing Information)"
               ],
@@ -3710,7 +3765,8 @@
                 "KSI-CED-RAT",
                 "KSI-IAM-AAM",
                 "KSI-INR-RIR",
-                "KSI-SVC-SIN"
+                "KSI-SVC-SIN",
+                "KSI-IAM-APM"
               ],
               "force": "MUST",
               "affects": ["Providers"],

--- a/schemas/fedramp-consolidated-rules.schema.json
+++ b/schemas/fedramp-consolidated-rules.schema.json
@@ -28,7 +28,6 @@
     },
     "FRR": {
       "type": "object",
-      "x-key-order": { "by": "key", "direction": "ascending" },
       "propertyNames": { "$ref": "#/$defs/frr_document_key" },
       "additionalProperties": {
         "type": "object",
@@ -42,7 +41,6 @@
     },
     "KSI": {
       "type": "object",
-      "x-key-order": { "by": "key", "direction": "ascending" },
       "propertyNames": { "$ref": "#/$defs/ksi_theme_key" },
       "additionalProperties": {
         "type": "object",
@@ -451,12 +449,6 @@
     },
     "frd_definitions_map": {
       "type": "object",
-      "x-key-order": {
-        "by": "property",
-        "property": "term",
-        "fallback": "key",
-        "direction": "ascending"
-      },
       "propertyNames": { "$ref": "#/$defs/frd_definition_id" },
       "additionalProperties": { "$ref": "#/$defs/frd_definition" }
     },
@@ -866,11 +858,6 @@
     "updated_list": {
       "type": "array",
       "minItems": 1,
-      "x-item-order": {
-        "by": "property",
-        "property": "date",
-        "direction": "descending"
-      },
       "items": {
         "type": "object",
         "required": ["date", "comment"],

--- a/schemas/fedramp-consolidated-rules.schema.json
+++ b/schemas/fedramp-consolidated-rules.schema.json
@@ -28,52 +28,46 @@
     },
     "FRR": {
       "type": "object",
-      "patternProperties": {
-        "^[A-Z]{3}$": {
-          "type": "object",
-          "required": ["info", "data"],
-          "properties": {
-            "info": { "$ref": "#/$defs/frr_document_info" },
-            "data": { "$ref": "#/$defs/data_container_frr" }
-          },
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
+      "x-key-order": { "by": "key", "direction": "ascending" },
+      "propertyNames": { "$ref": "#/$defs/frr_document_key" },
+      "additionalProperties": {
+        "type": "object",
+        "required": ["info", "data"],
+        "properties": {
+          "info": { "$ref": "#/$defs/frr_document_info" },
+          "data": { "$ref": "#/$defs/data_container_frr" }
+        },
+        "additionalProperties": false
+      }
     },
     "KSI": {
       "type": "object",
-      "patternProperties": {
-        "^[A-Z]{3}$": {
-          "type": "object",
-          "required": [
-            "id",
-            "name",
-            "web_name",
-            "short_name",
-            "status",
-            "indicators"
-          ],
-          "properties": {
-            "id": { "type": "string", "pattern": "^KSI-[A-Z]{3}$" },
-            "name": { "type": "string" },
-            "web_name": { "type": "string" },
-            "short_name": { "type": "string", "pattern": "^[A-Z]{3}$" },
-            "status": { "$ref": "#/$defs/document_status" },
-            "indicators": {
-              "type": "object",
-              "patternProperties": {
-                "^KSI-[A-Z]{3}-[A-Z0-9]{3}$": {
-                  "$ref": "#/$defs/ksi_indicator"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
+      "x-key-order": { "by": "key", "direction": "ascending" },
+      "propertyNames": { "$ref": "#/$defs/ksi_theme_key" },
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "web_name",
+          "short_name",
+          "status",
+          "indicators"
+        ],
+        "properties": {
+          "id": { "$ref": "#/$defs/ksi_theme_id" },
+          "name": { "type": "string" },
+          "web_name": { "type": "string" },
+          "short_name": { "$ref": "#/$defs/ksi_theme_key" },
+          "status": { "$ref": "#/$defs/document_status" },
+          "indicators": {
+            "type": "object",
+            "propertyNames": { "$ref": "#/$defs/ksi_indicator_id" },
+            "additionalProperties": { "$ref": "#/$defs/ksi_indicator" }
+          }
+        },
+        "additionalProperties": false
+      }
     },
     "CTL": {
       "type": "object",
@@ -250,31 +244,22 @@
       "properties": {
         "types": {
           "type": "array",
-          "items": { "type": "string", "enum": ["20x", "Rev5"] },
+          "items": { "$ref": "#/$defs/certification_type" },
           "uniqueItems": true
         },
         "paths": {
           "type": "array",
-          "items": { "type": "string", "enum": ["Program", "Agency"] },
+          "items": { "$ref": "#/$defs/certification_path" },
           "uniqueItems": true
         },
         "classes": {
           "type": "array",
-          "items": { "type": "string", "enum": ["A", "B", "C", "D"] },
+          "items": { "$ref": "#/$defs/class_name" },
           "uniqueItems": true
         },
         "affects": {
           "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "Advisors",
-              "Agencies",
-              "Assessors",
-              "FedRAMP",
-              "Providers"
-            ]
-          },
+          "items": { "$ref": "#/$defs/affected_party" },
           "minItems": 1,
           "uniqueItems": true
         }
@@ -284,6 +269,25 @@
     "frr_info_subsets": {
       "type": "object",
       "propertyNames": { "$ref": "#/$defs/frr_info_subset_name" },
+      "patternProperties": {
+        "X$": {
+          "allOf": [
+            { "$ref": "#/$defs/frr_subset_definition" },
+            {
+              "type": "object",
+              "properties": {
+                "applicability": {
+                  "type": "object",
+                  "properties": {
+                    "types": { "const": ["20x"] },
+                    "paths": { "const": ["Program"] }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
       "additionalProperties": { "$ref": "#/$defs/frr_subset_definition" }
     },
     "info_flows": {
@@ -447,10 +451,14 @@
     },
     "frd_definitions_map": {
       "type": "object",
-      "patternProperties": {
-        "^FRD-[A-Z]{3}$": { "$ref": "#/$defs/frd_definition" }
+      "x-key-order": {
+        "by": "property",
+        "property": "term",
+        "fallback": "key",
+        "direction": "ascending"
       },
-      "additionalProperties": false
+      "propertyNames": { "$ref": "#/$defs/frd_definition_id" },
+      "additionalProperties": { "$ref": "#/$defs/frd_definition" }
     },
     "frd_definition": {
       "type": "object",
@@ -492,16 +500,12 @@
     },
     "frr_requirements_subset_group": {
       "type": "object",
-      "patternProperties": {
-        "^[A-Z]{3}-[A-Z]{3}-[A-Z0-9]{3}$": {
-          "$ref": "#/$defs/frr_requirement"
-        }
-      },
-      "additionalProperties": false
+      "propertyNames": { "$ref": "#/$defs/frr_requirement_id" },
+      "additionalProperties": { "$ref": "#/$defs/frr_requirement" }
     },
     "frr_requirement": {
       "type": "object",
-      "required": ["name", "affects"],
+      "required": ["name", "affects", "updated"],
       "oneOf": [
         {
           "properties": { "statement": {}, "force": {} },
@@ -572,7 +576,12 @@
         "force": {
           "$ref": "#/$defs/force_enum"
         },
-        "affects": { "type": "array", "items": { "type": "string" } },
+        "affects": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/affected_party" },
+          "minItems": 1,
+          "uniqueItems": true
+        },
         "artifacts": { "$ref": "#/$defs/artifacts" },
         "schema": { "$ref": "#/$defs/rule_schema" },
         "examples": {
@@ -588,17 +597,18 @@
             "additionalProperties": false
           }
         },
-        "timeframe_type": { "type": "string" },
-        "timeframe_num": { "type": "number" },
+        "timeframe_type": { "$ref": "#/$defs/timeframe_type" },
+        "timeframe_num": { "$ref": "#/$defs/positive_number" },
         "notification": {
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["party", "method", "target"],
+            "required": ["party", "method", "target", "name"],
             "properties": {
-              "party": { "type": "string" },
-              "method": { "type": "string" },
+              "party": { "$ref": "#/$defs/notification_party" },
+              "method": { "$ref": "#/$defs/notification_method" },
               "target": { "type": "string" },
+              "name": { "type": "string" },
               "url": { "type": "string", "format": "uri" }
             },
             "additionalProperties": false
@@ -606,10 +616,15 @@
         },
         "controls": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": { "$ref": "#/$defs/control_id" },
+          "uniqueItems": true
         },
         "terms": { "type": "array", "items": { "type": "string" } },
         "updated": { "$ref": "#/$defs/updated_list" }
+      },
+      "dependentRequired": {
+        "timeframe_type": ["timeframe_num"],
+        "timeframe_num": ["timeframe_type"]
       },
       "additionalProperties": false
     },
@@ -630,10 +645,14 @@
         },
         "force": { "$ref": "#/$defs/force_enum" },
         "effective_date": { "$ref": "#/$defs/effective_dates" },
-        "timeframe_type": { "type": "string" },
-        "timeframe_num": { "type": "number" },
+        "timeframe_type": { "$ref": "#/$defs/timeframe_type" },
+        "timeframe_num": { "$ref": "#/$defs/positive_number" },
         "pain_timeframes": { "$ref": "#/$defs/pain_timeframes" },
         "artifacts": { "$ref": "#/$defs/artifacts" }
+      },
+      "dependentRequired": {
+        "timeframe_type": ["timeframe_num"],
+        "timeframe_num": ["timeframe_type"]
       },
       "additionalProperties": false
     },
@@ -658,8 +677,8 @@
       "type": "object",
       "required": ["timeframe_type", "timeframe_num", "description"],
       "properties": {
-        "timeframe_type": { "type": "string" },
-        "timeframe_num": { "type": "number" },
+        "timeframe_type": { "$ref": "#/$defs/timeframe_type" },
+        "timeframe_num": { "$ref": "#/$defs/positive_number" },
         "description": { "type": "string" }
       },
       "additionalProperties": false
@@ -692,7 +711,11 @@
       "properties": {
         "name": { "type": "string" },
         "statement": { "type": "string" },
-        "controls": { "type": "array", "items": { "type": "string" } },
+        "controls": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/control_id" },
+          "uniqueItems": true
+        },
         "reference": { "type": "string" },
         "reference_url": { "type": "string", "format": "uri" },
         "updated": { "$ref": "#/$defs/updated_list" },
@@ -756,10 +779,98 @@
     "force_enum": {
       "type": "string",
       "description": "Defines the force of a requirement or indicator.",
-      "enum": ["MUST", "SHOULD", "MAY", "MUST NOT", "SHOULD NOT"]
+      "enum": ["MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY"]
+    },
+    "applicability_key": {
+      "type": "string",
+      "enum": ["all", "20x", "rev5"]
+    },
+    "class_key": {
+      "type": "string",
+      "enum": ["a", "b", "c", "d"]
+    },
+    "class_name": {
+      "type": "string",
+      "enum": ["A", "B", "C", "D"]
+    },
+    "certification_type": {
+      "type": "string",
+      "enum": ["20x", "Rev5"]
+    },
+    "certification_path": {
+      "type": "string",
+      "enum": ["Program", "Agency"]
+    },
+    "affected_party": {
+      "type": "string",
+      "enum": [
+        "Advisors",
+        "Agencies",
+        "Assessors",
+        "FedRAMP",
+        "Providers",
+        "Everyone"
+      ]
+    },
+    "notification_method": {
+      "type": "string",
+      "enum": ["email", "form", "update", "varies", "web"]
+    },
+    "notification_party": {
+      "type": "string",
+      "enum": [
+        "FedRAMP",
+        "Provider",
+        "Agency Customers",
+        "Everyone",
+        "All Necessary Parties",
+        "All Affected Parties"
+      ]
+    },
+    "timeframe_type": {
+      "type": "string",
+      "enum": ["bizdays", "days", "hours", "weeks", "months", "years"]
+    },
+    "positive_number": {
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "control_id": {
+      "type": "string",
+      "pattern": "^[a-z]{2}-\\d+(?:\\.\\d+)?$"
+    },
+    "frd_definition_id": {
+      "type": "string",
+      "pattern": "^FRD-[A-Z]{3}$"
+    },
+    "frr_document_key": {
+      "type": "string",
+      "pattern": "^[A-Z]{3}$"
+    },
+    "frr_requirement_id": {
+      "type": "string",
+      "pattern": "^(?!KSI-)[A-Z]{3}-[A-Z]{3}-[A-Z0-9]{3}$"
+    },
+    "ksi_theme_key": {
+      "type": "string",
+      "pattern": "^[A-Z]{3}$"
+    },
+    "ksi_theme_id": {
+      "type": "string",
+      "pattern": "^KSI-[A-Z]{3}$"
+    },
+    "ksi_indicator_id": {
+      "type": "string",
+      "pattern": "^KSI-[A-Z]{3}-[A-Z0-9]{3}$"
     },
     "updated_list": {
       "type": "array",
+      "minItems": 1,
+      "x-item-order": {
+        "by": "property",
+        "property": "date",
+        "direction": "descending"
+      },
       "items": {
         "type": "object",
         "required": ["date", "comment"],

--- a/tools/README.md
+++ b/tools/README.md
@@ -31,6 +31,9 @@ The hook runs `bun check` before commits.
 
 All commands read canonical file locations from
 [fedramp-rules.config.json](fedramp-rules.config.json).
+Repository-only ordering rules for dynamic object keys and array items live in
+[order-config.json](order-config.json). Standard object property order is
+derived directly from each schema object's `properties` order.
 
 Current configuration:
 
@@ -64,7 +67,7 @@ Runs the Bun test suite through [test.ts](test.ts). Coverage includes:
 - force consistency
 - term casing and synchronization
 - schema-driven property ordering
-- alphabetical FRR and KSI primary object ordering
+- config-driven dynamic key and array item ordering
 - update history checks
 - text hygiene
 - class-variant sanity checks
@@ -89,7 +92,7 @@ Runs [fix.ts](fix.ts), which plans and applies fixable normalizations:
 - ID alignment
 - inline rule display names
 - related rule references
-- schema-driven property ordering and alphabetical FRR/KSI primary object ordering
+- schema-driven property ordering and config-driven dynamic key ordering
 
 Useful variants:
 
@@ -154,6 +157,8 @@ Shared implementation:
 
 - [src/config.ts](src/config.ts)
   Resolves repository paths and shared configuration.
+- [src/order-config.ts](src/order-config.ts)
+  Loads repository-only ordering rules from [order-config.json](order-config.json).
 - [src/rules.ts](src/rules.ts)
   Loads, clones, and writes configured rules and schema documents.
 - [src/fix.ts](src/fix.ts)
@@ -169,7 +174,7 @@ Shared implementation:
 - [src/terms.ts](src/terms.ts)
   Term extraction, casing, and synchronization logic.
 - [src/property-order.ts](src/property-order.ts)
-  Schema-driven property-order and FRR/KSI primary object ordering logic.
+  Schema-driven property-order and config-driven dynamic object-key ordering.
 - [src/traversal.ts](src/traversal.ts)
   Shared FRD, FRR, and KSI traversal helpers.
 - [src/types.ts](src/types.ts)

--- a/tools/order-config.json
+++ b/tools/order-config.json
@@ -1,0 +1,66 @@
+{
+  "objectKeys": [
+    {
+      "path": "FRR",
+      "by": "key",
+      "direction": "ascending"
+    },
+    {
+      "path": "KSI",
+      "by": "key",
+      "direction": "ascending"
+    },
+    {
+      "path": "FRD.data.*",
+      "by": "property",
+      "property": "term",
+      "direction": "ascending"
+    },
+    {
+      "paths": ["FRR.*.info.subsets", "FRR.*.info.*.subsets", "FRR.*.data.*"],
+      "by": "explicit",
+      "keys": [
+        "FRP",
+        "AGC",
+        "CSO",
+        "CSF",
+        "CSX",
+        "CSL",
+        "AFR",
+        "IAF",
+        "IAS",
+        "IAX",
+        "IAL",
+        "AGM",
+        "ADP",
+        "BST",
+        "CAS",
+        "ENH",
+        "EVA",
+        "OCR",
+        "IIP",
+        "QTR",
+        "RPT",
+        "RTR",
+        "TFR",
+        "TRC",
+        "TRF",
+        "UTC",
+        "CLA",
+        "APP",
+        "APS",
+        "USE",
+        "SPN",
+        "CCL"
+      ]
+    }
+  ],
+  "arrayItems": [
+    {
+      "path": "**.updated",
+      "by": "property",
+      "property": "date",
+      "direction": "descending"
+    }
+  ]
+}

--- a/tools/src/consistency.ts
+++ b/tools/src/consistency.ts
@@ -1,11 +1,17 @@
 import { visitIndicators, visitRequirements } from "./traversal";
+import { loadSchemaDocument } from "./rules";
+import {
+  getSchemaAtPointer,
+  getSchemaPattern,
+  getSchemaPropertyOrder,
+  requireStringEnum,
+} from "./schema-metadata";
 import type {
   ClassKey,
   DefinitionEntry,
   FrrSubsetDefinition,
   KsiIndicator,
   Requirement,
-  RequirementLike,
   RulesDocument,
   UpdatedEntry,
 } from "./types";
@@ -23,70 +29,42 @@ export interface ConsistencyCheck {
 type JsonPathSegment = string | number;
 type JsonRecord = Record<string, unknown>;
 
-const CLASS_KEYS = ["a", "b", "c", "d"] as const;
-const APPLICABILITY_KEYS = ["all", "20x", "rev5"] as const;
-type ApplicabilityKey = (typeof APPLICABILITY_KEYS)[number];
-const CLASS_NAMES: Record<ClassKey, string> = {
-  a: "Class A",
-  b: "Class B",
-  c: "Class C",
-  d: "Class D",
-};
-const ALLOWED_ARTIFACT_KEYS_BY_PARENT: Record<
-  ApplicabilityKey,
-  readonly ApplicabilityKey[]
-> = {
-  all: APPLICABILITY_KEYS,
-  "20x": ["20x"],
-  rev5: ["rev5"],
-};
-const FRR_ID_REGEX = /^([A-Z]{3})-([A-Z]{3})-([A-Z0-9]{3})$/;
-const KSI_ID_REGEX = /^KSI-([A-Z]{3})-([A-Z0-9]{3})$/;
-const CONTROL_ID_REGEX = /^[a-z]{2}-\d+(?:\.\d+)?$/;
+type ApplicabilityKey = "all" | "20x" | "rev5";
+const SCHEMA_DOCUMENT = loadSchemaDocument();
+const CLASS_KEYS = requireStringEnum(
+  SCHEMA_DOCUMENT,
+  "#/$defs/class_key",
+) as ClassKey[];
+const CLASS_STATEMENT_REGEX = new RegExp(
+  `\\bClass (${requireStringEnum(SCHEMA_DOCUMENT, "#/$defs/class_name").join("|")})\\b`,
+  "g",
+);
+const APPLICABILITY_KEYS = requireStringEnum(
+  SCHEMA_DOCUMENT,
+  "#/$defs/applicability_key",
+) as ApplicabilityKey[];
+const AFFECTED_PARTY_ORDER = requireStringEnum(
+  SCHEMA_DOCUMENT,
+  "#/$defs/affected_party",
+);
+const FORCE_ORDER = requireStringEnum(SCHEMA_DOCUMENT, "#/$defs/force_enum");
+const FORCE_ORDER_INDEX = new Map(
+  FORCE_ORDER.map((force, index) => [force, index]),
+);
 const TEXT_CONTROL_CHARACTER_REGEX = /[\u0000-\u001f\u007f]/;
-const INLINE_FRR_ID_REGEX = /\b(?!KSI-)([A-Z]{3}-[A-Z]{3}-[A-Z0-9]{3})\b/g;
-const INLINE_KSI_ID_REGEX = /\b(KSI-[A-Z]{3}-[A-Z0-9]{3})\b/g;
+const INLINE_FRR_ID_REGEX = inlineIdRegex("#/$defs/frr_requirement_id");
+const INLINE_KSI_ID_REGEX = inlineIdRegex("#/$defs/ksi_indicator_id");
 const INLINE_RULE_ID_REGEXES = [INLINE_FRR_ID_REGEX, INLINE_KSI_ID_REGEX];
 
-const ALLOWED_AFFECTS = [
-  "Advisors",
-  "Agencies",
-  "Assessors",
-  "FedRAMP",
-  "Providers",
-] as const;
-const ALLOWED_SUBSET_APPLICABILITY_TYPES = ["20x", "Rev5"] as const;
-const ALLOWED_SUBSET_APPLICABILITY_PATHS = ["Program", "Agency"] as const;
-const ALLOWED_NOTIFICATION_METHODS = ["email", "update", "web"] as const;
-const ALLOWED_NOTIFICATION_PARTIES = [
-  "FedRAMP",
-  "Provider",
-  "All Necessary Parties",
-  "publicly",
-  "Agency Customers",
-  "All Affected Parties",
-] as const;
-const ALLOWED_TIMEFRAME_TYPES = [
-  "bizdays",
-  "days",
-  "hours",
-  "weeks",
-  "months",
-  "years",
-] as const;
-const FORCE_ORDER = [
-  "MUST",
-  "MUST NOT",
-  "SHOULD",
-  "SHOULD NOT",
-  "MAY",
-] as const;
-const FORCE_ORDER_INDEX = new Map<string, number>(
-  FORCE_ORDER.map((force, index): [string, number] => [
-    force,
-    index,
-  ]),
-);
+function inlineIdRegex(schemaPointer: string): RegExp {
+  const pattern = getSchemaPattern(SCHEMA_DOCUMENT, schemaPointer);
+  if (!pattern) {
+    throw new Error(`Schema is missing ID pattern at ${schemaPointer}.`);
+  }
+
+  const unanchoredPattern = pattern.replace(/^\^/, "").replace(/\$$/, "");
+  return new RegExp(`\\b(${unanchoredPattern})\\b`, "g");
+}
 
 export function formatConsistencyIssues(
   title: string,
@@ -147,11 +125,7 @@ export function collectConsistencyChecks(
       issues: collectFrrSubsetApplicabilityAffectsIssues(document),
     },
     {
-      title: "FRR 20x subset applicability warnings",
-      issues: collectFrr20xSubsetApplicabilityWarnings(document),
-    },
-    {
-      title: "Non-empty audit history",
+      title: "Audit history consistency",
       issues: collectAuditHistoryIssues(document),
     },
     {
@@ -165,10 +139,6 @@ export function collectConsistencyChecks(
     {
       title: "Artifact applicability",
       issues: collectArtifactApplicabilityIssues(document),
-    },
-    {
-      title: "Controlled vocabularies",
-      issues: collectControlledVocabularyIssues(document),
     },
     {
       title: "FRD term lookup determinism",
@@ -460,17 +430,6 @@ export function collectFullIdAlignmentIssues(
     );
   }
 
-  for (const entry of collectDefinitionEntries(document)) {
-    if (!entry.id.startsWith("FRD-")) {
-      issues.push(
-        issue(
-          entry.location,
-          `definition ID must start with FRD-, but found ${entry.id}.`,
-        ),
-      );
-    }
-  }
-
   for (const [sectionKey, section] of Object.entries(document.FRR ?? {})) {
     if (section.info.short_name !== sectionKey) {
       issues.push(
@@ -483,18 +442,11 @@ export function collectFullIdAlignmentIssues(
   }
 
   for (const entry of collectRequirementEntries(document)) {
-    const match = entry.id.match(FRR_ID_REGEX);
-    if (!match) {
-      issues.push(
-        issue(
-          entry.location,
-          `requirement ID ${entry.id} does not match ABC-LBL-XYZ format.`,
-        ),
-      );
+    const [idSection, idSubset] = entry.id.split("-");
+    if (!idSection || !idSubset) {
       continue;
     }
 
-    const [, idSection, idSubset] = match;
     if (idSection !== entry.sectionKey) {
       issues.push(
         issue(
@@ -534,18 +486,11 @@ export function collectFullIdAlignmentIssues(
   }
 
   for (const entry of collectIndicatorEntries(document)) {
-    const match = entry.id.match(KSI_ID_REGEX);
-    if (!match) {
-      issues.push(
-        issue(
-          entry.location,
-          `indicator ID ${entry.id} does not match KSI-ABC-XYZ format.`,
-        ),
-      );
+    const [, idTheme] = entry.id.split("-");
+    if (!idTheme) {
       continue;
     }
 
-    const [, idTheme] = match;
     if (idTheme !== entry.themeKey) {
       issues.push(
         issue(
@@ -722,7 +667,7 @@ function collectFrrSubsetRequirementAffects(entry: FrrSubsetDeclarationEntry): {
 
 function orderAffects(values: string[]): string[] {
   const remaining = new Set(values);
-  const ordered = (ALLOWED_AFFECTS as readonly string[]).filter((value) => {
+  const ordered = AFFECTED_PARTY_ORDER.filter((value) => {
     if (!remaining.has(value)) {
       return false;
     }
@@ -790,9 +735,7 @@ function compareForces(left: string, right: string): number {
     : leftIndex - rightIndex;
 }
 
-function getRequirementOrderingForce(
-  requirement: Requirement,
-): string | null {
+function getRequirementOrderingForce(requirement: Requirement): string | null {
   if (typeof requirement.force === "string") {
     return requirement.force;
   }
@@ -952,51 +895,6 @@ export function collectFrrSubsetApplicabilityAffectsIssues(
   return issues;
 }
 
-function collectSubsetApplicabilitySetWarnings(
-  entry: FrrSubsetDeclarationEntry,
-  key: "types" | "paths",
-  expected: readonly string[],
-): ConsistencyIssue[] {
-  const actual = getSubsetApplicabilityArray(entry.subset, key);
-  if (actual && hasSameStringSet(actual, [...expected])) {
-    return [];
-  }
-
-  return [
-    issue(
-      `${entry.location}.applicability.${key}`,
-      `20x-specific subset warning: subset ${entry.subsetKey} ends in X, so applicability.${key} should only include ${formatValues([...expected])}; found: ${formatValues(actual)}.`,
-    ),
-  ];
-}
-
-export function collectFrr20xSubsetApplicabilityWarnings(
-  document: RulesDocument,
-): ConsistencyIssue[] {
-  const issues: ConsistencyIssue[] = [];
-
-  for (const entry of collectFrrInfoSubsetEntries(document)) {
-    if (!entry.subsetKey.endsWith("X")) {
-      continue;
-    }
-
-    issues.push(
-      ...collectSubsetApplicabilitySetWarnings(
-        entry,
-        "types",
-        ALLOWED_SUBSET_APPLICABILITY_TYPES.slice(0, 1),
-      ),
-      ...collectSubsetApplicabilitySetWarnings(
-        entry,
-        "paths",
-        ALLOWED_SUBSET_APPLICABILITY_PATHS.slice(0, 1),
-      ),
-    );
-  }
-
-  return issues;
-}
-
 export function collectFrrUnusedSubsetWarnings(
   document: RulesDocument,
 ): ConsistencyIssue[] {
@@ -1073,7 +971,6 @@ function collectUpdatedHistoryIssues(
   const issues: ConsistencyIssue[] = [];
 
   if (!Array.isArray(updated) || updated.length === 0) {
-    issues.push(issue(location, "updated history must be a non-empty array."));
     return issues;
   }
 
@@ -1088,8 +985,15 @@ function collectUpdatedHistoryIssues(
     );
   }
 
+  const updatedSchema = getSchemaAtPointer(
+    SCHEMA_DOCUMENT,
+    "#/$defs/updated_list",
+  );
+  const itemOrder = updatedSchema?.["x-item-order"];
+  const descending =
+    isRecord(itemOrder) && itemOrder.direction === "descending";
   const expectedOrder = [...dates].sort((left, right) =>
-    right.localeCompare(left),
+    descending ? right.localeCompare(left) : left.localeCompare(right),
   );
   if (dates.some((date, index) => date !== expectedOrder[index])) {
     issues.push(
@@ -1163,7 +1067,7 @@ export function collectClassVariantStatementIssues(
       }
 
       const mentionedClasses = sortedUnique(
-        [...classEntry.statement.matchAll(/\bClass ([A-D])\b/g)].map(
+        [...classEntry.statement.matchAll(CLASS_STATEMENT_REGEX)].map(
           (match) => `Class ${match[1]}`,
         ),
       );
@@ -1171,7 +1075,7 @@ export function collectClassVariantStatementIssues(
         continue;
       }
 
-      const expectedClass = CLASS_NAMES[classKey];
+      const expectedClass = `Class ${classKey.toUpperCase()}`;
       const unexpectedClasses = mentionedClasses.filter(
         (className) => className !== expectedClass,
       );
@@ -1221,7 +1125,10 @@ export function collectArtifactApplicabilityIssues(
       return;
     }
 
-    const allowedKeys = ALLOWED_ARTIFACT_KEYS_BY_PARENT[parentApplicability];
+    const allowedKeys =
+      parentApplicability === "all"
+        ? APPLICABILITY_KEYS
+        : [parentApplicability];
     const disallowedKeys = Object.keys(value.artifacts).filter(
       (key) => !allowedKeys.includes(key as ApplicabilityKey),
     );
@@ -1236,209 +1143,6 @@ export function collectArtifactApplicabilityIssues(
       ),
     );
   });
-
-  return issues;
-}
-
-function collectAffectsIssues(
-  location: string,
-  requirement: Requirement,
-): ConsistencyIssue[] {
-  const issues: ConsistencyIssue[] = [];
-  const affects = requirement.affects ?? [];
-
-  if (affects.length === 0) {
-    issues.push(
-      issue(`${location}.affects`, "affects must list at least one party."),
-    );
-    return issues;
-  }
-
-  const duplicateAffects = collectDuplicateValues(affects);
-  if (duplicateAffects.length > 0) {
-    issues.push(
-      issue(
-        `${location}.affects`,
-        `affects contains duplicate values: ${duplicateAffects.join(", ")}.`,
-      ),
-    );
-  }
-
-  for (const [index, value] of affects.entries()) {
-    if (!(ALLOWED_AFFECTS as readonly string[]).includes(value)) {
-      issues.push(
-        issue(
-          `${location}.affects[${index}]`,
-          `affects value ${value} is not allowed. Allowed values are: ${joinAllowed(ALLOWED_AFFECTS)}.`,
-        ),
-      );
-    }
-  }
-
-  return issues;
-}
-
-function collectControlIssues(
-  location: string,
-  entity: RequirementLike,
-): ConsistencyIssue[] {
-  const issues: ConsistencyIssue[] = [];
-  const controls =
-    isRecord(entity) && Array.isArray(entity.controls)
-      ? entity.controls.filter(
-          (control): control is string => typeof control === "string",
-        )
-      : [];
-
-  const duplicateControls = collectDuplicateValues(controls);
-  if (duplicateControls.length > 0) {
-    issues.push(
-      issue(
-        `${location}.controls`,
-        `controls contains duplicate IDs: ${duplicateControls.join(", ")}.`,
-      ),
-    );
-  }
-
-  for (const [index, control] of controls.entries()) {
-    if (!CONTROL_ID_REGEX.test(control)) {
-      issues.push(
-        issue(
-          `${location}.controls[${index}]`,
-          `control ID ${control} must use lowercase family-number format, such as ac-2 or ia-2.1.`,
-        ),
-      );
-    }
-  }
-
-  return issues;
-}
-
-function collectTimeframeIssues(
-  value: unknown,
-  path: JsonPathSegment[],
-): ConsistencyIssue[] {
-  const issues: ConsistencyIssue[] = [];
-
-  walkJson(value, path, (node, nodePath) => {
-    if (!isRecord(node)) {
-      return;
-    }
-
-    const hasType = Object.hasOwn(node, "timeframe_type");
-    const hasNum = Object.hasOwn(node, "timeframe_num");
-    if (!hasType && !hasNum) {
-      return;
-    }
-
-    const location = formatPath(nodePath);
-    if (hasType !== hasNum) {
-      issues.push(
-        issue(
-          location,
-          "timeframe_type and timeframe_num must be provided together.",
-        ),
-      );
-    }
-
-    if (hasType && typeof node.timeframe_type === "string") {
-      if (
-        !(ALLOWED_TIMEFRAME_TYPES as readonly string[]).includes(
-          node.timeframe_type,
-        )
-      ) {
-        issues.push(
-          issue(
-            `${location}.timeframe_type`,
-            `timeframe_type ${node.timeframe_type} is not allowed. Allowed values are: ${joinAllowed(ALLOWED_TIMEFRAME_TYPES)}.`,
-          ),
-        );
-      }
-    }
-
-    if (
-      hasNum &&
-      typeof node.timeframe_num === "number" &&
-      node.timeframe_num <= 0
-    ) {
-      issues.push(
-        issue(
-          `${location}.timeframe_num`,
-          "timeframe_num must be greater than zero.",
-        ),
-      );
-    }
-  });
-
-  return issues;
-}
-
-function collectNotificationIssues(
-  value: unknown,
-  path: JsonPathSegment[],
-): ConsistencyIssue[] {
-  const issues: ConsistencyIssue[] = [];
-
-  walkJson(value, path, (node, nodePath) => {
-    if (!isRecord(node) || !Array.isArray(node.notification)) {
-      return;
-    }
-
-    for (const [index, notification] of node.notification.entries()) {
-      if (!isRecord(notification)) {
-        continue;
-      }
-
-      const location = `${formatPath(nodePath)}.notification[${index}]`;
-      if (
-        typeof notification.method === "string" &&
-        !(ALLOWED_NOTIFICATION_METHODS as readonly string[]).includes(
-          notification.method,
-        )
-      ) {
-        issues.push(
-          issue(
-            `${location}.method`,
-            `notification method ${notification.method} is not allowed. Allowed values are: ${joinAllowed(ALLOWED_NOTIFICATION_METHODS)}.`,
-          ),
-        );
-      }
-
-      if (
-        typeof notification.party === "string" &&
-        !(ALLOWED_NOTIFICATION_PARTIES as readonly string[]).includes(
-          notification.party,
-        )
-      ) {
-        issues.push(
-          issue(
-            `${location}.party`,
-            `notification party ${notification.party} is not allowed. Allowed values are: ${joinAllowed(ALLOWED_NOTIFICATION_PARTIES)}.`,
-          ),
-        );
-      }
-    }
-  });
-
-  return issues;
-}
-
-export function collectControlledVocabularyIssues(
-  document: RulesDocument,
-): ConsistencyIssue[] {
-  const issues: ConsistencyIssue[] = [];
-
-  visitRequirements(document, ({ location, requirement }) => {
-    issues.push(...collectAffectsIssues(location, requirement));
-    issues.push(...collectControlIssues(location, requirement));
-  });
-
-  visitIndicators(document, ({ location, indicator }) => {
-    issues.push(...collectControlIssues(location, indicator));
-  });
-
-  issues.push(...collectTimeframeIssues(document, []));
-  issues.push(...collectNotificationIssues(document, []));
 
   return issues;
 }
@@ -1953,41 +1657,34 @@ export function collectRelatedRuleReferenceFixes(
   }));
 }
 
-const RELATED_PRECEDING_KEYS = new Set([
-  "name",
-  "statement",
-  "varies_by_class",
-  "following_information",
-  "following_information_bullets",
-  "danger",
-  "note",
-  "notes",
-]);
-
 function assignRelatedInSchemaOrder(
   requirement: Requirement,
   related: string[],
 ): void {
-  if (Array.isArray(requirement.related)) {
-    requirement.related = related;
+  const hadRelated = Array.isArray(requirement.related);
+  requirement.related = related;
+  if (hadRelated) {
     return;
   }
 
-  const reordered: Record<string, unknown> = {};
-  let inserted = false;
-
-  for (const [key, value] of Object.entries(requirement)) {
-    if (!inserted && !RELATED_PRECEDING_KEYS.has(key)) {
-      reordered.related = related;
-      inserted = true;
-    }
-
-    reordered[key] = value;
-  }
-
-  if (!inserted) {
-    reordered.related = related;
-  }
+  const propertyOrder = getSchemaPropertyOrder(
+    SCHEMA_DOCUMENT,
+    "#/$defs/frr_requirement",
+  );
+  const orderIndex = new Map(
+    propertyOrder.map((property, index) => [property, index]),
+  );
+  const reordered = Object.fromEntries(
+    Object.entries(requirement)
+      .map(([key, value], index) => ({ key, value, index }))
+      .sort(
+        (left, right) =>
+          (orderIndex.get(left.key) ?? Number.MAX_SAFE_INTEGER) -
+            (orderIndex.get(right.key) ?? Number.MAX_SAFE_INTEGER) ||
+          left.index - right.index,
+      )
+      .map(({ key, value }) => [key, value]),
+  );
 
   for (const key of Object.keys(requirement)) {
     delete (requirement as unknown as Record<string, unknown>)[key];

--- a/tools/src/consistency.ts
+++ b/tools/src/consistency.ts
@@ -1,11 +1,11 @@
 import { visitIndicators, visitRequirements } from "./traversal";
 import { loadSchemaDocument } from "./rules";
 import {
-  getSchemaAtPointer,
   getSchemaPattern,
   getSchemaPropertyOrder,
   requireStringEnum,
 } from "./schema-metadata";
+import { findArrayItemOrderRule, loadOrderConfig } from "./order-config";
 import type {
   ClassKey,
   DefinitionEntry,
@@ -31,6 +31,7 @@ type JsonRecord = Record<string, unknown>;
 
 type ApplicabilityKey = "all" | "20x" | "rev5";
 const SCHEMA_DOCUMENT = loadSchemaDocument();
+const ORDER_CONFIG = loadOrderConfig();
 const CLASS_KEYS = requireStringEnum(
   SCHEMA_DOCUMENT,
   "#/$defs/class_key",
@@ -985,13 +986,18 @@ function collectUpdatedHistoryIssues(
     );
   }
 
-  const updatedSchema = getSchemaAtPointer(
-    SCHEMA_DOCUMENT,
-    "#/$defs/updated_list",
-  );
-  const itemOrder = updatedSchema?.["x-item-order"];
-  const descending =
-    isRecord(itemOrder) && itemOrder.direction === "descending";
+  const itemOrder = findArrayItemOrderRule(ORDER_CONFIG, `${location}.updated`);
+  if (
+    !itemOrder ||
+    itemOrder.by !== "property" ||
+    itemOrder.property !== "date"
+  ) {
+    throw new Error(
+      "Order config must define **.updated ordering by the date property.",
+    );
+  }
+
+  const descending = itemOrder.direction === "descending";
   const expectedOrder = [...dates].sort((left, right) =>
     descending ? right.localeCompare(left) : left.localeCompare(right),
   );
@@ -999,7 +1005,9 @@ function collectUpdatedHistoryIssues(
     issues.push(
       issue(
         `${location}.updated`,
-        `updated history must be sorted newest-first; found ${dates.join(", ")}.`,
+        `updated history must be sorted ${
+          descending ? "newest-first" : "oldest-first"
+        }; found ${dates.join(", ")}.`,
       ),
     );
   }

--- a/tools/src/id-alignment.ts
+++ b/tools/src/id-alignment.ts
@@ -1,12 +1,24 @@
+import { loadSchemaDocument } from "./rules";
+import { getSchemaPattern } from "./schema-metadata";
 import type { IdAlignmentIssue, RulesDocument, UpdatedEntry } from "./types";
 
-const ID_KEY_REGEX = /^([A-Z]+)-([A-Z]+)-([A-Z0-9]+)$/;
+const REQUIREMENT_ID_PATTERN = getSchemaPattern(
+  loadSchemaDocument(),
+  "#/$defs/frr_requirement_id",
+);
+const REQUIREMENT_ID_REGEX = REQUIREMENT_ID_PATTERN
+  ? new RegExp(REQUIREMENT_ID_PATTERN)
+  : null;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
-function ensureUpdatedEntry(target: Record<string, unknown>, comment: string, entryDate: string): void {
+function ensureUpdatedEntry(
+  target: Record<string, unknown>,
+  comment: string,
+  entryDate: string,
+): void {
   const entry: UpdatedEntry = { date: entryDate, comment };
   const updated = target.updated;
 
@@ -53,12 +65,14 @@ function processDataBlock(
         const renamePlan: Array<{ oldKey: string; newKey: string }> = [];
 
         for (const key of Object.keys(node)) {
-          const match = key.match(ID_KEY_REGEX);
-          if (!match) {
+          if (!REQUIREMENT_ID_REGEX?.test(key)) {
             continue;
           }
 
-          const [, left, middle, right] = match;
+          const [left, middle, right] = key.split("-");
+          if (!left || !middle || !right) {
+            continue;
+          }
           if (middle === parentKey) {
             continue;
           }
@@ -118,9 +132,14 @@ function processDataBlock(
   walk(dataBlock, null, basePath);
 }
 
-export function collectIdAlignmentIssues(document: RulesDocument): IdAlignmentIssue[] {
+export function collectIdAlignmentIssues(
+  document: RulesDocument,
+): IdAlignmentIssue[] {
   const cloned = structuredClone(document);
-  return fixIdAlignment(cloned, { entryDate: cloned.info.last_updated, updateDocument: false }).issues;
+  return fixIdAlignment(cloned, {
+    entryDate: cloned.info.last_updated,
+    updateDocument: false,
+  }).issues;
 }
 
 export function fixIdAlignment(
@@ -138,7 +157,13 @@ export function fixIdAlignment(
     }
 
     if (isRecord(node.data)) {
-      processDataBlock(node.data, options.entryDate, issues, options.updateDocument, nodePath ? `${nodePath}.data` : "data");
+      processDataBlock(
+        node.data,
+        options.entryDate,
+        issues,
+        options.updateDocument,
+        nodePath ? `${nodePath}.data` : "data",
+      );
     }
 
     for (const [key, value] of Object.entries(node)) {
@@ -149,7 +174,9 @@ export function fixIdAlignment(
   walk(document, "");
 
   const fixedCount = issues.filter((issue) => issue.status === "fixed").length;
-  const skippedCount = issues.filter((issue) => issue.status === "skipped_collision").length;
+  const skippedCount = issues.filter(
+    (issue) => issue.status === "skipped_collision",
+  ).length;
 
   if (options.updateDocument && fixedCount > 0) {
     document.info.version = incrementVersion(document.info.version);

--- a/tools/src/keywords.ts
+++ b/tools/src/keywords.ts
@@ -1,9 +1,18 @@
 import { visitRequirements } from "./traversal";
+import { loadSchemaDocument } from "./rules";
+import { requireStringEnum } from "./schema-metadata";
+import type { ClassKey } from "./types";
 import type { RulesDocument, ValidationIssue } from "./types";
 
-const KEYWORDS = ["MUST NOT", "SHOULD NOT", "MUST", "SHOULD", "MAY"] as const;
+const SCHEMA_DOCUMENT = loadSchemaDocument();
+const KEYWORDS = requireStringEnum(SCHEMA_DOCUMENT, "#/$defs/force_enum").sort(
+  (left, right) => right.length - left.length,
+);
 const KEYWORD_REGEX = new RegExp(`\\b(${KEYWORDS.join("|")})\\b`);
-const CLASS_KEYS = ["a", "b", "c", "d"] as const;
+const CLASS_KEYS = requireStringEnum(
+  SCHEMA_DOCUMENT,
+  "#/$defs/class_key",
+) as ClassKey[];
 
 function validateRequirementObject(
   obj: { statement?: string; force?: string } | undefined,

--- a/tools/src/order-config.ts
+++ b/tools/src/order-config.ts
@@ -1,0 +1,196 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type OrderDirection = "ascending" | "descending";
+
+interface OrderRuleBase {
+  paths: string[];
+}
+
+export interface KeyOrderRule extends OrderRuleBase {
+  by: "key";
+  direction: OrderDirection;
+}
+
+export interface PropertyOrderRule extends OrderRuleBase {
+  by: "property";
+  property: string;
+  direction: OrderDirection;
+}
+
+export interface ExplicitOrderRule extends OrderRuleBase {
+  by: "explicit";
+  keys: string[];
+}
+
+export type OrderRule = KeyOrderRule | PropertyOrderRule | ExplicitOrderRule;
+
+export interface OrderConfig {
+  objectKeys: OrderRule[];
+  arrayItems: OrderRule[];
+}
+
+const SOURCE_DIR = dirname(fileURLToPath(import.meta.url));
+const ORDER_CONFIG_PATH = resolve(dirname(SOURCE_DIR), "order-config.json");
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseOrderRule(
+  value: unknown,
+  collection: keyof OrderConfig,
+  index: number,
+): OrderRule {
+  if (!isRecord(value)) {
+    throw new Error(`Order config ${collection}[${index}] must be an object.`);
+  }
+
+  const { path, paths: configuredPaths, by, property, keys, direction } = value;
+  const paths =
+    typeof path === "string"
+      ? [path]
+      : Array.isArray(configuredPaths)
+        ? configuredPaths
+        : [];
+  if (
+    paths.length === 0 ||
+    paths.some(
+      (configuredPath) =>
+        typeof configuredPath !== "string" || configuredPath.length === 0,
+    )
+  ) {
+    throw new Error(
+      `Order config ${collection}[${index}] must define a non-empty path string or paths array.`,
+    );
+  }
+  if (by !== "key" && by !== "property" && by !== "explicit") {
+    throw new Error(
+      `Order config ${collection}[${index}].by must be "key", "property", or "explicit".`,
+    );
+  }
+
+  if (by === "explicit") {
+    if (
+      !Array.isArray(keys) ||
+      keys.some((key) => typeof key !== "string") ||
+      new Set(keys).size !== keys.length
+    ) {
+      throw new Error(
+        `Order config ${collection}[${index}].keys must be an array of unique strings.`,
+      );
+    }
+
+    return {
+      paths: paths as string[],
+      by,
+      keys: keys as string[],
+    };
+  }
+
+  if (by === "property" && typeof property !== "string") {
+    throw new Error(
+      `Order config ${collection}[${index}].property is required for property ordering.`,
+    );
+  }
+  if (direction !== "ascending" && direction !== "descending") {
+    throw new Error(
+      `Order config ${collection}[${index}].direction must be "ascending" or "descending".`,
+    );
+  }
+
+  if (by === "property") {
+    return {
+      paths: paths as string[],
+      by,
+      property: property as string,
+      direction,
+    };
+  }
+
+  return {
+    paths: paths as string[],
+    by,
+    direction,
+  };
+}
+
+function parseOrderRules(
+  value: unknown,
+  collection: keyof OrderConfig,
+): OrderRule[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`Order config ${collection} must be an array.`);
+  }
+
+  return value.map((rule, index) => parseOrderRule(rule, collection, index));
+}
+
+export function getOrderConfigPath(): string {
+  return ORDER_CONFIG_PATH;
+}
+
+export function loadOrderConfig(): OrderConfig {
+  const config = JSON.parse(
+    readFileSync(ORDER_CONFIG_PATH, "utf-8"),
+  ) as unknown;
+  if (!isRecord(config)) {
+    throw new Error("Order config must be an object.");
+  }
+
+  return {
+    objectKeys: parseOrderRules(config.objectKeys, "objectKeys"),
+    arrayItems: parseOrderRules(config.arrayItems, "arrayItems"),
+  };
+}
+
+function pathMatches(pattern: string, path: string): boolean {
+  const patternSegments = pattern === "" ? [] : pattern.split(".");
+  const pathSegments = path === "" ? [] : path.split(".");
+
+  function matchesFrom(patternIndex: number, pathIndex: number): boolean {
+    if (patternIndex === patternSegments.length) {
+      return pathIndex === pathSegments.length;
+    }
+
+    const segment = patternSegments[patternIndex];
+    if (segment === "**") {
+      return (
+        matchesFrom(patternIndex + 1, pathIndex) ||
+        (pathIndex < pathSegments.length &&
+          matchesFrom(patternIndex, pathIndex + 1))
+      );
+    }
+
+    return (
+      pathIndex < pathSegments.length &&
+      (segment === "*" || segment === pathSegments[pathIndex]) &&
+      matchesFrom(patternIndex + 1, pathIndex + 1)
+    );
+  }
+
+  return matchesFrom(0, 0);
+}
+
+function findOrderRule(rules: OrderRule[], path: string): OrderRule | null {
+  return (
+    rules.find((rule) =>
+      rule.paths.some((pattern) => pathMatches(pattern, path)),
+    ) ?? null
+  );
+}
+
+export function findObjectKeyOrderRule(
+  config: OrderConfig,
+  path: string,
+): OrderRule | null {
+  return findOrderRule(config.objectKeys, path);
+}
+
+export function findArrayItemOrderRule(
+  config: OrderConfig,
+  path: string,
+): OrderRule | null {
+  return findOrderRule(config.arrayItems, path);
+}

--- a/tools/src/property-order.ts
+++ b/tools/src/property-order.ts
@@ -1,57 +1,12 @@
 import type { PropertyOrderIssue, RulesDocument } from "./types";
+import {
+  dereferenceSchema,
+  isJsonObject,
+  type JsonObject,
+  type JsonSchema,
+} from "./schema-metadata";
 
-type JsonObject = Record<string, unknown>;
-type JsonSchema = Record<string, unknown>;
-
-function isRecord(value: unknown): value is JsonObject {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
-function decodeJsonPointerSegment(segment: string): string {
-  return segment.replaceAll("~1", "/").replaceAll("~0", "~");
-}
-
-function resolveRef(rootSchema: JsonSchema, ref: string): JsonSchema | null {
-  if (!ref.startsWith("#/")) {
-    return null;
-  }
-
-  let current: unknown = rootSchema;
-
-  for (const segment of ref.slice(2).split("/").map(decodeJsonPointerSegment)) {
-    if (!isRecord(current) || !(segment in current)) {
-      return null;
-    }
-
-    current = current[segment];
-  }
-
-  return isRecord(current) ? current : null;
-}
-
-function dereferenceSchema(
-  rootSchema: JsonSchema,
-  schema: unknown,
-): JsonSchema | null {
-  if (!isRecord(schema)) {
-    return null;
-  }
-
-  let current: JsonSchema | null = schema;
-  const seenRefs = new Set<string>();
-
-  while (current && typeof current.$ref === "string") {
-    const ref = current.$ref;
-    if (seenRefs.has(ref)) {
-      break;
-    }
-
-    seenRefs.add(ref);
-    current = resolveRef(rootSchema, ref);
-  }
-
-  return current;
-}
+const isRecord = isJsonObject;
 
 function getPropertiesSchema(schema: JsonSchema | null): JsonObject | null {
   if (!schema || !isRecord(schema.properties)) {
@@ -147,29 +102,63 @@ function getOrderedNamesFromSchema(
   return null;
 }
 
-function getFrdDefinitionTerm(value: unknown): string | null {
-  if (!isRecord(value) || typeof value.term !== "string") {
+function getStringProperty(value: unknown, property: string): string | null {
+  if (!isRecord(value) || typeof value[property] !== "string") {
     return null;
   }
 
-  return value.term;
+  return value[property];
 }
 
-function compareFrdDefinitionEntries(
+function compareEntriesByProperty(
   left: [string, unknown],
   right: [string, unknown],
+  property: string,
 ): number {
-  const leftTerm = getFrdDefinitionTerm(left[1]) ?? left[0];
-  const rightTerm = getFrdDefinitionTerm(right[1]) ?? right[0];
-  const termComparison = leftTerm.localeCompare(rightTerm);
+  const leftValue = getStringProperty(left[1], property) ?? left[0];
+  const rightValue = getStringProperty(right[1], property) ?? right[0];
+  const valueComparison = leftValue.localeCompare(rightValue);
 
-  return termComparison === 0
+  return valueComparison === 0
     ? left[0].localeCompare(right[0])
-    : termComparison;
+    : valueComparison;
 }
 
 function compareKeysAlphabetically(left: string, right: string): number {
   return left.localeCompare(right);
+}
+
+function getCustomKeyOrder(
+  schema: JsonSchema | null,
+  value: JsonObject,
+): string[] | null {
+  if (!schema || !isRecord(schema["x-key-order"])) {
+    return null;
+  }
+
+  const order = schema["x-key-order"];
+  const direction = order.direction === "descending" ? -1 : 1;
+  const entries = Object.entries(value);
+
+  if (order.by === "key") {
+    return entries
+      .map(([key]) => key)
+      .sort(
+        (left, right) => direction * compareKeysAlphabetically(left, right),
+      );
+  }
+
+  if (order.by === "property" && typeof order.property === "string") {
+    return entries
+      .sort(
+        (left, right) =>
+          direction *
+          compareEntriesByProperty(left, right, order.property as string),
+      )
+      .map(([key]) => key);
+  }
+
+  return null;
 }
 
 function formatPropertyList(values: string[]): string {
@@ -196,16 +185,11 @@ function getPreferredOrder(
   rootSchema: JsonSchema,
   schema: JsonSchema | null,
   value: JsonObject,
-  path: string,
+  _path: string,
 ): string[] {
-  if (path === "FRR" || path === "KSI") {
-    return Object.keys(value).sort(compareKeysAlphabetically);
-  }
-
-  if (path === "FRD.data.all") {
-    return Object.entries(value)
-      .sort(compareFrdDefinitionEntries)
-      .map(([key]) => key);
+  const customOrder = getCustomKeyOrder(schema, value);
+  if (customOrder) {
+    return customOrder;
   }
 
   const properties = getPropertiesSchema(schema);

--- a/tools/src/property-order.ts
+++ b/tools/src/property-order.ts
@@ -1,5 +1,10 @@
 import type { PropertyOrderIssue, RulesDocument } from "./types";
 import {
+  findObjectKeyOrderRule,
+  loadOrderConfig,
+  type OrderConfig,
+} from "./order-config";
+import {
   dereferenceSchema,
   isJsonObject,
   type JsonObject,
@@ -7,6 +12,7 @@ import {
 } from "./schema-metadata";
 
 const isRecord = isJsonObject;
+const ORDER_CONFIG = loadOrderConfig();
 
 function getPropertiesSchema(schema: JsonSchema | null): JsonObject | null {
   if (!schema || !isRecord(schema.properties)) {
@@ -44,64 +50,6 @@ function getItemsSchema(schema: JsonSchema | null): JsonSchema | null {
   return schema.items;
 }
 
-function getPropertyNamesSchema(schema: JsonSchema | null): JsonSchema | null {
-  if (!schema || !isRecord(schema.propertyNames)) {
-    return null;
-  }
-
-  return schema.propertyNames;
-}
-
-function getOrderedNamesFromSchema(
-  rootSchema: JsonSchema,
-  schema: unknown,
-): string[] | null {
-  const resolvedSchema = dereferenceSchema(rootSchema, schema);
-  if (!resolvedSchema) {
-    return null;
-  }
-
-  if (Array.isArray(resolvedSchema.enum)) {
-    const enumValues = resolvedSchema.enum.filter(
-      (value): value is string => typeof value === "string",
-    );
-    if (enumValues.length > 0) {
-      return enumValues;
-    }
-  }
-
-  if (typeof resolvedSchema.const === "string") {
-    return [resolvedSchema.const];
-  }
-
-  for (const keyword of ["anyOf", "oneOf", "allOf"] as const) {
-    const entries = resolvedSchema[keyword];
-    if (!Array.isArray(entries)) {
-      continue;
-    }
-
-    const orderedNames: string[] = [];
-    for (const entry of entries) {
-      const childNames = getOrderedNamesFromSchema(rootSchema, entry);
-      if (!childNames) {
-        continue;
-      }
-
-      for (const name of childNames) {
-        if (!orderedNames.includes(name)) {
-          orderedNames.push(name);
-        }
-      }
-    }
-
-    if (orderedNames.length > 0) {
-      return orderedNames;
-    }
-  }
-
-  return null;
-}
-
 function getStringProperty(value: unknown, property: string): string | null {
   if (!isRecord(value) || typeof value[property] !== "string") {
     return null;
@@ -128,18 +76,26 @@ function compareKeysAlphabetically(left: string, right: string): number {
   return left.localeCompare(right);
 }
 
-function getCustomKeyOrder(
-  schema: JsonSchema | null,
+function getConfiguredKeyOrder(
+  config: OrderConfig,
+  path: string,
   value: JsonObject,
 ): string[] | null {
-  if (!schema || !isRecord(schema["x-key-order"])) {
+  const order = findObjectKeyOrderRule(config, path);
+  if (!order) {
     return null;
   }
 
-  const order = schema["x-key-order"];
-  const direction = order.direction === "descending" ? -1 : 1;
   const entries = Object.entries(value);
+  if (order.by === "explicit") {
+    const presentKeys = order.keys.filter((key) => key in value);
+    const remainingKeys = Object.keys(value).filter(
+      (key) => !order.keys.includes(key),
+    );
+    return [...presentKeys, ...remainingKeys];
+  }
 
+  const direction = order.direction === "descending" ? -1 : 1;
   if (order.by === "key") {
     return entries
       .map(([key]) => key)
@@ -182,38 +138,25 @@ export function formatPropertyOrderReport(
 }
 
 function getPreferredOrder(
-  rootSchema: JsonSchema,
   schema: JsonSchema | null,
   value: JsonObject,
-  _path: string,
+  path: string,
 ): string[] {
-  const customOrder = getCustomKeyOrder(schema, value);
-  if (customOrder) {
-    return customOrder;
+  const configuredOrder = getConfiguredKeyOrder(ORDER_CONFIG, path, value);
+  if (configuredOrder) {
+    return configuredOrder;
   }
 
   const properties = getPropertiesSchema(schema);
-  const propertyNameSchema = getPropertyNamesSchema(schema);
-  const propertyNameOrder = propertyNameSchema
-    ? (getOrderedNamesFromSchema(rootSchema, propertyNameSchema) ?? [])
-    : [];
-
   const preferredKeys = properties ? Object.keys(properties) : [];
-  const orderedKeys = [...preferredKeys];
 
-  for (const key of propertyNameOrder) {
-    if (!orderedKeys.includes(key)) {
-      orderedKeys.push(key);
-    }
-  }
-
-  if (orderedKeys.length === 0) {
+  if (preferredKeys.length === 0) {
     return Object.keys(value);
   }
 
-  const presentPreferredKeys = orderedKeys.filter((key) => key in value);
+  const presentPreferredKeys = preferredKeys.filter((key) => key in value);
   const remainingKeys = Object.keys(value).filter(
-    (key) => !orderedKeys.includes(key),
+    (key) => !preferredKeys.includes(key),
   );
 
   return [...presentPreferredKeys, ...remainingKeys];
@@ -278,12 +221,7 @@ function collectIssuesForValue(
   }
 
   const actualOrder = Object.keys(value);
-  const expectedOrder = getPreferredOrder(
-    rootSchema,
-    resolvedSchema,
-    value,
-    path,
-  );
+  const expectedOrder = getPreferredOrder(resolvedSchema, value, path);
 
   if (
     actualOrder.length > 1 &&
@@ -354,7 +292,6 @@ function reorderValue(
 
   const actualOrder = Object.keys(withReorderedChildren);
   const expectedOrder = getPreferredOrder(
-    rootSchema,
     resolvedSchema,
     withReorderedChildren,
     path,

--- a/tools/src/schema-metadata.ts
+++ b/tools/src/schema-metadata.ts
@@ -1,0 +1,123 @@
+export type JsonObject = Record<string, unknown>;
+export type JsonSchema = Record<string, unknown>;
+
+export function isJsonObject(value: unknown): value is JsonObject {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function decodeJsonPointerSegment(segment: string): string {
+  return segment.replaceAll("~1", "/").replaceAll("~0", "~");
+}
+
+export function resolveSchemaPointer(
+  rootSchema: JsonSchema,
+  pointer: string,
+): unknown {
+  if (pointer === "#") {
+    return rootSchema;
+  }
+  if (!pointer.startsWith("#/")) {
+    return undefined;
+  }
+
+  let current: unknown = rootSchema;
+  for (const segment of pointer
+    .slice(2)
+    .split("/")
+    .map(decodeJsonPointerSegment)) {
+    if (!isJsonObject(current) || !(segment in current)) {
+      return undefined;
+    }
+    current = current[segment];
+  }
+
+  return current;
+}
+
+export function dereferenceSchema(
+  rootSchema: JsonSchema,
+  schema: unknown,
+): JsonSchema | null {
+  if (!isJsonObject(schema)) {
+    return null;
+  }
+
+  let current: JsonSchema | null = schema;
+  const seenRefs = new Set<string>();
+
+  while (current && typeof current.$ref === "string") {
+    const ref = current.$ref;
+    if (seenRefs.has(ref)) {
+      return null;
+    }
+
+    seenRefs.add(ref);
+    const resolved = resolveSchemaPointer(rootSchema, ref);
+    current = isJsonObject(resolved) ? resolved : null;
+  }
+
+  return current;
+}
+
+export function getSchemaAtPointer(
+  schemaDocument: unknown,
+  pointer: string,
+): JsonSchema | null {
+  if (!isJsonObject(schemaDocument)) {
+    return null;
+  }
+
+  return dereferenceSchema(
+    schemaDocument,
+    resolveSchemaPointer(schemaDocument, pointer),
+  );
+}
+
+export function getStringEnum(
+  schemaDocument: unknown,
+  pointer: string,
+): string[] {
+  const schema = getSchemaAtPointer(schemaDocument, pointer);
+  if (!schema || !Array.isArray(schema.enum)) {
+    return [];
+  }
+
+  return schema.enum.filter(
+    (value): value is string => typeof value === "string",
+  );
+}
+
+export function requireStringEnum(
+  schemaDocument: unknown,
+  pointer: string,
+): string[] {
+  const values = getStringEnum(schemaDocument, pointer);
+  if (values.length === 0) {
+    throw new Error(`Schema is missing a string enum at ${pointer}.`);
+  }
+
+  return values;
+}
+
+export function getSchemaProperties(
+  schemaDocument: unknown,
+  pointer: string,
+): JsonObject | null {
+  const schema = getSchemaAtPointer(schemaDocument, pointer);
+  return schema && isJsonObject(schema.properties) ? schema.properties : null;
+}
+
+export function getSchemaPattern(
+  schemaDocument: unknown,
+  pointer: string,
+): string | null {
+  const schema = getSchemaAtPointer(schemaDocument, pointer);
+  return schema && typeof schema.pattern === "string" ? schema.pattern : null;
+}
+
+export function getSchemaPropertyOrder(
+  schemaDocument: unknown,
+  pointer: string,
+): string[] {
+  return Object.keys(getSchemaProperties(schemaDocument, pointer) ?? {});
+}

--- a/tools/src/schema-validation.ts
+++ b/tools/src/schema-validation.ts
@@ -12,6 +12,16 @@ export function validateSchema(
     strict: true,
     allErrors: true,
   });
+  ajv.addKeyword({
+    keyword: "x-key-order",
+    schemaType: ["string", "object"],
+    valid: true,
+  });
+  ajv.addKeyword({
+    keyword: "x-item-order",
+    schemaType: ["string", "object"],
+    valid: true,
+  });
   addFormats(ajv as any);
 
   const schema = schemaDocument as AnySchema;
@@ -92,10 +102,7 @@ function isPropertyNameCompanionError(error: ErrorObject): boolean {
     return true;
   }
 
-  if (
-    error.keyword === "enum" &&
-    Array.isArray(error.params.allowedValues)
-  ) {
+  if (error.keyword === "enum" && Array.isArray(error.params.allowedValues)) {
     return true;
   }
 

--- a/tools/src/schema-validation.ts
+++ b/tools/src/schema-validation.ts
@@ -12,16 +12,6 @@ export function validateSchema(
     strict: true,
     allErrors: true,
   });
-  ajv.addKeyword({
-    keyword: "x-key-order",
-    schemaType: ["string", "object"],
-    valid: true,
-  });
-  ajv.addKeyword({
-    keyword: "x-item-order",
-    schemaType: ["string", "object"],
-    valid: true,
-  });
   addFormats(ajv as any);
 
   const schema = schemaDocument as AnySchema;

--- a/tools/src/traversal.ts
+++ b/tools/src/traversal.ts
@@ -6,8 +6,6 @@ import type {
   RulesDocument,
 } from "./types";
 
-const CLASS_KEYS = ["a", "b", "c", "d"] as const;
-
 export interface RequirementVisit {
   id: string;
   location: string;
@@ -25,9 +23,15 @@ export function getDefinitionEntries(document: RulesDocument): Array<{
   source: string;
   definition: DefinitionEntry;
 }> {
-  const entries: Array<{ id: string; source: string; definition: DefinitionEntry }> = [];
+  const entries: Array<{
+    id: string;
+    source: string;
+    definition: DefinitionEntry;
+  }> = [];
 
-  for (const [scopeKey, definitions] of Object.entries(document.FRD.data ?? {})) {
+  for (const [scopeKey, definitions] of Object.entries(
+    document.FRD.data ?? {},
+  )) {
     for (const [id, definition] of Object.entries(definitions ?? {})) {
       entries.push({
         id,
@@ -65,7 +69,12 @@ export function visitIndicators(
 ): void {
   for (const [themeKey, theme] of Object.entries(document.KSI ?? {})) {
     const indicators = Array.isArray(theme.indicators)
-      ? Object.fromEntries(theme.indicators.map((indicator, index) => [`${theme.id}-${index}`, indicator]))
+      ? Object.fromEntries(
+          theme.indicators.map((indicator, index) => [
+            `${theme.id}-${index}`,
+            indicator,
+          ]),
+        )
       : theme.indicators;
 
     for (const [id, indicator] of Object.entries(indicators ?? {})) {
@@ -104,8 +113,8 @@ export function getSearchableTextParts(entity: {
     parts.push(...entity.following_information_bullets);
   }
   if (entity.varies_by_class) {
-    for (const classKey of CLASS_KEYS) {
-      const statement = entity.varies_by_class[classKey]?.statement;
+    for (const classEntry of Object.values(entity.varies_by_class)) {
+      const statement = classEntry?.statement;
       if (statement) {
         parts.push(statement);
       }

--- a/tools/tests/artifact-applicability.test.ts
+++ b/tools/tests/artifact-applicability.test.ts
@@ -4,20 +4,27 @@ import {
   collectArtifactApplicabilityIssues,
   type ConsistencyIssue,
 } from "../src/consistency";
-import { cloneDocument, loadRulesDocument } from "../src/rules";
+import {
+  cloneDocument,
+  loadRulesDocument,
+  loadSchemaDocument,
+} from "../src/rules";
+import { getStringEnum } from "../src/schema-metadata";
 import type { RulesDocument } from "../src/types";
 
-const APPLICABILITY_KEYS = ["all", "20x", "rev5"] as const;
-type ApplicabilityKey = (typeof APPLICABILITY_KEYS)[number];
+type ApplicabilityKey = "all" | "20x" | "rev5";
+const APPLICABILITY_KEYS = getStringEnum(
+  loadSchemaDocument(),
+  "#/$defs/applicability_key",
+) as ApplicabilityKey[];
 
-const ALLOWED_ARTIFACT_KEYS_BY_PARENT: Record<
-  ApplicabilityKey,
-  readonly ApplicabilityKey[]
-> = {
-  all: APPLICABILITY_KEYS,
-  "20x": ["20x"],
-  rev5: ["rev5"],
-};
+function allowedArtifactKeys(
+  parentApplicability: ApplicabilityKey,
+): ApplicabilityKey[] {
+  return parentApplicability === "all"
+    ? APPLICABILITY_KEYS
+    : [parentApplicability];
+}
 
 type ArtifactHolder = Record<string, unknown> & {
   artifacts?: Record<string, string[]>;
@@ -105,8 +112,7 @@ function expectedIssueForTarget(
     return null;
   }
 
-  const allowedKeys =
-    ALLOWED_ARTIFACT_KEYS_BY_PARENT[target.parentApplicability];
+  const allowedKeys = allowedArtifactKeys(target.parentApplicability);
   const disallowedKeys = Object.keys(target.holder.artifacts).filter(
     (key) => !allowedKeys.includes(key as ApplicabilityKey),
   );
@@ -157,10 +163,7 @@ test("artifact applicability permits keys based on every FRR data scope in the r
   expect(targets.length).toBeGreaterThan(0);
 
   for (const target of targets) {
-    setArtifacts(
-      target,
-      ALLOWED_ARTIFACT_KEYS_BY_PARENT[target.parentApplicability],
-    );
+    setArtifacts(target, allowedArtifactKeys(target.parentApplicability));
   }
 
   const issues = collectArtifactApplicabilityIssues(document);

--- a/tools/tests/property-order.test.ts
+++ b/tools/tests/property-order.test.ts
@@ -5,7 +5,9 @@ import {
   fixPropertyOrder,
   formatPropertyOrderReport,
 } from "../src/property-order";
+import { loadOrderConfig } from "../src/order-config";
 import { loadRulesDocument, loadSchemaDocument } from "../src/rules";
+import { requireStringEnum } from "../src/schema-metadata";
 import type { RulesDocument } from "../src/types";
 
 test("the consolidated rules document follows the configured property order", () => {
@@ -19,6 +21,22 @@ test("the consolidated rules document follows the configured property order", ()
   }
 
   expect(issues).toEqual([]);
+});
+
+test("configured FRR subset order covers every schema-allowed subset", () => {
+  const subsetOrder = loadOrderConfig().objectKeys.find(
+    (rule) => rule.by === "explicit" && rule.paths.includes("FRR.*.data.*"),
+  );
+  if (!subsetOrder || subsetOrder.by !== "explicit") {
+    throw new Error("Order config is missing the explicit FRR subset order.");
+  }
+
+  const allowedSubsets = requireStringEnum(
+    loadSchemaDocument(),
+    "#/$defs/frr_data_subset_name",
+  );
+
+  expect([...subsetOrder.keys].sort()).toEqual([...allowedSubsets].sort());
 });
 
 test("property order fixes use schema property order as the source of truth", () => {
@@ -197,7 +215,7 @@ test("property order fixes alphabetize FRR and KSI primary objects", () => {
   expect(Object.keys(fixed.document.KSI)).toEqual(["CMT", "CNA", "MLA"]);
 });
 
-test("property order fixes use schema propertyNames enum order for FRR subsets and subset groups", () => {
+test("property order fixes use configured explicit order for FRR subsets and subset groups", () => {
   const schema = {
     type: "object",
     properties: {
@@ -296,7 +314,7 @@ test("property order fixes use schema propertyNames enum order for FRR subsets a
     {
       path: "FRR.ABC.info.subsets",
       actualOrder: ["IAL", "CSX", "FRP", "UTC"],
-      expectedOrder: ["FRP", "CSX", "UTC", "IAL"],
+      expectedOrder: ["FRP", "CSX", "IAL", "UTC"],
     },
     {
       path: "FRR.ABC.data.all",
@@ -310,8 +328,8 @@ test("property order fixes use schema propertyNames enum order for FRR subsets a
   expect(Object.keys(fixed.document.FRR.ABC!.info.subsets as object)).toEqual([
     "FRP",
     "CSX",
-    "UTC",
     "IAL",
+    "UTC",
   ]);
   expect(Object.keys(fixed.document.FRR.ABC!.data.all!)).toEqual([
     "FRP",

--- a/tools/tests/schema.test.ts
+++ b/tools/tests/schema.test.ts
@@ -163,6 +163,31 @@ test("the consolidated rules document matches the configured schema", () => {
   expect(result.valid).toBe(true);
 });
 
+test("the schema does not contain custom extension keywords", () => {
+  const extensionKeywords: string[] = [];
+
+  function visit(value: unknown, path: string): void {
+    if (Array.isArray(value)) {
+      value.forEach((entry, index) => visit(entry, `${path}[${index}]`));
+      return;
+    }
+    if (!isRecord(value)) {
+      return;
+    }
+
+    for (const [key, child] of Object.entries(value)) {
+      const childPath = path ? `${path}.${key}` : key;
+      if (key.startsWith("x-")) {
+        extensionKeywords.push(childPath);
+      }
+      visit(child, childPath);
+    }
+  }
+
+  visit(loadSchemaDocument(), "");
+  expect(extensionKeywords).toEqual([]);
+});
+
 function expectSchemaAccepts(title: string, document: RulesDocument): void {
   const result = validateSchema(document, loadSchemaDocument());
 

--- a/tools/tests/schema.test.ts
+++ b/tools/tests/schema.test.ts
@@ -263,6 +263,138 @@ test("the schema requires FRR subset applicability fields", () => {
   );
 });
 
+test("the schema requires notification names", () => {
+  const document = minimalRulesDocument();
+  (document as any).FRR.ABC.info.subsets = {
+    CSO: subsetDefinition(),
+  };
+  (document as any).FRR.ABC.data = {
+    all: {
+      CSO: {
+        "ABC-CSO-NTF": {
+          name: "Example Notification",
+          statement: "Providers MUST notify FedRAMP.",
+          force: "MUST",
+          affects: ["Providers"],
+          notification: [
+            {
+              party: "FedRAMP",
+              method: "form",
+              target: "https://example.gov/notify",
+              name: "Notification Form",
+            },
+          ],
+          updated: [
+            {
+              date: "2026-01-01",
+              comment: "Added example notification.",
+            },
+          ],
+        },
+      },
+    },
+  };
+
+  expectSchemaAccepts("notification with a name", document);
+
+  delete (document as any).FRR.ABC.data.all.CSO["ABC-CSO-NTF"].notification[0]
+    .name;
+
+  expectSchemaRejects("notification without a name", document);
+});
+
+test("the schema owns requirement vocabularies and scalar constraints", () => {
+  const document = minimalRulesDocument();
+  (document as any).FRR.ABC.info.subsets = {
+    CSO: subsetDefinition(),
+  };
+  const requirement = {
+    name: "Example Requirement",
+    statement: "Providers MUST notify FedRAMP.",
+    force: "MUST",
+    affects: ["Providers"],
+    controls: ["ac-2"],
+    timeframe_type: "days",
+    timeframe_num: 1,
+    notification: [
+      {
+        party: "FedRAMP",
+        method: "form",
+        target: "https://example.gov/notify",
+        name: "Notification Form",
+      },
+    ],
+    updated: [
+      {
+        date: "2026-01-01",
+        comment: "Added example requirement.",
+      },
+    ],
+  };
+  (document as any).FRR.ABC.data = {
+    all: {
+      CSO: {
+        "ABC-CSO-TST": requirement,
+      },
+    },
+  };
+
+  expectSchemaAccepts("requirement using schema vocabularies", document);
+
+  requirement.affects = ["Customers"];
+  expectSchemaRejects("requirement with unsupported affects", document);
+  requirement.affects = ["Providers"];
+
+  requirement.controls = ["AC-2"];
+  expectSchemaRejects("requirement with malformed control ID", document);
+  requirement.controls = ["ac-2"];
+
+  requirement.timeframe_type = "fortnights";
+  expectSchemaRejects("requirement with unsupported timeframe type", document);
+  requirement.timeframe_type = "days";
+
+  delete (requirement as any).timeframe_num;
+  expectSchemaRejects("requirement with incomplete timeframe", document);
+  requirement.timeframe_num = 0;
+  expectSchemaRejects("requirement with non-positive timeframe", document);
+  requirement.timeframe_num = 1;
+
+  requirement.notification[0]!.method = "carrier-pigeon";
+  expectSchemaRejects("notification with unsupported method", document);
+  requirement.notification[0]!.method = "form";
+
+  requirement.notification[0]!.party = "Nobody";
+  expectSchemaRejects("notification with unsupported party", document);
+  requirement.notification[0]!.party = "FedRAMP";
+
+  requirement.updated = [];
+  expectSchemaRejects("requirement without audit history", document);
+});
+
+test("the schema constrains X-suffix subsets to 20x Program applicability", () => {
+  const document = minimalRulesDocument();
+  (document as any).FRR.ABC.info.subsets = {
+    CSX: subsetDefinition({
+      applicability: {
+        types: ["20x", "Rev5"],
+        paths: ["Program", "Agency"],
+        classes: ["A", "B", "C", "D"],
+        affects: ["Providers"],
+      },
+    }),
+  };
+
+  expectSchemaRejects("X-suffix subset with broad applicability", document);
+
+  (document as any).FRR.ABC.info.subsets.CSX.applicability.types = ["20x"];
+  (document as any).FRR.ABC.info.subsets.CSX.applicability.paths = ["Program"];
+
+  expectSchemaAccepts(
+    "X-suffix subset with 20x Program applicability",
+    document,
+  );
+});
+
 test("the schema permits empty type, path, and class applicability arrays", () => {
   const document = minimalRulesDocument();
   (document as any).FRR.ABC.info.subsets = {

--- a/tools/tests/zz-consistency-report.test.ts
+++ b/tools/tests/zz-consistency-report.test.ts
@@ -4,6 +4,7 @@ import {
   collectConsistencyChecks,
   collectDuplicateRuleIdIssues,
   collectDuplicateRuleNameIssues,
+  collectAuditHistoryIssues,
   collectFrrSubsetApplicabilityAffectsIssues,
   collectFrrSubsetDeclarationIssues,
   collectFrrSubsetForceOrderWarnings,
@@ -107,6 +108,35 @@ test("duplicate rule names fail consistency validation", () => {
       message:
         'requirement name "Shared Rule Name" appears in multiple locations: ' +
         "FRR.ABC.data.all.CSO.ABC-CSO-001, FRR.ABC.data.all.CSO.ABC-CSO-002.",
+    },
+  ]);
+});
+
+test("updated histories use the order defined outside the schema", () => {
+  const document = {
+    FRD: {
+      data: {
+        all: {
+          "FRD-TST": {
+            term: "Test",
+            definition: "Test definition.",
+            updated: [
+              { date: "2025-01-01", comment: "Older change." },
+              { date: "2026-01-01", comment: "Newer change." },
+            ],
+          },
+        },
+      },
+    },
+    FRR: {},
+    KSI: {},
+  } as unknown as RulesDocument;
+
+  expect(collectAuditHistoryIssues(document)).toEqual([
+    {
+      location: "FRD.data.all.FRD-TST.updated",
+      message:
+        "updated history must be sorted newest-first; found 2025-01-01, 2026-01-01.",
     },
   ]);
 });

--- a/tools/tests/zz-consistency-report.test.ts
+++ b/tools/tests/zz-consistency-report.test.ts
@@ -4,7 +4,6 @@ import {
   collectConsistencyChecks,
   collectDuplicateRuleIdIssues,
   collectDuplicateRuleNameIssues,
-  collectFrr20xSubsetApplicabilityWarnings,
   collectFrrSubsetApplicabilityAffectsIssues,
   collectFrrSubsetDeclarationIssues,
   collectFrrSubsetForceOrderWarnings,
@@ -254,48 +253,6 @@ test("FRR subset applicability affects require a populated affects array when ru
         "Expected: FedRAMP.",
     },
   ]);
-});
-
-test("X-suffix FRR subsets warn unless they are 20x Program only", () => {
-  const document = {
-    FRR: {
-      ABC: {
-        info: {
-          subsets: {
-            CSX: {
-              name: "20x Provider",
-              description: "20x subset.",
-              applicability: {
-                types: ["20x", "Rev5"],
-                paths: ["Program", "Agency"],
-                classes: ["A", "B", "C", "D"],
-                affects: ["Providers"],
-              },
-            },
-          },
-        },
-        data: {},
-      },
-    },
-  } as unknown as RulesDocument;
-
-  expect(collectFrr20xSubsetApplicabilityWarnings(document)).toEqual([
-    {
-      location: "FRR.ABC.info.subsets.CSX.applicability.types",
-      message:
-        "20x-specific subset warning: subset CSX ends in X, so applicability.types should only include 20x; found: 20x, Rev5.",
-    },
-    {
-      location: "FRR.ABC.info.subsets.CSX.applicability.paths",
-      message:
-        "20x-specific subset warning: subset CSX ends in X, so applicability.paths should only include Program; found: Program, Agency.",
-    },
-  ]);
-
-  (document.FRR.ABC!.info as any).subsets.CSX.applicability.types = ["20x"];
-  (document.FRR.ABC!.info as any).subsets.CSX.applicability.paths = ["Program"];
-
-  expect(collectFrr20xSubsetApplicabilityWarnings(document)).toEqual([]);
 });
 
 test("FRR unused subset warnings detect subset declarations without rules", () => {


### PR DESCRIPTION
## Rules Content Changes

- Updated dataset version from `2026.06.15.01-preview` to `2026.06.19.01-preview` and `last_updated` from June 15 to June 19, 2026.
- Added `FRD-FCR` defining FedRAMP Certification Reports and `FRD-SDR` defining Security Decision Records.
- Added `CDS-CSO-FRC`, requiring providers to publish unmodified FedRAMP Certification Reports within two weeks of receipt.
- Replaced placeholder `FRC-CCL-PLC` with `FRC-CCL-UCC`, `FRC-CCL-DCC`, and `FRC-CCL-DNP`, establishing upgrade, downgrade, and 120-day notification expectations.
- Replaced `FRC-CLA-AFR` with `FRC-CLA-MFR`, `FRC-CLA-RFR`, and `FRC-CLA-OFR`, separating mandatory, recommended, and optional Class A rules.
- `FRC-APP-FIA` now varies by class: a fresh three-month assessment is optional for Class A and mandatory for Classes B–D.
- `FRC-CLA-ASF` now requires alternative-framework certification or assessment within the previous 12 months.
- `FRC-CLA-EAM` now enumerates required SOC 2 Type II, FedRAMP Ready, and GovRAMP assessment materials.
- `IVV-CSF-AIA` and `VDR-TFR-MVF` remove their Rev5 Class A variants.
- `CDS-CSO-FID` clarifies that FedRAMP IDs are required once assigned and documents placeholder handling before assignment.
- `CDS-CSO-HAD` replaces the three-year version-history requirement with Ongoing Certification Report-aligned snapshots retained throughout certification.
- `AFC-CSO-NOC` routes FedRAMP Security Inbox address changes through the CSP notification form.
- `AGU-AGC-NAI` routes additional agency information requests through the agency request form.
- `AGU-AGC-NAL` routes ATO notifications through the Submit an ATO Letter form and updates the required supporting information.
- `AGU-USE-NPC` identifies the provider’s security contact as the notification destination.
- `CCM-OCR-AFS` permits feedback summaries in either an addendum or the next Ongoing Certification Report.
- `CPO-CSO-OVR` replaces the assessment placeholder with `IVV-CSO-ICP` and adds the corresponding relationship.
- `MKT-CSO-PML` replaces its placeholder reference with the operational Marketplace Provider Listing Request form.
- `SCN-CSO-MAR` clarifies that significant-change audit records are supplied to FedRAMP upon request rather than continuously.
- `KSI-RPL-RRO` now requires recovery objectives to be defined as well as persistently reviewed.
- `SDR-CSF-ODP` corrects the Rev5 organization-defined-parameter requirement wording.
- `FRC-CSF-RDY` changes its recommended conversion from Rev5 Class A to 20x Class A.
- `SCG-CSO-RSC` expands secure-configuration guidance to cover privileged accounts as well as top-level administrative accounts.
- `AFC-FRP-PNT` now targets FedRAMP Public Notices. `CDS-CSF-TCM` now identifies FedRAMP and agency security contacts. `CDS-UTC-AAD` now uses the CSP Agency Access Denial form.
- `CCM-AGM-NAR`, `CCM-AGM-NFA`, `VER-AGM-DRE`, and `VER-AGM-NFR` now use the agency information and certification-change request form.
- `IEC-CSO-FIR`, `IEC-CSO-IIR`, and `IEC-CSO-OIR` now provide named FedRAMP, agency, and trust-center incident-reporting destinations.
- `REC-IAS-AFI` and `REC-IAS-CFI` now model the FOCI declaration as a named form notification.
- `SCN-ADP-NTF`, `SCN-TRF-NAF`, `SCN-TRF-NAV`, `SCN-TRF-NFP`, and `SCN-TRF-NIP` add human-readable names to their Certification Data notifications.
- `AGU-AGC-NAR` and `AGU-AGC-TPP` add names to their existing FedRAMP email notifications.
- Mechanically synchronized the new FedRAMP Certification Report term across `AGU-USE-NFC`, `AGU-USE-NPC`, `AGU-USE-ROR`, `CCM-AGM-ROR`, `CCM-OCR-AFS`, `CCM-OCR-AVL`, `CCM-OCR-FBM`, `CCM-OCR-LSI`, `CCM-OCR-NRD`, `CCM-OCR-RPS`, `CCM-QTR-SAR`, `CDS-CSO-HAD`, and `CDS-CSO-PUB`.
- Mechanically synchronized the new Security Decision Record term across `IVV-IAS-SUM`, `SDR-CSO-FRR`, `SDR-CSO-MTD`, and `SDR-CSX-KMT`.
- Changed `CMU`, `CPO`, `FRC`, `IEC`, `IVV`, `MKT`, `REC`, and `SDR` document statuses to `stable`.
- Structural: consolidated `MKT` framework-specific effective metadata into a common effective block beginning July 4, 2026, and removed unresolved Rev5 signup URL placeholders from affected FRR documents.
- Reset all 356 surviving rule, definition, and indicator histories to the June 23, 2026 official-launch entry; new records use the same entry.

## Schema And Structure Changes

- **Breaking:** FRR requirements now require a non-empty `updated` history; previously `updated` was optional and could be empty.
- **Breaking:** notification entries now require `name`, and notification parties and methods use controlled vocabularies rather than arbitrary strings.
- **Breaking:** `affects` values must be non-empty, unique, and drawn from the schema vocabulary; control IDs must use lowercase family-number format and be unique.
- **Breaking:** timeframes must use `bizdays`, `days`, `hours`, `weeks`, `months`, or `years`, must be positive, and must provide `timeframe_type` and `timeframe_num` together.
- **Breaking:** FRR subset names ending in `X` are now schema-constrained to 20x Program applicability.
- **Breaking:** FRR requirement property names now explicitly reject `KSI-`-prefixed IDs; ID patterns for FRD, FRR, and KSI records are centralized in reusable definitions.
- Refactored dynamic maps from repeated `patternProperties` definitions to reusable `propertyNames` and `additionalProperties` schemas.
- Added shared definitions for applicability keys, classes, certification types and paths, affected parties, notification values, timeframes, control IDs, and record IDs.
- Reordered the `force` vocabulary to `MUST`, `MUST NOT`, `SHOULD`, `SHOULD NOT`, and `MAY` without changing the allowed values.

## Tooling And Test Changes

- Added `tools/order-config.json` and `tools/src/order-config.ts` so repository-specific dynamic key and audit-history ordering no longer depends on schema vocabulary order.
- Added `tools/src/schema-metadata.ts` for schema pointer resolution, dereferencing, enum access, ID patterns, and property ordering.
- Updated consistency, keyword, ID-alignment, traversal, artifact-applicability, and property-order logic to derive constraints from the schema and ordering configuration.
- Moved controlled-vocabulary, timeframe, notification, audit-history, and 20x subset enforcement from duplicated consistency checks into schema validation.
- Expanded schema tests for notification names, controlled vocabularies, timeframes, audit histories, X-suffix subsets, class-specific statement shapes, and the absence of custom schema extensions.
- Validation: freshly fetched `origin/main`; `git diff --check main...HEAD` passed and `bun run check` passed all 68 tests.